### PR TITLE
feat(website): remove flash of unwanted light mode

### DIFF
--- a/website/src/app/layout.tsx
+++ b/website/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import { Navbar } from '@/components/navigation/navbar/Navbar'
+import { ColorModeScript } from '@/lib/ColorModeScript'
 import { css, cx } from '@/panda/css'
 import { Inter, Roboto_Mono } from '@next/font/google'
 import type { PropsWithChildren } from 'react'
@@ -13,6 +14,7 @@ const RootLayout = (props: PropsWithChildren) => {
   return (
     <html lang="en" className={cx(inter.variable, roboto.variable)}>
       <head>
+        <ColorModeScript />
         <script defer data-domain="ark-ui.com" src="https://plausible.io/js/script.js"></script>
       </head>
       <body>

--- a/website/src/lib/ColorModeScript.tsx
+++ b/website/src/lib/ColorModeScript.tsx
@@ -1,0 +1,14 @@
+import { colorModeLocalStorageKey } from '@/lib/useColorMode'
+
+/**
+ * This script is used to set the color mode on the initial page load.
+ * It runs before hydration and prevents a flash of maybe unwanted light mode.
+ */
+export const ColorModeScript = () => {
+  const colorModeScript =
+    // language=javascript
+    `if (JSON.parse(window.localStorage.getItem('${colorModeLocalStorageKey}')) === 'dark') {
+  document.documentElement.classList.add('dark')
+}`
+  return <script dangerouslySetInnerHTML={{ __html: colorModeScript }} />
+}

--- a/website/src/lib/useColorMode.ts
+++ b/website/src/lib/useColorMode.ts
@@ -2,8 +2,10 @@ import { useEffectOnce, useLocalStorage, useUpdateEffect } from 'usehooks-ts'
 
 type ColorMode = 'light' | 'dark'
 
+export const colorModeLocalStorageKey = 'ark-color-mode'
+
 export const useColorMode = () => {
-  const [colorMode, setColorMode] = useLocalStorage<ColorMode>('ark-color-mode', 'light')
+  const [colorMode, setColorMode] = useLocalStorage<ColorMode>(colorModeLocalStorageKey, 'light')
 
   const syncColorMode = () =>
     colorMode === 'dark'


### PR DESCRIPTION
Closes OSS-601

This PR adds an inline script which runs before hydration and adds the `dark` class to the html element if needed.
This makes the flash of unwanted light mode go poof.

To verify: open the vercel preview, switch to dark mode and reload the page.