### PR TITLE
feat(react): streamline hover card trigger

### DIFF
--- a/packages/react/src/hover-card/hover-card-trigger.tsx
+++ b/packages/react/src/hover-card/hover-card-trigger.tsx
@@ -1,12 +1,12 @@
-import { forwardRef } from '@polymorphic-factory/react'
-import { mergeProps } from '@zag-js/react'
-import { ark, HTMLArkProps } from '../factory'
+import { Children, cloneElement, ReactElement } from 'react'
 import { useHoverCardContext } from './hover-card-context'
 
-export type HoverCardTriggerProps = HTMLArkProps<'a'>
+export type HoverCardTriggerProps = {
+  children: ReactElement
+}
 
-export const HoverCardTrigger = forwardRef<'a', HoverCardTriggerProps>((props, ref) => {
+export const HoverCardTrigger = (props: HoverCardTriggerProps) => {
   const { triggerProps } = useHoverCardContext()
-  const mergedProps = mergeProps(triggerProps, props)
-  return <ark.a {...mergedProps} ref={ref} />
-})
+  const onlyChild = Children.only(props.children)
+  return cloneElement(onlyChild, triggerProps)
+}

--- a/packages/react/src/hover-card/hover-card.stories.tsx
+++ b/packages/react/src/hover-card/hover-card.stories.tsx
@@ -11,8 +11,10 @@ import './hover-card.css'
 
 export const Basic = () => (
   <HoverCard>
-    <HoverCardTrigger href="https://mastodon.com/zag_js" target="_blank">
-      Mastodon
+    <HoverCardTrigger>
+      <a href="https://mastodon.com/zag_js" target="_blank" rel="noreferrer">
+        Mastodon
+      </a>
     </HoverCardTrigger>
 
     <HoverCardPortal>

--- a/packages/react/src/hover-card/hover-card.test.tsx
+++ b/packages/react/src/hover-card/hover-card.test.tsx
@@ -10,8 +10,10 @@ import { HoverCardTrigger } from './hover-card-trigger'
 
 const ComponentUnderTest = () => (
   <HoverCard openDelay={0} closeDelay={0}>
-    <HoverCardTrigger href="https://mastodon.com/zag_js" target="_blank">
-      Mastodon
+    <HoverCardTrigger>
+      <a href="https://mastodon.com/zag_js" target="_blank" rel="noreferrer">
+        Mastodon
+      </a>
     </HoverCardTrigger>
 
     <HoverCardPortal>


### PR DESCRIPTION
Streamlined the implementation to our other Trigger components:

```tsx
<HoverCardTrigger href="https://mastodon.com/zag_js" target="_blank">
  Mastodon
</HoverCardTrigger>
```

to

```tsx
<HoverCardTrigger>
  <a href="https://mastodon.com/zag_js" target="_blank" rel="noreferrer">
    Mastodon
  </a>
</HoverCardTrigger>