### PR TITLE
docs(react): add pin-input docs

### DIFF
--- a/packages/react/src/pin-input/docs/pin-input.mdx
+++ b/packages/react/src/pin-input/docs/pin-input.mdx
@@ -1,7 +1,91 @@
 # Pin Input
 
-The pin input is optimized for entering a sequence of digits or letters. The input fields allow one
-character at a time. When the digit or letter is entered, focus transfers to the next input in the
-sequence, until every input is filled.
+The pin input is optimized for entering a sequence of digits or letters. The
+input fields allow one character at a time. When the digit or letter is entered,
+focus transfers to the next input in the sequence, until every input is filled.
 
 <Showcase preset="pin-input" />
+
+## Import
+
+```ts
+import {
+  PinInput,
+  PinInputControl,
+  PinInputField,
+  PinInputLabel,
+} from '@ark-ui/react'
+```
+
+## Usage
+
+The PinInput component consists of the `PinInputControl` `PinInputField` and
+`PinInputLabel` components. Combine them as desired to fit your design system.
+
+```tsx
+<PinInput>
+  <PinInputLabel>Label</PinInputLabel>
+  <PinInputControl>
+    <PinInputField index={0} />
+    <PinInputField index={1} />
+    <PinInputField index={2} />
+  </PinInputControl>
+</PinInput>
+```
+
+### Setting a default value
+
+To set the initial value of the pin input, set the `defaultValue` prop.
+
+```tsx
+<PinInput defaultValue="123">{/*...*/}</PinInput>
+```
+
+### Changing the placeholder
+
+To customize the default pin input placeholder `○` for each input, pass the
+placeholder prop and set it to your desired value.
+
+```tsx
+<PinInput placeholder="*">{/*...*/}</PinInput>
+```
+
+### Blur on complete
+
+By default, the last input maintains focus when filled, and we invoke the
+`onComplete` callback. To blur the last input when the user completes the input,
+set the prop `blurOnComplete` to `true`.
+
+```tsx
+<PinInput blurOnComplete>{/*...*/}</PinInput>
+```
+
+### Using OTP mode
+
+To trigger smartphone OTP auto-suggestion, it is recommended to set the
+`autocomplete` attribute to "one-time-code". The pin input component provides
+support for this automatically when you set the `otp` prop to true.
+
+```tsx
+<PinInput otp>{/*...*/}</PinInput>
+```
+
+### Securing the text input
+
+When collecting private or sensitive information using the pin input, you might
+need to mask the value entered, similar to `<input type="password"/>`. Pass the
+`mask` prop to `true`.
+
+```tsx
+<PinInput mask>{/*...*/}</PinInput>
+```
+
+### Listening for changes
+
+The pin input component invokes several callback functions when the user enters:
+
+- `onChange` — Callback invoked when the value is changed.
+- `onComplete` — Callback invoked when all fields have been completed (by typing
+  or pasting).
+- `onInvalid` — Callback invoked when an invalid value is entered into the
+  input. An invalid value is any value that doesn't match the specified "type".


### PR DESCRIPTION
Docs Page: https://ark-docs-git-feature-oss-497-docs-add-pin-inpu-90a5a7-chakra-ui.vercel.app/docs/react/components/pin-input