### PR TITLE
feat: add render function to solid/Slider and solid/SliderOutput and react/RangeSlider

### DIFF
--- a/packages/react/src/range-slider/range-slider-output.tsx
+++ b/packages/react/src/range-slider/range-slider-output.tsx
@@ -10,7 +10,7 @@ import type { UseRangeSliderReturn } from './use-range-slider'
 export type RangeSliderOutputProps = Assign<
   HTMLArkProps<'output'>,
   {
-    children: ReactNode | ((api: UseRangeSliderReturn) => ReactNode)
+    children?: ((api: UseRangeSliderReturn) => ReactNode) | ReactNode
   }
 >
 

--- a/packages/react/src/range-slider/range-slider.tsx
+++ b/packages/react/src/range-slider/range-slider.tsx
@@ -11,7 +11,7 @@ import { useRangeSlider, UseRangeSliderProps, UseRangeSliderReturn } from './use
 export type RangeSliderProps = Assign<
   HTMLArkProps<'div'>,
   UseRangeSliderProps & {
-    children: ReactNode | ((api: UseRangeSliderReturn) => ReactNode)
+    children?: ((api: UseRangeSliderReturn) => ReactNode) | ReactNode
   }
 >
 

--- a/packages/solid/src/range-slider/range-slider-output.tsx
+++ b/packages/solid/src/range-slider/range-slider-output.tsx
@@ -9,7 +9,7 @@ import type { UseRangeSliderReturn } from './use-range-slider'
 export type RangeSliderOutputProps = Assign<
   HTMLArkProps<'output'>,
   {
-    children: JSX.Element | ((api: ReturnType<UseRangeSliderReturn>) => JSX.Element)
+    children?: JSX.Element | ((api: ReturnType<UseRangeSliderReturn>) => JSX.Element)
   }
 >
 

--- a/packages/solid/src/range-slider/range-slider.tsx
+++ b/packages/solid/src/range-slider/range-slider.tsx
@@ -13,7 +13,7 @@ import {
 export type RangeSliderProps = Assign<
   HTMLArkProps<'div'>,
   UseRangeSliderProps & {
-    children: JSX.Element | ((api: ReturnType<UseRangeSliderReturn>) => JSX.Element)
+    children?: JSX.Element | ((api: ReturnType<UseRangeSliderReturn>) => JSX.Element)
   }
 >
 

--- a/packages/solid/src/slider/slider-output.tsx
+++ b/packages/solid/src/slider/slider-output.tsx
@@ -8,7 +8,7 @@ import type { UseSliderReturn } from './use-slider'
 export type SliderOutputProps = Assign<
   HTMLArkProps<'output'>,
   {
-    children: JSX.Element | ((pages: ReturnType<UseSliderReturn>) => JSX.Element)
+    children?: ((pages: ReturnType<UseSliderReturn>) => JSX.Element) | JSX.Element
   }
 >
 

--- a/packages/solid/src/slider/slider.tsx
+++ b/packages/solid/src/slider/slider.tsx
@@ -9,7 +9,7 @@ import { useSlider, type UseSliderProps, type UseSliderReturn } from './use-slid
 export type SliderProps = Assign<
   HTMLArkProps<'div'>,
   UseSliderProps & {
-    children: JSX.Element | ((api: ReturnType<UseSliderReturn>) => JSX.Element)
+    children?: ((api: ReturnType<UseSliderReturn>) => JSX.Element) | JSX.Element
   }
 >
 


### PR DESCRIPTION
I missed the Range Slider for React in #401 - added in in this PR.