### PR TITLE
chore: rename atlas to ark

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Atlas
+# Ark
 
 ## Preview components
 
-Although Atlas is a headless component library, as a developer you still want to make sure that the components behave correctly. At the time of writing neither [Storybook](https://storybook.js.org/docs/react/api/frameworks-feature-support) or Storybook [alternatives](https://histoire.dev/) supports all major frontend frameworks.
+Although Ark is a headless component library, as a developer you still want to make sure that the components behave correctly. At the time of writing neither [Storybook](https://storybook.js.org/docs/react/api/frameworks-feature-support) or Storybook [alternatives](https://histoire.dev/) supports all major frontend frameworks.
 
 So instead we are recommend [Preview.js](https://previewjs.com/), an IDE plugin with support for React, SolidJS, Svelte and Vue. The plugin is availabe for [VSCode](https://marketplace.visualstudio.com/items?itemName=zenclabs.previewjs) and [JetBrains based IDEs](https://plugins.jetbrains.com/plugin/17569-react-preview--deprecated-in-favor-of-preview-js/).
 

--- a/packages/react/src/accordion/accordion-button.tsx
+++ b/packages/react/src/accordion/accordion-button.tsx
@@ -1,15 +1,15 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { useAccordionContext } from './accordion-context'
 import { useAccordionItemContext } from './accordion-item-context'
 
-export type AccordionButtonProps = HTMLAtlasProps<'button'>
+export type AccordionButtonProps = HTMLArkProps<'button'>
 
 export const AccordionButton = forwardRef<'button', AccordionButtonProps>((props, ref) => {
   const { getTriggerProps } = useAccordionContext()
   const context = useAccordionItemContext()
   const mergedProps = mergeProps(getTriggerProps(context), props)
 
-  return <atlas.button {...mergedProps} ref={ref} />
+  return <ark.button {...mergedProps} ref={ref} />
 })

--- a/packages/react/src/accordion/accordion-icon.tsx
+++ b/packages/react/src/accordion/accordion-icon.tsx
@@ -1,8 +1,8 @@
 import { forwardRef } from '@polymorphic-factory/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 
-export type AccordionIconProps = HTMLAtlasProps<'div'>
+export type AccordionIconProps = HTMLArkProps<'div'>
 
 export const AccordionIcon = forwardRef<'div', AccordionIconProps>((props, ref) => {
-  return <atlas.div {...props} ref={ref} />
+  return <ark.div {...props} ref={ref} />
 })

--- a/packages/react/src/accordion/accordion-item.tsx
+++ b/packages/react/src/accordion/accordion-item.tsx
@@ -1,10 +1,10 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { useAccordionContext, type AccordionContext } from './accordion-context'
 import { AccordionItemProvider } from './accordion-item-context'
 
-export type AccordionItemProps = HTMLAtlasProps<'div'> & {
+export type AccordionItemProps = HTMLArkProps<'div'> & {
   value: string
   disabled?: boolean
   children?:
@@ -20,9 +20,9 @@ export const AccordionItem = forwardRef<'div', AccordionItemProps>((props, ref) 
 
   return (
     <AccordionItemProvider value={{ value, disabled, ...itemState }}>
-      <atlas.div {...mergedProps} ref={ref}>
+      <ark.div {...mergedProps} ref={ref}>
         {typeof children === 'function' ? children(itemState) : children}
-      </atlas.div>
+      </ark.div>
     </AccordionItemProvider>
   )
 })

--- a/packages/react/src/accordion/accordion-panel.tsx
+++ b/packages/react/src/accordion/accordion-panel.tsx
@@ -1,15 +1,15 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { useAccordionContext } from './accordion-context'
 import { useAccordionItemContext } from './accordion-item-context'
 
-export type AccordionPanelProps = HTMLAtlasProps<'div'>
+export type AccordionPanelProps = HTMLArkProps<'div'>
 
 export const AccordionPanel = forwardRef<'div', AccordionPanelProps>((props, ref) => {
   const { getContentProps } = useAccordionContext()
   const context = useAccordionItemContext()
   const mergedProps = mergeProps(getContentProps(context), props)
 
-  return <atlas.div {...mergedProps} ref={ref} />
+  return <ark.div {...mergedProps} ref={ref} />
 })

--- a/packages/react/src/accordion/accordion.tsx
+++ b/packages/react/src/accordion/accordion.tsx
@@ -1,11 +1,11 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { splitProps, type Assign } from '../split-props'
 import { AccordionProvider } from './accordion-context'
 import { useAccordion, UseAccordionProps } from './use-accordion'
 
-export type AccordionProps = Assign<HTMLAtlasProps<'div'>, UseAccordionProps>
+export type AccordionProps = Assign<HTMLArkProps<'div'>, UseAccordionProps>
 
 export const Accordion = forwardRef<'div', AccordionProps>((props, ref) => {
   const [useAccordionProps, divProps] = splitProps(props, [
@@ -24,7 +24,7 @@ export const Accordion = forwardRef<'div', AccordionProps>((props, ref) => {
 
   return (
     <AccordionProvider value={accordion}>
-      <atlas.div {...mergedProps} ref={ref} />
+      <ark.div {...mergedProps} ref={ref} />
     </AccordionProvider>
   )
 })

--- a/packages/react/src/checkbox/checkbox-control.tsx
+++ b/packages/react/src/checkbox/checkbox-control.tsx
@@ -1,13 +1,13 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { useCheckboxContext } from './checkbox-context'
 
-export type CheckboxControlProps = HTMLAtlasProps<'div'>
+export type CheckboxControlProps = HTMLArkProps<'div'>
 
 export const CheckboxControl = forwardRef<'div', CheckboxControlProps>((props, ref) => {
   const { controlProps } = useCheckboxContext()
   const mergedProps = mergeProps(controlProps, props)
 
-  return <atlas.div {...mergedProps} ref={ref} />
+  return <ark.div {...mergedProps} ref={ref} />
 })

--- a/packages/react/src/checkbox/checkbox-input.tsx
+++ b/packages/react/src/checkbox/checkbox-input.tsx
@@ -1,13 +1,13 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { useCheckboxContext } from './checkbox-context'
 
-export type CheckboxInputProps = HTMLAtlasProps<'input'>
+export type CheckboxInputProps = HTMLArkProps<'input'>
 
 export const CheckboxInput = forwardRef<'input', CheckboxInputProps>((props, ref) => {
   const { inputProps } = useCheckboxContext()
   const mergedProps = mergeProps(inputProps, props)
 
-  return <atlas.input {...mergedProps} ref={ref} />
+  return <ark.input {...mergedProps} ref={ref} />
 })

--- a/packages/react/src/checkbox/checkbox-label.tsx
+++ b/packages/react/src/checkbox/checkbox-label.tsx
@@ -1,13 +1,13 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { useCheckboxContext } from './checkbox-context'
 
-export type CheckboxLabelProps = HTMLAtlasProps<'label'>
+export type CheckboxLabelProps = HTMLArkProps<'label'>
 
 export const CheckboxLabel = forwardRef<'label', CheckboxLabelProps>((props, ref) => {
   const { labelProps } = useCheckboxContext()
   const mergedProps = mergeProps(labelProps, props)
 
-  return <atlas.label {...mergedProps} ref={ref} />
+  return <ark.label {...mergedProps} ref={ref} />
 })

--- a/packages/react/src/checkbox/checkbox.tsx
+++ b/packages/react/src/checkbox/checkbox.tsx
@@ -1,11 +1,11 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { splitProps, type Assign } from '../split-props'
 import { CheckboxProvider } from './checkbox-context'
 import { useCheckbox, UseCheckboxProps } from './use-checkbox'
 
-export type CheckboxProps = Assign<HTMLAtlasProps<'label'>, UseCheckboxProps>
+export type CheckboxProps = Assign<HTMLArkProps<'label'>, UseCheckboxProps>
 
 export const Checkbox = forwardRef<'label', CheckboxProps>((props, ref) => {
   const [useCheckboxProps, labelprops] = splitProps(props, [
@@ -33,7 +33,7 @@ export const Checkbox = forwardRef<'label', CheckboxProps>((props, ref) => {
 
   return (
     <CheckboxProvider value={checkbox}>
-      <atlas.label {...mergedProps} ref={ref} />
+      <ark.label {...mergedProps} ref={ref} />
     </CheckboxProvider>
   )
 })

--- a/packages/react/src/dialog/dialog-backdrop.tsx
+++ b/packages/react/src/dialog/dialog-backdrop.tsx
@@ -1,13 +1,13 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { useDialogContext } from './dialog-context'
 
-export type DialogBackdropProps = HTMLAtlasProps<'div'>
+export type DialogBackdropProps = HTMLArkProps<'div'>
 
 export const DialogBackdrop = forwardRef<'div', DialogBackdropProps>((props, ref) => {
   const { backdropProps } = useDialogContext()
   const mergedProps = mergeProps(backdropProps, props)
 
-  return <atlas.div {...mergedProps} ref={ref} />
+  return <ark.div {...mergedProps} ref={ref} />
 })

--- a/packages/react/src/dialog/dialog-close-button.tsx
+++ b/packages/react/src/dialog/dialog-close-button.tsx
@@ -1,13 +1,13 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { useDialogContext } from './dialog-context'
 
-export type DialogCloseButtonProps = HTMLAtlasProps<'button'>
+export type DialogCloseButtonProps = HTMLArkProps<'button'>
 
 export const DialogCloseButton = forwardRef<'button', DialogCloseButtonProps>((props, ref) => {
   const { closeButtonProps } = useDialogContext()
   const mergedProps = mergeProps(closeButtonProps, props)
 
-  return <atlas.button {...mergedProps} ref={ref} />
+  return <ark.button {...mergedProps} ref={ref} />
 })

--- a/packages/react/src/dialog/dialog-content.tsx
+++ b/packages/react/src/dialog/dialog-content.tsx
@@ -1,13 +1,13 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { useDialogContext } from './dialog-context'
 
-export type DialogContentProps = HTMLAtlasProps<'div'>
+export type DialogContentProps = HTMLArkProps<'div'>
 
 export const DialogContent = forwardRef<'div', DialogContentProps>((props, ref) => {
   const { contentProps } = useDialogContext()
   const mergedProps = mergeProps(contentProps, props)
 
-  return <atlas.div {...mergedProps} ref={ref} />
+  return <ark.div {...mergedProps} ref={ref} />
 })

--- a/packages/react/src/dialog/dialog-description.tsx
+++ b/packages/react/src/dialog/dialog-description.tsx
@@ -1,13 +1,13 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { useDialogContext } from './dialog-context'
 
-export type DialogDescriptionProps = HTMLAtlasProps<'p'>
+export type DialogDescriptionProps = HTMLArkProps<'p'>
 
 export const DialogDescription = forwardRef<'p', DialogDescriptionProps>((props, ref) => {
   const { descriptionProps } = useDialogContext()
   const mergedProps = mergeProps(descriptionProps, props)
 
-  return <atlas.p {...mergedProps} ref={ref} />
+  return <ark.p {...mergedProps} ref={ref} />
 })

--- a/packages/react/src/dialog/dialog-portal.tsx
+++ b/packages/react/src/dialog/dialog-portal.tsx
@@ -5,5 +5,5 @@ export type DialogPortalProps = PortalProps
 
 export const DialogPortal = (props: DialogPortalProps) => {
   const { isOpen } = useDialogContext()
-  return isOpen ? <Portal type="atlas-portal" {...props} /> : null
+  return isOpen ? <Portal type="ark-portal" {...props} /> : null
 }

--- a/packages/react/src/dialog/dialog-title.tsx
+++ b/packages/react/src/dialog/dialog-title.tsx
@@ -1,13 +1,13 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { useDialogContext } from './dialog-context'
 
-export type DialogTitleProps = HTMLAtlasProps<'h2'>
+export type DialogTitleProps = HTMLArkProps<'h2'>
 
 export const DialogTitle = forwardRef<'h2', DialogTitleProps>((props, ref) => {
   const { titleProps } = useDialogContext()
   const mergedProps = mergeProps(titleProps, props)
 
-  return <atlas.h2 {...mergedProps} ref={ref} />
+  return <ark.h2 {...mergedProps} ref={ref} />
 })

--- a/packages/react/src/dialog/dialog-trigger.tsx
+++ b/packages/react/src/dialog/dialog-trigger.tsx
@@ -1,5 +1,5 @@
 import { cloneElement, ReactElement } from 'react'
-import { atlas } from '../factory'
+import { ark } from '../factory'
 import { useDialogContext } from './dialog-context'
 
 export type DialogTriggerProps = { children: ReactElement | string | number }
@@ -9,7 +9,7 @@ export const DialogTrigger = (props: DialogTriggerProps) => {
   const { triggerProps } = useDialogContext()
 
   return typeof children === 'string' || typeof children === 'number' ? (
-    <atlas.span {...triggerProps}>{children}</atlas.span>
+    <ark.span {...triggerProps}>{children}</ark.span>
   ) : (
     cloneElement(children, triggerProps)
   )

--- a/packages/react/src/dialog/dialog-underlay.tsx
+++ b/packages/react/src/dialog/dialog-underlay.tsx
@@ -1,12 +1,12 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { useDialogContext } from './dialog-context'
-export type DialogUnderlayProps = HTMLAtlasProps<'div'>
+export type DialogUnderlayProps = HTMLArkProps<'div'>
 
 export const DialogUnderlay = forwardRef<'div', DialogUnderlayProps>((props, ref) => {
   const { underlayProps } = useDialogContext()
   const mergedProps = mergeProps(underlayProps, props)
 
-  return <atlas.div {...mergedProps} ref={ref} />
+  return <ark.div {...mergedProps} ref={ref} />
 })

--- a/packages/react/src/editable/editable-area.tsx
+++ b/packages/react/src/editable/editable-area.tsx
@@ -1,13 +1,13 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { useEditableContext } from './editable-context'
 
-export type EditableAreaProps = HTMLAtlasProps<'div'>
+export type EditableAreaProps = HTMLArkProps<'div'>
 
 export const EditableArea = forwardRef<'div', EditableAreaProps>((props, ref) => {
   const { areaProps } = useEditableContext()
   const mergedProps = mergeProps(areaProps, props)
 
-  return <atlas.div {...mergedProps} ref={ref} />
+  return <ark.div {...mergedProps} ref={ref} />
 })

--- a/packages/react/src/editable/editable-cancel-button.tsx
+++ b/packages/react/src/editable/editable-cancel-button.tsx
@@ -1,15 +1,15 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { useEditableContext } from './editable-context'
 
-export type EditableCancelButtonProps = HTMLAtlasProps<'button'>
+export type EditableCancelButtonProps = HTMLArkProps<'button'>
 
 export const EditableCancelButton = forwardRef<'button', EditableCancelButtonProps>(
   (props, ref) => {
     const { cancelButtonProps } = useEditableContext()
     const mergedProps = mergeProps(cancelButtonProps, props)
 
-    return <atlas.button {...mergedProps} ref={ref} />
+    return <ark.button {...mergedProps} ref={ref} />
   },
 )

--- a/packages/react/src/editable/editable-controls.tsx
+++ b/packages/react/src/editable/editable-controls.tsx
@@ -1,9 +1,9 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import type { ReactNode } from 'react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { EditableContext, useEditableContext } from './editable-context'
 
-export type EditableControlsProps = Omit<HTMLAtlasProps<'div'>, 'children'> & {
+export type EditableControlsProps = Omit<HTMLArkProps<'div'>, 'children'> & {
   children: (context: EditableContext) => ReactNode
 }
 
@@ -12,8 +12,8 @@ export const EditableControls = forwardRef<'div', EditableControlsProps>((props,
   const api = useEditableContext()
 
   return (
-    <atlas.div {...divProps} ref={ref}>
+    <ark.div {...divProps} ref={ref}>
       {children(api)}
-    </atlas.div>
+    </ark.div>
   )
 })

--- a/packages/react/src/editable/editable-edit-button.tsx
+++ b/packages/react/src/editable/editable-edit-button.tsx
@@ -1,12 +1,12 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { useEditableContext } from './editable-context'
-export type EditableEditButtonProps = HTMLAtlasProps<'button'>
+export type EditableEditButtonProps = HTMLArkProps<'button'>
 
 export const EditableEditButton = forwardRef<'button', EditableEditButtonProps>((props, ref) => {
   const { editButtonProps } = useEditableContext()
   const mergedProps = mergeProps(editButtonProps, props)
 
-  return <atlas.button {...mergedProps} ref={ref} />
+  return <ark.button {...mergedProps} ref={ref} />
 })

--- a/packages/react/src/editable/editable-input.tsx
+++ b/packages/react/src/editable/editable-input.tsx
@@ -1,13 +1,13 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { useEditableContext } from './editable-context'
 
-export type EditableInputProps = HTMLAtlasProps<'input'>
+export type EditableInputProps = HTMLArkProps<'input'>
 
 export const EditableInput = forwardRef<'input', EditableInputProps>((props, ref) => {
   const { inputProps } = useEditableContext()
   const mergedProps = mergeProps(inputProps, props)
 
-  return <atlas.input {...mergedProps} ref={ref} />
+  return <ark.input {...mergedProps} ref={ref} />
 })

--- a/packages/react/src/editable/editable-preview.tsx
+++ b/packages/react/src/editable/editable-preview.tsx
@@ -1,13 +1,13 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { useEditableContext } from './editable-context'
 
-export type EditablePreviewProps = HTMLAtlasProps<'span'>
+export type EditablePreviewProps = HTMLArkProps<'span'>
 
 export const EditablePreview = forwardRef<'span', EditablePreviewProps>((props, ref) => {
   const { previewProps } = useEditableContext()
   const mergedProps = mergeProps(previewProps, props)
 
-  return <atlas.span {...mergedProps} ref={ref} />
+  return <ark.span {...mergedProps} ref={ref} />
 })

--- a/packages/react/src/editable/editable-submit-button.tsx
+++ b/packages/react/src/editable/editable-submit-button.tsx
@@ -1,15 +1,15 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { useEditableContext } from './editable-context'
 
-export type EditableSubmitButtonProps = HTMLAtlasProps<'button'>
+export type EditableSubmitButtonProps = HTMLArkProps<'button'>
 
 export const EditableSubmitButton = forwardRef<'button', EditableSubmitButtonProps>(
   (props, ref) => {
     const { submitButtonProps } = useEditableContext()
     const mergedProps = mergeProps(submitButtonProps, props)
 
-    return <atlas.button {...mergedProps} ref={ref} />
+    return <ark.button {...mergedProps} ref={ref} />
   },
 )

--- a/packages/react/src/editable/editable.tsx
+++ b/packages/react/src/editable/editable.tsx
@@ -1,11 +1,11 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { splitProps, type Assign } from '../split-props'
 import { EditableProvider } from './editable-context'
 import { useEditable, UseEditableProps } from './use-editable'
 
-export type EditableProps = Assign<HTMLAtlasProps<'div'>, UseEditableProps>
+export type EditableProps = Assign<HTMLArkProps<'div'>, UseEditableProps>
 
 export const Editable = forwardRef<'div', EditableProps>((props, ref) => {
   const [useEditableProps, divProps] = splitProps(props, [
@@ -36,7 +36,7 @@ export const Editable = forwardRef<'div', EditableProps>((props, ref) => {
 
   return (
     <EditableProvider value={editable}>
-      <atlas.div {...mergedProps} ref={ref} />
+      <ark.div {...mergedProps} ref={ref} />
     </EditableProvider>
   )
 })

--- a/packages/react/src/factory.tsx
+++ b/packages/react/src/factory.tsx
@@ -1,16 +1,16 @@
 /**
- * All html and svg elements for atlas components.
- * This is mostly for `atlas.<element>` syntax.
+ * All html and svg elements for ark components.
+ * This is mostly for `ark.<element>` syntax.
  */
 import type { HTMLPolymorphicComponents, HTMLPolymorphicProps } from '@polymorphic-factory/react'
 import { polymorphicFactory } from '@polymorphic-factory/react'
 import type { ElementType } from 'react'
 
-export type HTMLAtlasComponents = HTMLPolymorphicComponents
+export type HTMLArkComponents = HTMLPolymorphicComponents
 
-export type HTMLAtlasProps<T extends ElementType> = HTMLPolymorphicProps<T>
+export type HTMLArkProps<T extends ElementType> = HTMLPolymorphicProps<T>
 
 /**
- * The atlas factory serves as an object of JSX elements to render React components which accept the `as` prop
+ * The ark factory serves as an object of JSX elements to render React components which accept the `as` prop
  */
-export const atlas = polymorphicFactory()
+export const ark = polymorphicFactory()

--- a/packages/react/src/number-input/number-input-decrement-button.tsx
+++ b/packages/react/src/number-input/number-input-decrement-button.tsx
@@ -1,15 +1,15 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { useNumberInputContext } from './number-input-context'
 
-export type NumberInputDecrementButtonProps = HTMLAtlasProps<'button'>
+export type NumberInputDecrementButtonProps = HTMLArkProps<'button'>
 
 export const NumberInputDecrementButton = forwardRef<'button', NumberInputDecrementButtonProps>(
   (props, ref) => {
     const { decrementButtonProps } = useNumberInputContext()
     const mergedProps = mergeProps(decrementButtonProps, props)
 
-    return <atlas.button {...mergedProps} ref={ref} />
+    return <ark.button {...mergedProps} ref={ref} />
   },
 )

--- a/packages/react/src/number-input/number-input-field.tsx
+++ b/packages/react/src/number-input/number-input-field.tsx
@@ -1,13 +1,13 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { useNumberInputContext } from './number-input-context'
 
-export type NumberInputFieldProps = HTMLAtlasProps<'input'>
+export type NumberInputFieldProps = HTMLArkProps<'input'>
 
 export const NumberInputField = forwardRef<'input', NumberInputFieldProps>((props, ref) => {
   const { inputProps } = useNumberInputContext()
   const mergedProps = mergeProps(inputProps, props)
 
-  return <atlas.input {...mergedProps} ref={ref} />
+  return <ark.input {...mergedProps} ref={ref} />
 })

--- a/packages/react/src/number-input/number-input-increment-button.tsx
+++ b/packages/react/src/number-input/number-input-increment-button.tsx
@@ -1,15 +1,15 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { useNumberInputContext } from './number-input-context'
 
-export type NumberInputIncrementButtonProps = HTMLAtlasProps<'button'>
+export type NumberInputIncrementButtonProps = HTMLArkProps<'button'>
 
 export const NumberInputIncrementButton = forwardRef<'button', NumberInputIncrementButtonProps>(
   (props, ref) => {
     const { incrementButtonProps } = useNumberInputContext()
     const mergedProps = mergeProps(incrementButtonProps, props)
 
-    return <atlas.button {...mergedProps} ref={ref} />
+    return <ark.button {...mergedProps} ref={ref} />
   },
 )

--- a/packages/react/src/number-input/number-input.tsx
+++ b/packages/react/src/number-input/number-input.tsx
@@ -1,11 +1,11 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { splitProps, type Assign } from '../split-props'
 import { NumberInputProvider } from './number-input-context'
 import { useNumberInput, UseNumberInputProps } from './use-number-input'
 
-export type NumberInputProps = Assign<HTMLAtlasProps<'div'>, UseNumberInputProps>
+export type NumberInputProps = Assign<HTMLArkProps<'div'>, UseNumberInputProps>
 
 export const NumberInput = forwardRef<'div', NumberInputProps>((props, ref) => {
   const [useNumberInputProps, divProps] = splitProps(props, [
@@ -44,7 +44,7 @@ export const NumberInput = forwardRef<'div', NumberInputProps>((props, ref) => {
 
   return (
     <NumberInputProvider value={pinInput}>
-      <atlas.div {...mergedProps} ref={ref} />
+      <ark.div {...mergedProps} ref={ref} />
     </NumberInputProvider>
   )
 })

--- a/packages/react/src/pagination/pagination-ellipsis.tsx
+++ b/packages/react/src/pagination/pagination-ellipsis.tsx
@@ -1,14 +1,14 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { Assign, splitProps } from '../split-props'
 import { usePaginationContext } from './pagination-context'
 
-export type PaginationEllipsisProps = Assign<HTMLAtlasProps<'span'>, { index: number }>
+export type PaginationEllipsisProps = Assign<HTMLArkProps<'span'>, { index: number }>
 
 export const PaginationEllipsis = forwardRef<'span', PaginationEllipsisProps>((props, ref) => {
   const { getEllipsisProps } = usePaginationContext()
   const [{ index }, spanProps] = splitProps(props, ['index'])
   const mergedProps = mergeProps(getEllipsisProps({ index }), spanProps)
-  return <atlas.span {...mergedProps} ref={ref} />
+  return <ark.span {...mergedProps} ref={ref} />
 })

--- a/packages/react/src/pagination/pagination-item.tsx
+++ b/packages/react/src/pagination/pagination-item.tsx
@@ -1,14 +1,14 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { Assign, splitProps } from '../split-props'
 import { usePaginationContext } from './pagination-context'
 
-export type PaginationItemProps = Assign<HTMLAtlasProps<'a'>, { value: number }>
+export type PaginationItemProps = Assign<HTMLArkProps<'a'>, { value: number }>
 
 export const PaginationItem = forwardRef<'a', PaginationItemProps>((props, ref) => {
   const { getItemProps } = usePaginationContext()
   const [{ value }, anchorProps] = splitProps(props, ['value'])
   const mergedProps = mergeProps(getItemProps({ type: 'page', value }), anchorProps)
-  return <atlas.a href={`#${value}`} {...mergedProps} ref={ref} />
+  return <ark.a href={`#${value}`} {...mergedProps} ref={ref} />
 })

--- a/packages/react/src/pagination/pagination-next-item.tsx
+++ b/packages/react/src/pagination/pagination-next-item.tsx
@@ -1,12 +1,12 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { usePaginationContext } from './pagination-context'
 
-export type PaginationNextItemProps = HTMLAtlasProps<'a'>
+export type PaginationNextItemProps = HTMLArkProps<'a'>
 
 export const PaginationNextItem = forwardRef<'a', PaginationNextItemProps>((props, ref) => {
   const { nextItemProps } = usePaginationContext()
   const mergedProps = mergeProps(nextItemProps, props)
-  return <atlas.a href="#next" {...mergedProps} ref={ref} />
+  return <ark.a href="#next" {...mergedProps} ref={ref} />
 })

--- a/packages/react/src/pagination/pagination-prev-item.tsx
+++ b/packages/react/src/pagination/pagination-prev-item.tsx
@@ -1,12 +1,12 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { usePaginationContext } from './pagination-context'
 
-export type PaginationPrevItemProps = HTMLAtlasProps<'a'>
+export type PaginationPrevItemProps = HTMLArkProps<'a'>
 
 export const PaginationPrevItem = forwardRef<'a', PaginationPrevItemProps>((props, ref) => {
   const { prevItemProps } = usePaginationContext()
   const mergedProps = mergeProps(prevItemProps, props)
-  return <atlas.a href="#previous" {...mergedProps} ref={ref} />
+  return <ark.a href="#previous" {...mergedProps} ref={ref} />
 })

--- a/packages/react/src/pagination/pagination.tsx
+++ b/packages/react/src/pagination/pagination.tsx
@@ -1,14 +1,14 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
 import type { ReactNode } from 'react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { runIfFn } from '../run-if-fn'
 import { Assign, splitProps } from '../split-props'
 import { PaginationProvider } from './pagination-context'
 import { usePagination, UsePaginationProps, UsePaginationReturn } from './use-pagination'
 
 export type PaginationProps = Assign<
-  Assign<HTMLAtlasProps<'nav'>, UsePaginationProps>,
+  Assign<HTMLArkProps<'nav'>, UsePaginationProps>,
   {
     children: ReactNode | ((pages: UsePaginationReturn) => ReactNode)
   }
@@ -34,9 +34,9 @@ export const Pagination = forwardRef<'nav', PaginationProps>((props, ref) => {
 
   return (
     <PaginationProvider value={pagination}>
-      <atlas.nav {...mergedProps} ref={ref}>
+      <ark.nav {...mergedProps} ref={ref}>
         {view}
-      </atlas.nav>
+      </ark.nav>
     </PaginationProvider>
   )
 })

--- a/packages/react/src/pin-input/pin-input-field.tsx
+++ b/packages/react/src/pin-input/pin-input-field.tsx
@@ -1,14 +1,14 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { usePinInputContext } from './pin-input-context'
 
-export type PinInputFieldProps = { index: number } & HTMLAtlasProps<'input'>
+export type PinInputFieldProps = { index: number } & HTMLArkProps<'input'>
 
 export const PinInputField = forwardRef<'input', PinInputFieldProps>((props, ref) => {
   const { index, ...inputProps } = props
   const { getInputProps } = usePinInputContext()
   const mergedProps = mergeProps(getInputProps({ index }), inputProps)
 
-  return <atlas.input {...mergedProps} ref={ref} />
+  return <ark.input {...mergedProps} ref={ref} />
 })

--- a/packages/react/src/pin-input/pin-input.tsx
+++ b/packages/react/src/pin-input/pin-input.tsx
@@ -1,11 +1,11 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { splitProps, type Assign } from '../split-props'
 import { PinInputProvider } from './pin-input-context'
 import { usePinInput, UsePinInputProps } from './use-pin-input'
 
-export type PinInputProps = Assign<HTMLAtlasProps<'div'>, UsePinInputProps>
+export type PinInputProps = Assign<HTMLArkProps<'div'>, UsePinInputProps>
 
 export const PinInput = forwardRef<'div', PinInputProps>((props, ref) => {
   const [usePinInputProps, divProps] = splitProps(props, [
@@ -34,7 +34,7 @@ export const PinInput = forwardRef<'div', PinInputProps>((props, ref) => {
 
   return (
     <PinInputProvider value={pinInput}>
-      <atlas.div {...mergedProps} ref={ref} />
+      <ark.div {...mergedProps} ref={ref} />
     </PinInputProvider>
   )
 })

--- a/packages/react/src/pin-input/use-pin-input.ts
+++ b/packages/react/src/pin-input/use-pin-input.ts
@@ -19,7 +19,7 @@ export const usePinInput = (props: UsePinInputProps) => {
     value: props.value,
   })
 
-  // TODO https://github.com/chakra-ui/atlas/issues/48
+  // TODO https://github.com/chakra-ui/ark/issues/48
   const [state, send] = useMachine(pinInput.machine(initialContext), { context })
 
   return pinInput.connect(state, send, normalizeProps)

--- a/packages/react/src/popover/popover-arrow.tsx
+++ b/packages/react/src/popover/popover-arrow.tsx
@@ -1,13 +1,13 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { usePopoverContext } from './popover-context'
 
-export type PopoverArrowProps = HTMLAtlasProps<'div'>
+export type PopoverArrowProps = HTMLArkProps<'div'>
 
 export const PopoverArrow = forwardRef<'div', PopoverArrowProps>((props, ref) => {
   const { arrowProps } = usePopoverContext()
   const mergedProps = mergeProps(arrowProps, props)
 
-  return <atlas.div {...mergedProps} ref={ref} />
+  return <ark.div {...mergedProps} ref={ref} />
 })

--- a/packages/react/src/popover/popover-close-button.tsx
+++ b/packages/react/src/popover/popover-close-button.tsx
@@ -1,13 +1,13 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { usePopoverContext } from './popover-context'
 
-export type PopoverCloseButtonProps = HTMLAtlasProps<'button'>
+export type PopoverCloseButtonProps = HTMLArkProps<'button'>
 
 export const PopoverCloseButton = forwardRef<'button', PopoverCloseButtonProps>((props, ref) => {
   const { closeButtonProps } = usePopoverContext()
   const mergedProps = mergeProps(closeButtonProps, props)
 
-  return <atlas.button {...mergedProps} ref={ref} />
+  return <ark.button {...mergedProps} ref={ref} />
 })

--- a/packages/react/src/popover/popover-content.tsx
+++ b/packages/react/src/popover/popover-content.tsx
@@ -1,13 +1,13 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { usePopoverContext } from './popover-context'
 
-export type PopoverContentProps = HTMLAtlasProps<'div'>
+export type PopoverContentProps = HTMLArkProps<'div'>
 
 export const PopoverContent = forwardRef<'div', PopoverContentProps>((props, ref) => {
   const { contentProps } = usePopoverContext()
   const mergedProps = mergeProps(contentProps, props)
 
-  return <atlas.div {...mergedProps} ref={ref} />
+  return <ark.div {...mergedProps} ref={ref} />
 })

--- a/packages/react/src/popover/popover-description.tsx
+++ b/packages/react/src/popover/popover-description.tsx
@@ -1,13 +1,13 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { usePopoverContext } from './popover-context'
 
-export type PopoverDescriptionProps = HTMLAtlasProps<'div'>
+export type PopoverDescriptionProps = HTMLArkProps<'div'>
 
 export const PopoverDescription = forwardRef<'div', PopoverDescriptionProps>((props, ref) => {
   const { descriptionProps } = usePopoverContext()
   const mergedProps = mergeProps(descriptionProps, props)
 
-  return <atlas.div {...mergedProps} ref={ref} />
+  return <ark.div {...mergedProps} ref={ref} />
 })

--- a/packages/react/src/popover/popover-inner-arrow.tsx
+++ b/packages/react/src/popover/popover-inner-arrow.tsx
@@ -1,13 +1,13 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { usePopoverContext } from './popover-context'
 
-export type PopoverInnerArrowProps = HTMLAtlasProps<'div'>
+export type PopoverInnerArrowProps = HTMLArkProps<'div'>
 
 export const PopoverInnerArrow = forwardRef<'div', PopoverInnerArrowProps>((props, ref) => {
   const { innerArrowProps } = usePopoverContext()
   const mergedProps = mergeProps(innerArrowProps, props)
 
-  return <atlas.div {...mergedProps} ref={ref} />
+  return <ark.div {...mergedProps} ref={ref} />
 })

--- a/packages/react/src/popover/popover-positioner.tsx
+++ b/packages/react/src/popover/popover-positioner.tsx
@@ -1,13 +1,13 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { usePopoverContext } from './popover-context'
 
-export type PopoverPositionerProps = HTMLAtlasProps<'div'>
+export type PopoverPositionerProps = HTMLArkProps<'div'>
 
 export const PopoverPositioner = forwardRef<'div', PopoverPositionerProps>((props, ref) => {
   const { positionerProps } = usePopoverContext()
   const mergedProps = mergeProps(positionerProps, props)
 
-  return <atlas.div {...mergedProps} ref={ref} />
+  return <ark.div {...mergedProps} ref={ref} />
 })

--- a/packages/react/src/popover/popover-title.tsx
+++ b/packages/react/src/popover/popover-title.tsx
@@ -1,13 +1,13 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { usePopoverContext } from './popover-context'
 
-export type PopoverTitleProps = HTMLAtlasProps<'div'>
+export type PopoverTitleProps = HTMLArkProps<'div'>
 
 export const PopoverTitle = forwardRef<'div', PopoverTitleProps>((props, ref) => {
   const { titleProps } = usePopoverContext()
   const mergedProps = mergeProps(titleProps, props)
 
-  return <atlas.div {...mergedProps} ref={ref} />
+  return <ark.div {...mergedProps} ref={ref} />
 })

--- a/packages/react/src/popover/popover-trigger.tsx
+++ b/packages/react/src/popover/popover-trigger.tsx
@@ -1,5 +1,5 @@
 import { cloneElement, ReactElement } from 'react'
-import { atlas } from '../factory'
+import { ark } from '../factory'
 import { usePopoverContext } from './popover-context'
 
 export type PopoverTriggerProps = { children: ReactElement | string | number }
@@ -9,7 +9,7 @@ export const PopoverTrigger = (props: PopoverTriggerProps) => {
   const { triggerProps } = usePopoverContext()
 
   return typeof children === 'string' || typeof children === 'number' ? (
-    <atlas.span {...triggerProps}>{children}</atlas.span>
+    <ark.span {...triggerProps}>{children}</ark.span>
   ) : (
     cloneElement(children, triggerProps)
   )

--- a/packages/react/src/pressable/pressable.tsx
+++ b/packages/react/src/pressable/pressable.tsx
@@ -1,10 +1,10 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { splitProps, type Assign } from '../split-props'
 import { usePressable, UsePressableProps } from './use-pressable'
 
-export type PressableProps = Assign<HTMLAtlasProps<'button'>, UsePressableProps>
+export type PressableProps = Assign<HTMLArkProps<'button'>, UsePressableProps>
 
 export const Pressable = forwardRef<'button', PressableProps>((props, ref) => {
   const [usePressableProps, divProps] = splitProps(props, [
@@ -23,5 +23,5 @@ export const Pressable = forwardRef<'button', PressableProps>((props, ref) => {
   const { pressableProps } = usePressable(usePressableProps)
   const mergedProps = mergeProps(pressableProps, divProps)
 
-  return <atlas.button {...mergedProps} ref={ref} />
+  return <ark.button {...mergedProps} ref={ref} />
 })

--- a/packages/react/src/radio-group/radio-control.tsx
+++ b/packages/react/src/radio-group/radio-control.tsx
@@ -1,15 +1,15 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { useRadioContext } from './radio-context'
 import { useRadioGroupContext } from './radio-group-context'
 
-export type RadioControlProps = HTMLAtlasProps<'div'>
+export type RadioControlProps = HTMLArkProps<'div'>
 
 export const RadioControl = forwardRef<'div', RadioControlProps>((props, ref) => {
   const { getItemControlProps } = useRadioGroupContext()
   const context = useRadioContext()
   const mergedProps = mergeProps(getItemControlProps(context), props)
 
-  return <atlas.div {...mergedProps} ref={ref} />
+  return <ark.div {...mergedProps} ref={ref} />
 })

--- a/packages/react/src/radio-group/radio-group-label.tsx
+++ b/packages/react/src/radio-group/radio-group-label.tsx
@@ -1,13 +1,13 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { useRadioGroupContext } from './radio-group-context'
 
-export type RadioGroupLabelProps = HTMLAtlasProps<'label'>
+export type RadioGroupLabelProps = HTMLArkProps<'label'>
 
 export const RadioGroupLabel = forwardRef<'label', RadioGroupLabelProps>((props, ref) => {
   const { labelProps } = useRadioGroupContext()
   const mergedProps = mergeProps(labelProps, props)
 
-  return <atlas.label {...mergedProps} ref={ref} />
+  return <ark.label {...mergedProps} ref={ref} />
 })

--- a/packages/react/src/radio-group/radio-group.tsx
+++ b/packages/react/src/radio-group/radio-group.tsx
@@ -1,11 +1,11 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { splitProps, type Assign } from '../split-props'
 import { RadioGroupProvider } from './radio-group-context'
 import { useRadioGroup, UseRadioGroupProps } from './use-radio-group'
 
-export type RadioGroupProps = Assign<HTMLAtlasProps<'div'>, UseRadioGroupProps>
+export type RadioGroupProps = Assign<HTMLArkProps<'div'>, UseRadioGroupProps>
 
 export const RadioGroup = forwardRef<'div', UseRadioGroupProps>((props, ref) => {
   const [useRadioGroupProps, divProps] = splitProps(props, [
@@ -25,7 +25,7 @@ export const RadioGroup = forwardRef<'div', UseRadioGroupProps>((props, ref) => 
 
   return (
     <RadioGroupProvider value={radioGroup}>
-      <atlas.div {...mergedProps} ref={ref} />
+      <ark.div {...mergedProps} ref={ref} />
     </RadioGroupProvider>
   )
 })

--- a/packages/react/src/radio-group/radio-input.tsx
+++ b/packages/react/src/radio-group/radio-input.tsx
@@ -1,15 +1,15 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { useRadioContext } from './radio-context'
 import { useRadioGroupContext } from './radio-group-context'
 
-export type RadioInputProps = HTMLAtlasProps<'input'>
+export type RadioInputProps = HTMLArkProps<'input'>
 
 export const RadioInput = forwardRef<'input', RadioInputProps>((props, ref) => {
   const { getItemInputProps } = useRadioGroupContext()
   const context = useRadioContext()
   const mergedProps = mergeProps(getItemInputProps(context), props)
 
-  return <atlas.input {...mergedProps} ref={ref} />
+  return <ark.input {...mergedProps} ref={ref} />
 })

--- a/packages/react/src/radio-group/radio-label.tsx
+++ b/packages/react/src/radio-group/radio-label.tsx
@@ -1,15 +1,15 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { useRadioContext } from './radio-context'
 import { useRadioGroupContext } from './radio-group-context'
 
-export type RadioLabelProps = HTMLAtlasProps<'span'>
+export type RadioLabelProps = HTMLArkProps<'span'>
 
 export const RadioLabel = forwardRef<'span', RadioLabelProps>((props, ref) => {
   const { getItemLabelProps } = useRadioGroupContext()
   const context = useRadioContext()
   const mergedProps = mergeProps(getItemLabelProps(context), props)
 
-  return <atlas.span {...mergedProps} ref={ref} />
+  return <ark.span {...mergedProps} ref={ref} />
 })

--- a/packages/react/src/radio-group/radio.tsx
+++ b/packages/react/src/radio-group/radio.tsx
@@ -1,10 +1,10 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { RadioContext, RadioProvider } from './radio-context'
 import { useRadioGroupContext } from './radio-group-context'
 
-export type RadioProps = Omit<HTMLAtlasProps<'label'>, keyof RadioContext> & RadioContext
+export type RadioProps = Omit<HTMLArkProps<'label'>, keyof RadioContext> & RadioContext
 
 export const Radio = forwardRef<'label', RadioProps>((props, ref) => {
   const { value, disabled, invalid, readonly, ...divProps } = props
@@ -13,7 +13,7 @@ export const Radio = forwardRef<'label', RadioProps>((props, ref) => {
 
   return (
     <RadioProvider value={{ value, disabled, invalid, readonly }}>
-      <atlas.label {...mergedProps} ref={ref} />
+      <ark.label {...mergedProps} ref={ref} />
     </RadioProvider>
   )
 })

--- a/packages/react/src/rating/rating-group.tsx
+++ b/packages/react/src/rating/rating-group.tsx
@@ -1,10 +1,10 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
 import type { ReactNode } from 'react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { RatingContext, useRatingContext } from './rating-context'
 
-export type RatingGroupProps = Omit<HTMLAtlasProps<'div'>, 'children'> & {
+export type RatingGroupProps = Omit<HTMLArkProps<'div'>, 'children'> & {
   children: ReactNode | ((context: RatingContext) => ReactNode)
   renderIcon?: never
 }
@@ -16,8 +16,8 @@ export const RatingGroup = forwardRef<'div', RatingGroupProps>((props, ref) => {
   const mergedProps = mergeProps(api.itemGroupProps, divProps)
 
   return (
-    <atlas.div {...mergedProps} ref={ref}>
+    <ark.div {...mergedProps} ref={ref}>
       {renderPropResult}
-    </atlas.div>
+    </ark.div>
   )
 })

--- a/packages/react/src/rating/rating-item.tsx
+++ b/packages/react/src/rating/rating-item.tsx
@@ -1,13 +1,13 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
 import type { ReactNode } from 'react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { useRatingContext } from './rating-context'
 import { RatingItemContext, RatingItemProvider } from './rating-item-context'
 
 export type RenderIconFn = (state: RatingItemContext) => ReactNode
 
-export type RatingItemProps = Omit<HTMLAtlasProps<'span'>, 'children'> & {
+export type RatingItemProps = Omit<HTMLArkProps<'span'>, 'children'> & {
   index: number
   children: ReactNode | RenderIconFn
 }
@@ -20,8 +20,8 @@ export const RatingItem = forwardRef<'span', RatingItemProps>((props, ref) => {
   const mergedProps = mergeProps(getItemProps({ index }), divProps)
 
   return (
-    <atlas.span {...mergedProps} ref={ref}>
+    <ark.span {...mergedProps} ref={ref}>
       <RatingItemProvider value={state}>{icon}</RatingItemProvider>
-    </atlas.span>
+    </ark.span>
   )
 })

--- a/packages/react/src/rating/rating-label.tsx
+++ b/packages/react/src/rating/rating-label.tsx
@@ -1,12 +1,12 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { useRatingContext } from './rating-context'
 
-export type RatingLabelProps = HTMLAtlasProps<'label'>
+export type RatingLabelProps = HTMLArkProps<'label'>
 export const RatingLabel = forwardRef<'label', RatingLabelProps>((props, ref) => {
   const { labelProps } = useRatingContext()
   const mergedProps = mergeProps(labelProps, props)
 
-  return <atlas.label {...mergedProps} ref={ref} />
+  return <ark.label {...mergedProps} ref={ref} />
 })

--- a/packages/react/src/rating/rating.tsx
+++ b/packages/react/src/rating/rating.tsx
@@ -1,11 +1,11 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { splitProps, type Assign } from '../split-props'
 import { RatingProvider } from './rating-context'
 import { useRating, UseRatingProps } from './use-rating'
 
-export type RatingProps = Assign<HTMLAtlasProps<'input'>, UseRatingProps>
+export type RatingProps = Assign<HTMLArkProps<'input'>, UseRatingProps>
 
 export const Rating = forwardRef<'input', RatingProps>((props, ref) => {
   const [useRatingProps, divProps] = splitProps(props as UseRatingProps, [
@@ -29,10 +29,10 @@ export const Rating = forwardRef<'input', RatingProps>((props, ref) => {
 
   return (
     <RatingProvider value={rating}>
-      <atlas.div {...mergedProps}>
+      <ark.div {...mergedProps}>
         {props.children}
-        <atlas.input {...rating.inputProps} ref={ref} />
-      </atlas.div>
+        <ark.input {...rating.inputProps} ref={ref} />
+      </ark.div>
     </RatingProvider>
   )
 })

--- a/packages/react/src/tabs/tab-indicator.tsx
+++ b/packages/react/src/tabs/tab-indicator.tsx
@@ -1,13 +1,13 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { useTabsContext } from './tabs-context'
 
-export type TabIndicatorProps = HTMLAtlasProps<'div'>
+export type TabIndicatorProps = HTMLArkProps<'div'>
 
 export const TabIndicator = forwardRef<'div', TabIndicatorProps>((props, ref) => {
   const { indicatorProps } = useTabsContext()
   const mergedProps = mergeProps(indicatorProps, props)
 
-  return <atlas.div {...mergedProps} ref={ref} />
+  return <ark.div {...mergedProps} ref={ref} />
 })

--- a/packages/react/src/tabs/tab-list.tsx
+++ b/packages/react/src/tabs/tab-list.tsx
@@ -1,13 +1,13 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { useTabsContext } from './tabs-context'
 
-export type TabListProps = HTMLAtlasProps<'div'>
+export type TabListProps = HTMLArkProps<'div'>
 
 export const TabList = forwardRef<'div', TabListProps>((props, ref) => {
   const { triggerGroupProps } = useTabsContext()
   const mergedProps = mergeProps(triggerGroupProps, props)
 
-  return <atlas.div {...mergedProps} ref={ref} />
+  return <ark.div {...mergedProps} ref={ref} />
 })

--- a/packages/react/src/tabs/tab-panel.tsx
+++ b/packages/react/src/tabs/tab-panel.tsx
@@ -1,12 +1,12 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
 import type { connect } from '@zag-js/tabs'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { splitProps, type Assign } from '../split-props'
 import { useTabsContext } from './tabs-context'
 
 export type TabPanelProps = Assign<
-  HTMLAtlasProps<'div'>,
+  HTMLArkProps<'div'>,
   Parameters<ReturnType<typeof connect>['getContentProps']>[0]
 >
 
@@ -15,5 +15,5 @@ export const TabPanel = forwardRef<'div', TabPanelProps>((props, ref) => {
   const { getContentProps } = useTabsContext()
   const mergedProps = mergeProps(getContentProps(tabContentProps), divProps)
 
-  return <atlas.div {...mergedProps} ref={ref} />
+  return <ark.div {...mergedProps} ref={ref} />
 })

--- a/packages/react/src/tabs/tab-panels.tsx
+++ b/packages/react/src/tabs/tab-panels.tsx
@@ -1,13 +1,13 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { useTabsContext } from './tabs-context'
 
-export type TabPanelsProps = HTMLAtlasProps<'div'>
+export type TabPanelsProps = HTMLArkProps<'div'>
 
 export const TabPanels = forwardRef<'div', TabPanelsProps>((props, ref) => {
   const { contentGroupProps } = useTabsContext()
   const mergedProps = mergeProps(contentGroupProps, props)
 
-  return <atlas.div {...mergedProps} ref={ref} />
+  return <ark.div {...mergedProps} ref={ref} />
 })

--- a/packages/react/src/tabs/tab.tsx
+++ b/packages/react/src/tabs/tab.tsx
@@ -1,12 +1,12 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
 import type { connect } from '@zag-js/tabs'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { splitProps, type Assign } from '../split-props'
 import { useTabsContext } from './tabs-context'
 
 export type TabProps = Assign<
-  HTMLAtlasProps<'button'>,
+  HTMLArkProps<'button'>,
   Parameters<ReturnType<typeof connect>['getTriggerProps']>[0]
 >
 
@@ -15,5 +15,5 @@ export const Tab = forwardRef<'button', TabProps>((props, ref) => {
   const { getTriggerProps } = useTabsContext()
   const mergedProps = mergeProps(getTriggerProps(tabProps), buttonProps)
 
-  return <atlas.button {...mergedProps} ref={ref} />
+  return <ark.button {...mergedProps} ref={ref} />
 })

--- a/packages/react/src/tabs/tabs.tsx
+++ b/packages/react/src/tabs/tabs.tsx
@@ -1,11 +1,11 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { Assign, splitProps } from '../split-props'
 import { TabsProvider } from './tabs-context'
 import { useTabs, UseTabsProps } from './use-tabs'
 
-export type TabsProps = Assign<HTMLAtlasProps<'div'>, UseTabsProps>
+export type TabsProps = Assign<HTMLArkProps<'div'>, UseTabsProps>
 
 export const Tabs = forwardRef<'div', TabsProps>((props, ref) => {
   const [useTabsProps, divProps] = splitProps(props, [
@@ -27,7 +27,7 @@ export const Tabs = forwardRef<'div', TabsProps>((props, ref) => {
 
   return (
     <TabsProvider value={tabs}>
-      <atlas.div {...mergedProps} ref={ref} />
+      <ark.div {...mergedProps} ref={ref} />
     </TabsProvider>
   )
 })

--- a/packages/react/src/tooltip/tooltip-arrow.tsx
+++ b/packages/react/src/tooltip/tooltip-arrow.tsx
@@ -1,13 +1,13 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { useTooltipContext } from './tooltip-context'
 
-export type TooltipArrowProps = HTMLAtlasProps<'div'>
+export type TooltipArrowProps = HTMLArkProps<'div'>
 
 export const TooltipArrow = forwardRef<'div', TooltipArrowProps>((props, ref) => {
   const { arrowProps } = useTooltipContext()
   const mergedProps = mergeProps(arrowProps, props)
 
-  return <atlas.div {...mergedProps} ref={ref} />
+  return <ark.div {...mergedProps} ref={ref} />
 })

--- a/packages/react/src/tooltip/tooltip-content.tsx
+++ b/packages/react/src/tooltip/tooltip-content.tsx
@@ -1,13 +1,13 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { useTooltipContext } from './tooltip-context'
 
-export type TooltipContentProps = HTMLAtlasProps<'div'>
+export type TooltipContentProps = HTMLArkProps<'div'>
 
 export const TooltipContent = forwardRef<'div', TooltipContentProps>((props, ref) => {
   const { contentProps } = useTooltipContext()
   const mergedProps = mergeProps(contentProps, props)
 
-  return <atlas.div {...mergedProps} ref={ref} />
+  return <ark.div {...mergedProps} ref={ref} />
 })

--- a/packages/react/src/tooltip/tooltip-inner-arrow.tsx
+++ b/packages/react/src/tooltip/tooltip-inner-arrow.tsx
@@ -1,13 +1,13 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { useTooltipContext } from './tooltip-context'
 
-export type TooltipInnerArrowProps = HTMLAtlasProps<'div'>
+export type TooltipInnerArrowProps = HTMLArkProps<'div'>
 
 export const TooltipInnerArrow = forwardRef<'div', TooltipInnerArrowProps>((props, ref) => {
   const { innerArrowProps } = useTooltipContext()
   const mergedProps = mergeProps(innerArrowProps, props)
 
-  return <atlas.div {...mergedProps} ref={ref} />
+  return <ark.div {...mergedProps} ref={ref} />
 })

--- a/packages/react/src/tooltip/tooltip-positioner.tsx
+++ b/packages/react/src/tooltip/tooltip-positioner.tsx
@@ -1,13 +1,13 @@
 import { forwardRef } from '@polymorphic-factory/react'
 import { mergeProps } from '@zag-js/react'
-import { atlas, HTMLAtlasProps } from '../factory'
+import { ark, HTMLArkProps } from '../factory'
 import { useTooltipContext } from './tooltip-context'
 
-export type TooltipPositionerProps = HTMLAtlasProps<'div'>
+export type TooltipPositionerProps = HTMLArkProps<'div'>
 
 export const TooltipPositioner = forwardRef<'div', TooltipPositionerProps>((props, ref) => {
   const { positionerProps, isOpen } = useTooltipContext()
   const mergedProps = mergeProps(positionerProps, props)
 
-  return isOpen ? <atlas.div {...mergedProps} ref={ref} /> : null
+  return isOpen ? <ark.div {...mergedProps} ref={ref} /> : null
 })

--- a/packages/react/src/tooltip/tooltip-trigger.tsx
+++ b/packages/react/src/tooltip/tooltip-trigger.tsx
@@ -1,5 +1,5 @@
 import { cloneElement, ReactElement } from 'react'
-import { atlas } from '../factory'
+import { ark } from '../factory'
 import { useTooltipContext } from './tooltip-context'
 
 export type TooltipTriggerProps = { children: ReactElement | string | number }
@@ -9,7 +9,7 @@ export const TooltipTrigger = (props: TooltipTriggerProps) => {
   const { triggerProps } = useTooltipContext()
 
   return typeof children === 'string' || typeof children === 'number' ? (
-    <atlas.span {...triggerProps}>{children}</atlas.span>
+    <ark.span {...triggerProps}>{children}</ark.span>
   ) : (
     cloneElement(children, triggerProps)
   )

--- a/packages/solid/src/pin-input/use-pin-input.ts
+++ b/packages/solid/src/pin-input/use-pin-input.ts
@@ -7,7 +7,7 @@ export type UsePinInputProps = Omit<pinInput.Context, 'id'> & {
 }
 export type UsePinInputReturn = ReturnType<typeof usePinInput>
 
-// TODO https://github.com/chakra-ui/atlas/issues/48
+// TODO https://github.com/chakra-ui/ark/issues/48
 export const usePinInput = (props: UsePinInputProps) => {
   const [state, send] = useMachine(
     pinInput.machine({


### PR DESCRIPTION
search and replace with case preservation for `atlas` => `ark`