### PR TITLE
feat(vue): add select

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The plugin is available for [VSCode](https://marketplace.visualstudio.com/items?
 | Radio Group  | 🟢    | 🟢    | ⚪  |
 | Range Slider | 🟢    | 🟢    | ⚪  |
 | Rating       | 🟢    | 🟢    | ⚪  |
-| Select       | 🟢    | 🟢    | ⚪  |
+| Select       | 🟢    | 🟢    | 🟢  |
 | Slider       | 🟢    | 🟢    | ⚪  |
 | Tabs         | 🟢    | 🟢    | ⚪  |
 | Tags Input   | 🟢    | 🟢    | ⚪  |

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -52,7 +52,8 @@
     "@zag-js/tags-input": "0.3.7",
     "@zag-js/toast": "0.2.7",
     "@zag-js/tooltip": "0.2.6",
-    "@zag-js/vue": "0.2.4"
+    "@zag-js/vue": "0.2.4",
+    "@zag-js/select": "0.1.6"
   },
   "devDependencies": {
     "@testing-library/dom": "8.19.1",

--- a/packages/vue/src/accordion/accordion-trigger.tsx
+++ b/packages/vue/src/accordion/accordion-trigger.tsx
@@ -1,5 +1,5 @@
-import { cloneVNode, defineComponent, h } from 'vue'
-import { getValidChildren } from '../utils'
+import { defineComponent, h } from 'vue'
+import { useUniqueChild } from '../utils'
 import { useAccordionContext } from './accordion-context'
 import { useAccordionItemContext } from './accordion-item-context'
 
@@ -14,14 +14,7 @@ export const AccordionTrigger = defineComponent<AccordionTriggerProps>({
     const { value, disabled } = useAccordionItemContext()
 
     return () => {
-      const validChildren = getValidChildren(slots)
-      if (validChildren.length > 1) {
-        const errorMessage =
-          '[AccordionTrigger] : Accordion Trigger can only have one root element.'
-        console.error(errorMessage)
-        throw new SyntaxError(errorMessage)
-      }
-      const DefaultSlot = cloneVNode(validChildren[0])
+      const DefaultSlot = useUniqueChild(slots, 'AccordionTrigger')
 
       return h(DefaultSlot, { ...api.value.getTriggerProps({ value, disabled }), ...attrs })
     }

--- a/packages/vue/src/select/index.ts
+++ b/packages/vue/src/select/index.ts
@@ -1,0 +1,14 @@
+export { Select, type SelectProps } from './select'
+export { SelectContent, type SelectContentProps } from './select-content'
+export { SelectProvider, useSelectContext, type SelectContext } from './select-context'
+export { SelectLabel, type SelectLabelProps } from './select-label'
+export { SelectOption, type SelectOptionProps } from './select-option'
+export { SelectOptionGroup, type SelectOptionGroupProps } from './select-option-group'
+export {
+  SelectOptionGroupLabel,
+  type SelectOptionGroupLabelProps,
+} from './select-option-group-label'
+export { SelectPositioner, type SelectPositionerProps } from './select-positioner'
+export { SelectTrigger, type SelectTriggerProps } from './select-trigger'
+export { selectAnatomy } from './select.anatomy'
+export { useSelect, type UseSelectProps, type UseSelectReturn } from './use-select'

--- a/packages/vue/src/select/select-content.tsx
+++ b/packages/vue/src/select/select-content.tsx
@@ -1,0 +1,19 @@
+import { defineComponent } from 'vue'
+import { ark, HTMLArkProps } from '../factory'
+import { ComponentWithProps, getValidChildren } from '../utils'
+import { useSelectContext } from './select-context'
+
+export type SelectContentProps = HTMLArkProps<'ul'>
+
+export const SelectContent: ComponentWithProps<SelectContentProps> = defineComponent({
+  name: 'SelectContent',
+  setup(_, { slots, attrs }) {
+    const api = useSelectContext()
+
+    return () => (
+      <ark.ul {...api.value.contentProps} {...attrs}>
+        {() => getValidChildren(slots)}
+      </ark.ul>
+    )
+  },
+})

--- a/packages/vue/src/select/select-context.ts
+++ b/packages/vue/src/select/select-context.ts
@@ -1,0 +1,9 @@
+import type { connect } from '@zag-js/select'
+import type { ComputedRef } from 'vue'
+import { createContext } from '../context'
+import type { UseSelectReturn } from './use-select'
+
+export const [SelectProvider, useSelectContext] =
+  createContext<ComputedRef<ReturnType<typeof connect>>>('SelectContext')
+
+export type SelectContext = UseSelectReturn

--- a/packages/vue/src/select/select-label.tsx
+++ b/packages/vue/src/select/select-label.tsx
@@ -1,0 +1,19 @@
+import { defineComponent } from 'vue'
+import { ark, HTMLArkProps } from '../factory'
+import { ComponentWithProps, getValidChildren } from '../utils'
+import { useSelectContext } from './select-context'
+
+export type SelectLabelProps = HTMLArkProps<'label'>
+
+export const SelectLabel: ComponentWithProps<SelectLabelProps> = defineComponent({
+  name: 'SelectLabel',
+  setup(_, { slots, attrs }) {
+    const api = useSelectContext()
+
+    return () => (
+      <ark.label {...api.value.labelProps} {...attrs}>
+        {() => getValidChildren(slots)}
+      </ark.label>
+    )
+  },
+})

--- a/packages/vue/src/select/select-option-group-label.tsx
+++ b/packages/vue/src/select/select-option-group-label.tsx
@@ -1,0 +1,27 @@
+import { defineComponent, PropType } from 'vue'
+import { ark, HTMLArkProps } from '../factory'
+import { ComponentWithProps, getValidChildren } from '../utils'
+import { useSelectContext } from './select-context'
+
+export interface SelectOptionGroupLabelProps extends HTMLArkProps<'label'> {
+  htmlFor: string
+}
+
+export const SelectOptionGroupLabel: ComponentWithProps<SelectOptionGroupLabelProps> =
+  defineComponent({
+    props: {
+      htmlFor: String as PropType<SelectOptionGroupLabelProps['htmlFor']>,
+    },
+    setup(props, { slots, attrs }) {
+      const api = useSelectContext()
+
+      return () => (
+        <ark.label
+          {...api.value.getOptionGroupLabelProps({ htmlFor: props.htmlFor as string })}
+          {...attrs}
+        >
+          {() => getValidChildren(slots)}
+        </ark.label>
+      )
+    },
+  })

--- a/packages/vue/src/select/select-option-group.tsx
+++ b/packages/vue/src/select/select-option-group.tsx
@@ -1,0 +1,23 @@
+import { defineComponent, PropType } from 'vue'
+import { ark, HTMLArkProps } from '../factory'
+import { ComponentWithProps, getValidChildren } from '../utils'
+import { useSelectContext } from './select-context'
+
+export interface SelectOptionGroupProps extends HTMLArkProps<'div'> {
+  id: string
+}
+
+export const SelectOptionGroup: ComponentWithProps<SelectOptionGroupProps> = defineComponent({
+  props: {
+    id: String as PropType<SelectOptionGroupProps['id']>,
+  },
+  setup(props, { slots, attrs }) {
+    const api = useSelectContext()
+
+    return () => (
+      <ark.div {...api.value.getOptionGroupProps({ id: props.id as string })} {...attrs}>
+        {() => getValidChildren(slots)}
+      </ark.div>
+    )
+  },
+})

--- a/packages/vue/src/select/select-option.tsx
+++ b/packages/vue/src/select/select-option.tsx
@@ -1,0 +1,49 @@
+import { computed, defineComponent, PropType } from 'vue'
+import { ark, HTMLArkProps } from '../factory'
+import { ComponentWithProps, getValidChildren } from '../utils'
+import { useSelectContext } from './select-context'
+
+type OptionProps = Parameters<ReturnType<typeof useSelectContext>['value']['getOptionProps']>[0]
+export interface SelectOptionProps extends HTMLArkProps<'li'>, OptionProps {}
+
+const VueSelectOptionProps = {
+  disabled: {
+    type: Boolean as PropType<OptionProps['disabled']>,
+  },
+  label: {
+    type: String as PropType<OptionProps['label']>,
+    required: true,
+  },
+  value: {
+    type: String as PropType<OptionProps['value']>,
+    required: true,
+  },
+  valueText: {
+    type: String as PropType<OptionProps['valueText']>,
+  },
+}
+
+export const SelectOption: ComponentWithProps<SelectOptionProps> = defineComponent({
+  name: 'SelectOption',
+  props: VueSelectOptionProps,
+  setup(props, { slots, attrs }) {
+    const selectOptionProps = computed<OptionProps>(() => ({
+      label: props.label as string,
+      disabled: props.disabled,
+      value: props.value as string,
+      valueText: props.valueText,
+    }))
+
+    const api = useSelectContext()
+
+    return () => {
+      const validChildren = getValidChildren(slots)
+
+      return (
+        <ark.li {...api.value.getOptionProps(selectOptionProps.value)} {...attrs}>
+          {() => (validChildren.length > 1 ? validChildren : selectOptionProps.value.label)}
+        </ark.li>
+      )
+    }
+  },
+})

--- a/packages/vue/src/select/select-positioner.tsx
+++ b/packages/vue/src/select/select-positioner.tsx
@@ -1,0 +1,19 @@
+import { defineComponent } from 'vue'
+import { ark, HTMLArkProps } from '../factory'
+import { ComponentWithProps, getValidChildren } from '../utils'
+import { useSelectContext } from './select-context'
+
+export type SelectPositionerProps = HTMLArkProps<'div'>
+
+export const SelectPositioner: ComponentWithProps<SelectPositionerProps> = defineComponent({
+  name: 'SelectPositioner',
+  setup(_, { slots, attrs }) {
+    const api = useSelectContext()
+
+    return () => (
+      <ark.div {...api.value.positionerProps} {...attrs}>
+        {() => getValidChildren(slots)}
+      </ark.div>
+    )
+  },
+})

--- a/packages/vue/src/select/select-trigger.tsx
+++ b/packages/vue/src/select/select-trigger.tsx
@@ -1,0 +1,20 @@
+import { defineComponent, h } from 'vue'
+import { useUniqueChild } from '../utils'
+import { useSelectContext } from './select-context'
+
+/** This type is here so that the script 'check-exports' passes
+ *  because in Vue we don't pass 'children' as props
+ */
+export type SelectTriggerProps = Record<string, unknown>
+
+export const SelectTrigger = defineComponent<SelectTriggerProps>({
+  name: 'SelectTrigger',
+  setup(_, { slots, attrs }) {
+    const api = useSelectContext()
+    return () => {
+      const DefaultSlot = useUniqueChild(slots, 'SelectTrigger')
+
+      return h(DefaultSlot, { ...api.value.triggerProps, ...attrs })
+    }
+  },
+})

--- a/packages/vue/src/select/select.anatomy.ts
+++ b/packages/vue/src/select/select.anatomy.ts
@@ -1,0 +1,1 @@
+export { anatomy as selectAnatomy } from '@zag-js/select'

--- a/packages/vue/src/select/select.story.vue
+++ b/packages/vue/src/select/select.story.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import {
+  Select,
+  SelectTrigger,
+  SelectLabel,
+  SelectPositioner,
+  SelectContent,
+  SelectOption,
+  SelectProps,
+} from './index'
+
+const selectedOption = ref<SelectProps['modelValue']>()
+</script>
+<template>
+  <Select v-model="selectedOption">
+    <SelectLabel>Framework:</SelectLabel>
+    <SelectTrigger>
+      <button>{{ selectedOption?.label ?? 'Select' }}</button>
+    </SelectTrigger>
+
+    <Teleport to="body">
+      <SelectPositioner>
+        <SelectContent>
+          <SelectOption value="react" label="React" />
+          <SelectOption value="solidjs" label="SolidJs" />
+          <SelectOption value="vue" label="VueJS">VueJS</SelectOption>
+        </SelectContent>
+      </SelectPositioner>
+    </Teleport>
+  </Select>
+</template>

--- a/packages/vue/src/select/select.test.tsx
+++ b/packages/vue/src/select/select.test.tsx
@@ -1,0 +1,26 @@
+import user from '@testing-library/user-event'
+import { render } from '@testing-library/vue'
+import SelectStory from './select.story.vue'
+
+describe('Select', () => {
+  it('should render', () => {
+    render(SelectStory)
+  })
+
+  it('should show options on click', async () => {
+    const { getByRole, getByText } = render(SelectStory)
+
+    expect(getByRole('option', { hidden: true, name: 'React' })).not.toBeVisible()
+    await user.click(getByText('Select'))
+    expect(getByRole('option', { name: 'React' })).toBeVisible()
+  })
+
+  it('should allow to select an option', async () => {
+    const { getByRole, getByText, queryByText } = render(SelectStory)
+    expect(getByRole('option', { hidden: true, name: 'React' })).not.toBeVisible()
+    await user.click(getByText('Select'))
+
+    await user.click(getByRole('option', { name: 'React' }))
+    expect(queryByText('Select')).not.toBeInTheDocument()
+  })
+})

--- a/packages/vue/src/select/select.tsx
+++ b/packages/vue/src/select/select.tsx
@@ -1,0 +1,57 @@
+import { computed, defineComponent, PropType } from 'vue'
+import { SelectProvider } from './select-context'
+import { useSelect, UseSelectProps } from './use-select'
+
+export interface SelectProps {
+  modelValue: UseSelectProps['context']['modelValue']
+  isLooped?: UseSelectProps['context']['loop']
+  isClosedOnSelect?: UseSelectProps['context']['closeOnSelect']
+  isDisabled?: UseSelectProps['context']['disabled']
+  isReadOnly?: UseSelectProps['context']['readOnly']
+}
+
+export const Select = defineComponent({
+  name: 'Select',
+  emits: ['change', 'highlight', 'open', 'close', 'update:modelValue'],
+  props: {
+    modelValue: {
+      type: [Object, null] as PropType<SelectProps['modelValue']>,
+      default: null,
+    },
+    isLooped: {
+      type: Boolean as PropType<SelectProps['isLooped']>,
+      default: false,
+    },
+    isClosedOnSelect: {
+      type: Boolean as PropType<UseSelectProps['context']['closeOnSelect']>,
+      default: true,
+    },
+    isDisabled: {
+      type: Boolean as PropType<UseSelectProps['context']['disabled']>,
+      default: false,
+    },
+    isReadOnly: {
+      type: Boolean as PropType<UseSelectProps['context']['readOnly']>,
+      default: false,
+    },
+  },
+  setup(props, { slots, emit }) {
+    const selectProps = computed<UseSelectProps>(() => ({
+      context: {
+        ...props,
+        loop: props.isLooped,
+        closeOnSelect: props.isClosedOnSelect,
+        disabled: props.isDisabled,
+        readOnly: props.isReadOnly,
+        modelValue: props.modelValue,
+      },
+      emit,
+    }))
+
+    const { api } = useSelect(selectProps.value)
+
+    SelectProvider(api)
+
+    return () => slots?.default?.()
+  },
+})

--- a/packages/vue/src/select/use-select.ts
+++ b/packages/vue/src/select/use-select.ts
@@ -1,0 +1,53 @@
+import { connect, Context as SelectContext, machine } from '@zag-js/select'
+import { normalizeProps, useMachine } from '@zag-js/vue'
+import { computed, getCurrentInstance, reactive, watch } from 'vue'
+
+interface SelectProps extends SelectContext {
+  modelValue: SelectContext['selectedOption']
+}
+
+export interface UseSelectProps {
+  context: Omit<SelectProps, 'id'>
+  emit: CallableFunction
+}
+
+export const useSelect = (props: UseSelectProps) => {
+  const reactiveProps = reactive(props)
+  const { context, emit } = reactiveProps
+  const reactiveContext = reactive(context)
+  const instance = getCurrentInstance()
+  const [state, send] = useMachine(
+    machine({
+      ...reactiveContext,
+      id: instance?.uid.toString() as string,
+      selectedOption: context.modelValue,
+      onChange: (details) => {
+        emit('change', { ...details })
+        emit('update:modelValue', { ...details })
+      },
+      onHighlight(details) {
+        emit('highlight', { ...details })
+      },
+      onClose() {
+        emit('close')
+      },
+      onOpen() {
+        emit('open')
+      },
+    }),
+  )
+
+  watch(
+    () => context.modelValue,
+    (value, prevValue) => {
+      if (value === prevValue) return
+      api.value.setSelectedOption(value as { label: string; value: string })
+    },
+  )
+
+  const api = computed(() => connect(state.value, send, normalizeProps))
+
+  return { api }
+}
+
+export type UseSelectReturn = ReturnType<typeof useSelect>

--- a/packages/vue/src/utils.ts
+++ b/packages/vue/src/utils.ts
@@ -1,4 +1,12 @@
-import { AllowedComponentProps, ComponentCustomProps, isVNode, Slots, VNode, VNodeProps } from 'vue'
+import {
+  AllowedComponentProps,
+  cloneVNode,
+  ComponentCustomProps,
+  isVNode,
+  Slots,
+  VNode,
+  VNodeProps,
+} from 'vue'
 
 /**
  * Gets only the valid children of a component,
@@ -23,4 +31,23 @@ export type ComponentWithProps<P> = {
         [key: string]: unknown
       }
   }
+}
+
+/**
+ * Returns a copy of only the valid default slot
+ *
+ * @param slots - the slots object from the component setup
+ * @param componentName component display name for thrown errors
+ * @returns A VNode clone of the default slot
+ */
+export function useUniqueChild(slots: Slots, componentName: string) {
+  const validChildren = getValidChildren(slots)
+  if (validChildren.length > 1) {
+    const errorMessage = `[${componentName}] : ${componentName} can only have one root element.`
+    console.error(errorMessage)
+    throw new SyntaxError(errorMessage)
+  }
+  const DefaultSlot = cloneVNode(validChildren[0])
+
+  return DefaultSlot
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -252,6 +252,7 @@ importers:
       '@zag-js/radio': 0.1.4
       '@zag-js/range-slider': 0.2.7
       '@zag-js/rating': 0.2.4
+      '@zag-js/select': 0.1.6
       '@zag-js/slider': 0.2.7
       '@zag-js/tags-input': 0.3.7
       '@zag-js/toast': 0.2.7
@@ -283,6 +284,7 @@ importers:
       '@zag-js/radio': 0.1.4
       '@zag-js/range-slider': 0.2.7
       '@zag-js/rating': 0.2.4
+      '@zag-js/select': 0.1.6
       '@zag-js/slider': 0.2.7
       '@zag-js/tags-input': 0.3.7
       '@zag-js/toast': 0.2.7
@@ -460,8 +462,8 @@ packages:
       react: ^17.0.2 || ^18.0.0
       react-dom: ^17.0.2 || ^18.0.0
     dependencies:
-      '@babel/core': 7.20.12
-      '@babel/plugin-transform-react-jsx': 7.19.0_@babel+core@7.20.12
+      '@babel/core': 7.20.5
+      '@babel/plugin-transform-react-jsx': 7.19.0_@babel+core@7.20.5
       '@types/react': 18.0.26
       '@types/react-dom': 18.0.10
       react: 18.2.0
@@ -499,9 +501,14 @@ packages:
     dependencies:
       '@babel/highlight': 7.18.6
 
+  /@babel/compat-data/7.20.1:
+    resolution: {integrity: sha512-EWZ4mE2diW3QALKvDMiXnbZpRvlj+nayZ112nK93SnhqOtpdsbVD4W+2tEoT3YNBAG9RBR0ISY758ZkOgsn6pQ==}
+    engines: {node: '>=6.9.0'}
+
   /@babel/compat-data/7.20.10:
     resolution: {integrity: sha512-sEnuDPpOJR/fcafHMjpcpGN5M2jbUGUHwmuWKM/YdPzeEDJg8bgmbcWQFUfE32MQjti1koACvoPVsDe8Uq+idg==}
     engines: {node: '>=6.9.0'}
+    dev: true
 
   /@babel/core/7.20.12:
     resolution: {integrity: sha512-XsMfHovsUYHFMdrIHkZphTN/2Hzzi78R08NuHfDBehym2VsPDL6Zn/JAD/JQdnRvbSsbQc4mVaU1m6JgtTEElg==}
@@ -524,6 +531,7 @@ packages:
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/core/7.20.5:
     resolution: {integrity: sha512-UdOWmk4pNWTm/4DlPUl/Pt4Gz4rcEMb7CY0Y3eJl5Yz1vI8ZJGmHWaVE55LoxRjdpx0z259GE9U5STA9atUinQ==}
@@ -531,28 +539,27 @@ packages:
     dependencies:
       '@ampproject/remapping': 2.2.0
       '@babel/code-frame': 7.18.6
-      '@babel/generator': 7.20.7
-      '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.20.5
-      '@babel/helper-module-transforms': 7.20.11
-      '@babel/helpers': 7.20.7
-      '@babel/parser': 7.20.7
-      '@babel/template': 7.20.7
-      '@babel/traverse': 7.20.12
-      '@babel/types': 7.20.7
+      '@babel/generator': 7.20.5
+      '@babel/helper-compilation-targets': 7.20.0_@babel+core@7.20.5
+      '@babel/helper-module-transforms': 7.20.2
+      '@babel/helpers': 7.20.6
+      '@babel/parser': 7.20.5
+      '@babel/template': 7.18.10
+      '@babel/traverse': 7.20.5
+      '@babel/types': 7.20.5
       convert-source-map: 1.9.0
       debug: 4.3.4
       gensync: 1.0.0-beta.2
-      json5: 2.2.3
+      json5: 2.2.1
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/generator/7.20.5:
     resolution: {integrity: sha512-jl7JY2Ykn9S0yj4DQP82sYvPU+T3g0HFcWTqDLqiuA9tGRNIj9VfbtXGAYTTkyNEnQk1jkMGOdYka8aG/lulCA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.20.5
       '@jridgewell/gen-mapping': 0.3.2
       jsesc: 2.5.2
 
@@ -563,12 +570,25 @@ packages:
       '@babel/types': 7.20.7
       '@jridgewell/gen-mapping': 0.3.2
       jsesc: 2.5.2
+    dev: true
 
   /@babel/helper-annotate-as-pure/7.18.6:
     resolution: {integrity: sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.20.5
+
+  /@babel/helper-compilation-targets/7.20.0_@babel+core@7.20.5:
+    resolution: {integrity: sha512-0jp//vDGp9e8hZzBc6N/KwA5ZK3Wsm/pfm4CrY7vzegkVxc65SgSn6wYOnwHe9Js9HRQ1YTCKLGPzDtaS3RoLQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/compat-data': 7.20.1
+      '@babel/core': 7.20.5
+      '@babel/helper-validator-option': 7.18.6
+      browserslist: 4.21.4
+      semver: 6.3.0
 
   /@babel/helper-compilation-targets/7.20.7_@babel+core@7.20.12:
     resolution: {integrity: sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==}
@@ -578,19 +598,6 @@ packages:
     dependencies:
       '@babel/compat-data': 7.20.10
       '@babel/core': 7.20.12
-      '@babel/helper-validator-option': 7.18.6
-      browserslist: 4.21.4
-      lru-cache: 5.1.1
-      semver: 6.3.0
-
-  /@babel/helper-compilation-targets/7.20.7_@babel+core@7.20.5:
-    resolution: {integrity: sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/compat-data': 7.20.10
-      '@babel/core': 7.20.5
       '@babel/helper-validator-option': 7.18.6
       browserslist: 4.21.4
       lru-cache: 5.1.1
@@ -643,7 +650,7 @@ packages:
     resolution: {integrity: sha512-kkH7sWzKPq0xt3H1n+ghb4xEMP8k0U7XV3kkB+ZGy69kDk2ySFW1qPi06sjKzFY3t1j6XbJSqr4mF9L7CYVyhg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.20.5
     dev: true
 
   /@babel/helper-module-imports/7.18.6:
@@ -664,6 +671,22 @@ packages:
       '@babel/template': 7.20.7
       '@babel/traverse': 7.20.12
       '@babel/types': 7.20.7
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/helper-module-transforms/7.20.2:
+    resolution: {integrity: sha512-zvBKyJXRbmK07XhMuujYoJ48B5yvvmM6+wcpv6Ivj4Yg6qO7NOZOSnvZN9CRl1zz1Z4cKf8YejmCMh8clOoOeA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-environment-visitor': 7.18.9
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/helper-simple-access': 7.20.2
+      '@babel/helper-split-export-declaration': 7.18.6
+      '@babel/helper-validator-identifier': 7.19.1
+      '@babel/template': 7.18.10
+      '@babel/traverse': 7.20.5
+      '@babel/types': 7.20.5
     transitivePeerDependencies:
       - supports-color
 
@@ -695,7 +718,7 @@ packages:
     resolution: {integrity: sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.20.5
 
   /@babel/helper-split-export-declaration/7.18.6:
     resolution: {integrity: sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==}
@@ -715,6 +738,16 @@ packages:
     resolution: {integrity: sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==}
     engines: {node: '>=6.9.0'}
 
+  /@babel/helpers/7.20.6:
+    resolution: {integrity: sha512-Pf/OjgfgFRW5bApskEz5pvidpim7tEDPlFtKcNRXWmfHGn9IEI2W2flqRQXTFb7gIPTyK++N6rVHuwKut4XK6w==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/template': 7.18.10
+      '@babel/traverse': 7.20.5
+      '@babel/types': 7.20.5
+    transitivePeerDependencies:
+      - supports-color
+
   /@babel/helpers/7.20.7:
     resolution: {integrity: sha512-PBPjs5BppzsGaxHQCDKnZ6Gd9s6xl8bBCluz3vEInLGRJmnZan4F6BYCeqtyXqkk4W5IlPmjK4JlOuZkpJ3xZA==}
     engines: {node: '>=6.9.0'}
@@ -724,6 +757,7 @@ packages:
       '@babel/types': 7.20.7
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/highlight/7.18.6:
     resolution: {integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==}
@@ -745,7 +779,7 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.20.5
 
   /@babel/parser/7.20.7:
     resolution: {integrity: sha512-T3Z9oHybU+0vZlY9CiDSJQTD5ZapcW18ZctFMi0MOAl/4BjFF4ul7NVSARLdbGO5vDqy9eQiGTV0LtKfvCYvcg==}
@@ -753,16 +787,7 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.20.7
-
-  /@babel/plugin-syntax-jsx/7.18.6_@babel+core@7.20.12:
-    resolution: {integrity: sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: false
+    dev: true
 
   /@babel/plugin-syntax-jsx/7.18.6_@babel+core@7.20.5:
     resolution: {integrity: sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==}
@@ -772,7 +797,6 @@ packages:
     dependencies:
       '@babel/core': 7.20.5
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-syntax-typescript/7.20.0_@babel+core@7.20.5:
     resolution: {integrity: sha512-rd9TkG+u1CExzS4SM1BlMEhMXwFLKVjOAFFCDx9PbX5ycJWDoWMcwdJH9RhkPu1dOgn5TrxLot/Gx6lWFuAUNQ==}
@@ -804,18 +828,18 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-react-jsx/7.19.0_@babel+core@7.20.12:
+  /@babel/plugin-transform-react-jsx/7.19.0_@babel+core@7.20.5:
     resolution: {integrity: sha512-UVEvX3tXie3Szm3emi1+G63jyw1w5IcMY0FSKM+CRnKRI5Mr1YbCNgsSTwoTwKphQEG9P+QqmuRFneJPZuHNhg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.5
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-module-imports': 7.18.6
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.20.12
-      '@babel/types': 7.20.7
+      '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.20.5
+      '@babel/types': 7.20.5
     dev: false
 
   /@babel/plugin-transform-typescript/7.20.2_@babel+core@7.20.5:
@@ -882,6 +906,7 @@ packages:
       '@babel/code-frame': 7.18.6
       '@babel/parser': 7.20.7
       '@babel/types': 7.20.7
+    dev: true
 
   /@babel/traverse/7.20.12:
     resolution: {integrity: sha512-MsIbFN0u+raeja38qboyF8TIT7K0BFzz/Yd/77ta4MsUsmP2RAnidIlwq7d5HFQrH/OZJecGV6B71C4zAgpoSQ==}
@@ -899,6 +924,7 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/traverse/7.20.5:
     resolution: {integrity: sha512-WM5ZNN3JITQIq9tFZaw1ojLU3WgWdtkxnhM1AegMS+PvHjkM5IXjmYEGY7yukz5XS4sJyEf2VzWjI8uAavhxBQ==}
@@ -932,6 +958,7 @@ packages:
       '@babel/helper-string-parser': 7.19.4
       '@babel/helper-validator-identifier': 7.19.1
       to-fast-properties: 2.0.0
+    dev: true
 
   /@bcoe/v8-coverage/0.2.3:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
@@ -2658,8 +2685,8 @@ packages:
   /@types/babel__core/7.1.20:
     resolution: {integrity: sha512-PVb6Bg2QuscZ30FvOU7z4guG6c926D9YRvOxEaelzndpMsvP+YM74Q/dAFASpg2l6+XLalxSGxcq/lrgYWZtyQ==}
     dependencies:
-      '@babel/parser': 7.20.7
-      '@babel/types': 7.20.7
+      '@babel/parser': 7.20.5
+      '@babel/types': 7.20.5
       '@types/babel__generator': 7.6.4
       '@types/babel__template': 7.4.1
       '@types/babel__traverse': 7.18.3
@@ -2668,20 +2695,20 @@ packages:
   /@types/babel__generator/7.6.4:
     resolution: {integrity: sha512-tFkciB9j2K755yrTALxD44McOrk+gfpIpvC3sxHjRawj6PfnQxrse4Clq5y/Rq+G3mrBurMax/lG8Qn2t9mSsg==}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.20.5
     dev: false
 
   /@types/babel__template/7.4.1:
     resolution: {integrity: sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==}
     dependencies:
-      '@babel/parser': 7.20.7
-      '@babel/types': 7.20.7
+      '@babel/parser': 7.20.5
+      '@babel/types': 7.20.5
     dev: false
 
   /@types/babel__traverse/7.18.3:
     resolution: {integrity: sha512-1kbcJ40lLB7MHsj39U4Sh1uTd2E7rLEa79kmDpI6cy+XiXsteB3POdQomoq4FxszMrO3ZYchkhYJw7A2862b3w==}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.20.5
     dev: false
 
   /@types/chai-subset/1.3.3:
@@ -3768,10 +3795,10 @@ packages:
       '@astrojs/markdown-remark': 1.1.3
       '@astrojs/telemetry': 1.0.1
       '@astrojs/webapi': 1.1.1
-      '@babel/core': 7.20.12
+      '@babel/core': 7.20.5
       '@babel/generator': 7.20.5
       '@babel/parser': 7.20.5
-      '@babel/plugin-transform-react-jsx': 7.19.0_@babel+core@7.20.12
+      '@babel/plugin-transform-react-jsx': 7.19.0_@babel+core@7.20.5
       '@babel/traverse': 7.20.5
       '@babel/types': 7.20.5
       '@proload/core': 0.3.3
@@ -3877,7 +3904,7 @@ packages:
       '@babel/core': 7.20.5
       '@babel/helper-module-imports': 7.16.0
       '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.20.5
-      '@babel/types': 7.20.7
+      '@babel/types': 7.20.5
       html-entities: 2.3.2
     dev: true
 
@@ -6769,10 +6796,16 @@ packages:
       minimist: 1.2.7
     dev: true
 
+  /json5/2.2.1:
+    resolution: {integrity: sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   /json5/2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+    dev: true
 
   /jsonc-parser/2.3.1:
     resolution: {integrity: sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==}
@@ -7047,6 +7080,7 @@ packages:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
     dependencies:
       yallist: 3.1.1
+    dev: true
 
   /lru-cache/6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
@@ -9243,9 +9277,9 @@ packages:
     peerDependencies:
       solid-js: ^1.3
     dependencies:
-      '@babel/generator': 7.20.7
+      '@babel/generator': 7.20.5
       '@babel/helper-module-imports': 7.18.6
-      '@babel/types': 7.20.7
+      '@babel/types': 7.20.5
       solid-js: 1.6.6
     dev: true
 
@@ -9734,7 +9768,7 @@ packages:
     dependencies:
       '@types/json5': 0.0.30
       '@types/resolve': 1.20.2
-      json5: 2.2.3
+      json5: 2.2.1
       resolve: 1.22.1
       strip-bom: 4.0.0
       type-fest: 0.13.1
@@ -10635,6 +10669,7 @@ packages:
 
   /yallist/3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+    dev: true
 
   /yallist/4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}


### PR DESCRIPTION
Adds the `Select` component to Ark for Vue.

This also adds the util composable `useUniqueChild` for any component parts that need to extract a copy of a valid default slot (includes `AccordionTrigger` and `SelectTrigger`)