### PR TITLE
chore: polish split props fn

### DIFF
--- a/packages/react/src/create-split-props.test.ts
+++ b/packages/react/src/create-split-props.test.ts
@@ -1,21 +1,37 @@
 import { createSplitProps } from './create-split-props'
 
 describe('createSplitProps', () => {
-  it('should split props', () => {
-    type Framework = {
-      name: string
-    }
-    const source = { name: 'react', b: 2, c: 3 }
+  type Target = {
+    name: string
+  }
 
+  const source = {
+    name: 'react',
+    b: 2,
+    c: 3,
+  }
+
+  it('should throw TS error on incomplete keys', () => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-expect-error this must be an error because name is not specified
-    createSplitProps<User>()(source, [])
+    createSplitProps<Target>()(source, [])
+  })
 
+  it('should throw TS error on extra keys', () => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-expect-error this must be an error because age is not known to User
-    createSplitProps<User>()(source, ['name', 'age'])
+    // @ts-expect-error this must be an error because age is not known to Target
+    createSplitProps<Target>()(source, ['name', 'age'])
+  })
 
-    const [firstGroup, rest] = createSplitProps<Framework>()(source, ['name'])
+  it('should create an empty object when no keys are required', () => {
+    const [firstGroup, rest] = createSplitProps()(source, [])
+
+    expect(firstGroup).toStrictEqual({})
+    expect(rest).toStrictEqual(source)
+  })
+
+  it('should split props', () => {
+    const [firstGroup, rest] = createSplitProps<Target>()(source, ['name'])
 
     expect(firstGroup).toStrictEqual({ name: 'react' })
     expect(rest).toEqual({ b: 2, c: 3 })

--- a/packages/react/src/create-split-props.ts
+++ b/packages/react/src/create-split-props.ts
@@ -1,13 +1,16 @@
 export const createSplitProps =
-  <T, K = keyof T, S extends T = T>() =>
-  <U extends K[]>(props: S, keys: U & ([K] extends [U[number]] ? unknown : never)): [T, any] => {
-    // return type
-    return keys.reduce<[T, any]>( // TODO any
-      (prev, key) => {
-        const [target, source] = prev
-        const { [key as string]: value, ...rest } = source
-        return [{ ...target, [key as string]: value }, rest]
+  <Target>() =>
+  <Keys extends (keyof Target)[], Props extends Target = Target>(
+    props: Props,
+    keys: Keys & ([keyof Target] extends [Keys[number]] ? unknown : never),
+  ) =>
+    (keys as string[]).reduce<[Target, Omit<Props, Extract<typeof keys[number], string>>]>(
+      (previousValue, currentValue) => {
+        const [target, source] = previousValue
+        const key = currentValue as keyof Target & keyof typeof source
+        target[key] = source[key]
+        delete source[key]
+        return [target, source]
       },
-      [{} as T, props],
+      [{} as Target, { ...props }],
     )
-  }


### PR DESCRIPTION
- splitted tests
- give generics human readable names
- moved type `S` from hoc to child and rename to `Props`
- replaced object spread in `reduce` with local mutation