### PR TITLE
chore: add micro storybook for react package

### DIFF
--- a/packages/react/index.css
+++ b/packages/react/index.css
@@ -1,0 +1,105 @@
+html,
+body,
+#root {
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;
+  flex: 1 0 100%;
+  padding: 0;
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif,
+    'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+}
+
+:root {
+  --colors-sidebar-background: #A0AEC0;
+  --colors-separator: #A0AEC0;
+}
+
+.story-renderer {
+  flex: 1;
+  display: flex;
+}
+
+.story-renderer__sidebar {
+  flex: 0 1 auto;
+  display: flex;
+  flex-direction: column;
+  background-color: var(--colors-sidebar-background);
+  padding: 2rem 0.5rem;
+}
+
+.story-renderer__container {
+  flex: 1 1 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.story-renderer__header {
+  padding: 2rem 1rem;
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+}
+
+.story-renderer__content {
+  padding: 0 1rem;
+}
+
+.story-renderer__title {
+  margin: 0;
+  text-transform: capitalize;
+}
+
+.story {
+  position: relative;
+  padding: 1.75rem 0;
+}
+
+.story + .story {
+  border-bottom: 1px solid var(--colors-separator);
+}
+
+.story__header {
+  padding: 0 0 1.75rem;
+}
+
+.story__title {
+  margin: 0;
+}
+
+.story__wrapper {
+}
+
+.component-links {
+}
+
+.component-links__list {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.5rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.component-links__list-item {
+  display: flex;
+}
+
+.component-links__link {
+  flex: 1;
+  color: currentColor;
+  text-decoration: none;
+  text-transform: capitalize;
+  padding: 0.5rem 1rem 0.5rem 0.75rem;
+  border-radius: 0.25rem;
+  transition: background-color 200ms ease-out;
+}
+
+.component-links__link[aria-current='page'] {
+  background-color: rgba(255, 255, 255, 0.2);
+}
+
+.component-links__link:hover {
+  background-color: rgba(255, 255, 255, 0.2);
+}

--- a/packages/react/index.html
+++ b/packages/react/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@ark-ui/react</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/packages/react/main.tsx
+++ b/packages/react/main.tsx
@@ -1,0 +1,108 @@
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import {
+  createBrowserRouter,
+  Navigate,
+  NavLink,
+  RouterProvider,
+  useLoaderData,
+} from 'react-router-dom'
+import './index.css'
+
+const storyModules = import.meta.glob('./src/**/*.stories.tsx')
+const stories = Object.fromEntries(
+  Object.entries(storyModules).map(([path, storyModule]) => {
+    const componentName = path.split('/').at(-1)?.split('.').at(0)
+    return [componentName, storyModule] as const
+  }),
+)
+
+const ComponentLinks = () => {
+  const links = Object.entries(stories).map(([componentName], index) => (
+    <li key={index} className="component-links__list-item">
+      <NavLink to={`/story/${componentName}`} className="component-links__link">
+        {componentName}
+      </NavLink>
+    </li>
+  ))
+
+  return (
+    <nav className="component-links">
+      <ul className="component-links__list">{links}</ul>
+    </nav>
+  )
+}
+
+interface StoryRendererProps {
+  storyModule: Record<string, React.ElementType>
+  componentName: string
+}
+
+function StoryRenderer({ storyModule, componentName }: StoryRendererProps) {
+  const stories = Object.entries(
+    storyModule || { 'Not found': () => <h3>such empty space</h3> },
+  ).map(([storyName, StoryComponent], index) => (
+    <section key={index} className="story">
+      <header className="story__header">
+        <h2 className="story__title">{storyName}</h2>
+      </header>
+      <div className="story__wrapper">
+        <StoryComponent />
+      </div>
+    </section>
+  ))
+
+  return (
+    <div className="story-renderer">
+      <aside className="story-renderer__sidebar">
+        <ComponentLinks />
+      </aside>
+      <main className="story-renderer__container">
+        <header className="story-renderer__header">
+          <h1 className="story-renderer__title">{componentName}</h1>
+        </header>
+        <div className="story-renderer__content">{stories}</div>
+      </main>
+    </div>
+  )
+}
+
+const StoryRouteRenderer = () => {
+  const storyModuleTuple = useLoaderData() as
+    | [string, Record<string, React.ElementType>]
+    | undefined
+
+  if (!storyModuleTuple) {
+    return <h1>404</h1>
+  }
+
+  const [componentName, storyModule] = storyModuleTuple
+  return <StoryRenderer componentName={componentName} storyModule={storyModule} />
+}
+
+const router = createBrowserRouter([
+  {
+    element: <StoryRouteRenderer />,
+    path: 'story/:storyName',
+    loader: async ({ params }) => {
+      if (!params.storyName) return
+      const storyThunk = stories[params.storyName]
+      return [params.storyName, await storyThunk?.()]
+    },
+  },
+  {
+    element: <Navigate to="/story/accordion" />,
+    path: '*',
+  },
+])
+
+const App = () => (
+  <React.StrictMode>
+    <RouterProvider router={router} />
+  </React.StrictMode>
+)
+
+const rootElement = document.getElementById('root')
+if (rootElement) {
+  createRoot(rootElement).render(<App />)
+}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -32,6 +32,7 @@
   },
   "scripts": {
     "build": "tsup src/index.ts",
+    "dev": "vite",
     "lint": "eslint --ext .ts,.tsx src",
     "test": "vitest",
     "test:ci": "vitest --run --coverage",
@@ -79,6 +80,8 @@
     "jsdom": "20.0.3",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-router": "6.4.3",
+    "react-router-dom": "6.4.3",
     "tsup": "6.5.0",
     "typescript": "4.9.3",
     "vite": "3.2.4",

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "jsxImportSource": "react"
+    "jsxImportSource": "react",
+    "types": ["vite/client", "vitest"]
   },
-  "include": ["src"]
+  "include": ["src", "vite.config.ts", "main.tsx"]
 }

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -1,12 +1,12 @@
-/// <reference types="vitest" />
-/// <reference types="vite/client" />
-
 import react from '@vitejs/plugin-react'
 import { defineConfig } from 'vite'
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    open: true,
+  },
   test: {
     setupFiles: './src/setupTest.ts',
     coverage: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,6 +118,8 @@ importers:
       jsdom: 20.0.3
       react: 18.2.0
       react-dom: 18.2.0
+      react-router: 6.4.3
+      react-router-dom: 6.4.3
       tsup: 6.5.0
       typescript: 4.9.3
       vite: 3.2.4
@@ -163,6 +165,8 @@ importers:
       jsdom: 20.0.3
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
+      react-router: 6.4.3_react@18.2.0
+      react-router-dom: 6.4.3_biqbaboplfbrettd7655fr4n2y
       tsup: 6.5.0_typescript@4.9.3
       typescript: 4.9.3
       vite: 3.2.4
@@ -3526,7 +3530,6 @@ packages:
   /@remix-run/router/1.0.3:
     resolution: {integrity: sha512-ceuyTSs7PZ/tQqi19YZNBc5X7kj1f8p+4DIyrcIYFY9h+hd1OKm4RqtiWldR9eGEvIiJfsqwM4BsuCtRIuEw6Q==}
     engines: {node: '>=14'}
-    dev: false
 
   /@rollup/pluginutils/4.2.1:
     resolution: {integrity: sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==}
@@ -12361,7 +12364,6 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       react-router: 6.4.3_react@18.2.0
-    dev: false
 
   /react-router/5.3.4_react@18.2.0:
     resolution: {integrity: sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==}
@@ -12388,7 +12390,6 @@ packages:
     dependencies:
       '@remix-run/router': 1.0.3
       react: 18.2.0
-    dev: false
 
   /react-textarea-autosize/8.4.0_fan5qbzahqtxlm5dzefqlqx5ia:
     resolution: {integrity: sha512-YrTFaEHLgJsi8sJVYHBzYn+mkP3prGkmP2DKb/tm0t7CLJY5t1Rxix8070LAKb0wby7bl/lf2EeHkuMihMZMwQ==}


### PR DESCRIPTION
I had fun building a micro storybook in ~100 LOC for the react package I wanted to share.
Used `react-router-dom` with loaders to dynamically render the stories in `src/**/*.stories.tsx`.

```sh
# try it with
pnpm react dev
```

<img width="1840" alt="image" src="https://user-images.githubusercontent.com/16899513/204401178-89ee46a1-a65d-42cf-8118-7afe4bbbd67a.png">

> :warning: **This PR is not intended to be merged as is** 
> Let's talk if we need something like this or a docs instance would be sufficient.