### PR TITLE
fix(docs): center playground

### DIFF
--- a/docs/src/components/shared/Playground.tsx
+++ b/docs/src/components/shared/Playground.tsx
@@ -1,5 +1,5 @@
 import React, { ComponentType, PropsWithChildren, Suspense } from 'react'
-import { AbsoluteCenter, Box } from '../../../panda/jsx'
+import { Box } from '../../../panda/jsx'
 
 function lazyNamedImport<
   Module extends { [Key in MemberName]: ComponentType<any> },
@@ -66,7 +66,10 @@ export const Playground = (props: PlaygroundProps) => {
 
 const Canvas = (props: PropsWithChildren) => (
   <Box
-    position="relative"
+    display="flex"
+    justifyContent="center"
+    alignItems="center"
+    p="4"
     flex="1"
     bgImage={{
       base: 'radial-gradient(circle,var(--colors-gray-200) 1px, transparent 1px)',
@@ -74,6 +77,6 @@ const Canvas = (props: PropsWithChildren) => (
     }}
     bgSize="16px 16px"
   >
-    <AbsoluteCenter>{props.children}</AbsoluteCenter>
+    {props.children}
   </Box>
 )


### PR DESCRIPTION
`AbsoluteCenter` breaks some showcases like Slider and Rangeslider:
<img width="736" alt="image" src="https://user-images.githubusercontent.com/16899513/208708475-df8166dc-6572-4060-9185-d3d50e683161.png">

This PR reverts the Playground to a flex based center.