### PR TITLE
chore(docs): run panda codegen in prepare lifecycle

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "astro dev",
-    "prebuild": "panda codegen",
+    "prepare": "panda codegen",
     "build": "astro build",
     "start": "astro preview",
     "css": "panda",


### PR DESCRIPTION
- prevents race condition when run as prebuild script
- docs are ready to develop when checking out the repo for the first time or switching branches and run `pnpm install`