### PR TITLE
feat(vue): add custom `useId` composable

### DIFF
--- a/packages/vue/src/accordion/use-accordion.ts
+++ b/packages/vue/src/accordion/use-accordion.ts
@@ -1,6 +1,7 @@
 import { connect, machine, type Context as AccordionContext } from '@zag-js/accordion'
 import { normalizeProps, useMachine } from '@zag-js/vue'
-import { computed, getCurrentInstance, onMounted, reactive, watch } from 'vue'
+import { computed, onMounted, reactive, watch } from 'vue'
+import { useId } from '../utils'
 
 interface AccordionProps extends Omit<AccordionContext, 'id' | 'value'> {
   modelValue?: AccordionContext['value']
@@ -16,12 +17,11 @@ export const useAccordion = (props: UseAccordionProps) => {
   const reactiveProps = reactive(props)
   const { context, emit, defaultValue } = reactiveProps
   const reactiveContext = reactive(context)
-  const instance = getCurrentInstance()
   const [state, send] = useMachine(
     machine({
       ...reactiveContext,
       value: defaultValue,
-      id: instance?.uid.toString() as string,
+      id: useId().value,
       onChange: (details) => {
         emit('change', details.value)
         emit(

--- a/packages/vue/src/select/use-select.ts
+++ b/packages/vue/src/select/use-select.ts
@@ -1,6 +1,7 @@
 import { connect, Context as SelectContext, machine } from '@zag-js/select'
 import { normalizeProps, useMachine } from '@zag-js/vue'
-import { computed, getCurrentInstance, reactive, watch } from 'vue'
+import { computed, reactive, watch } from 'vue'
+import { useId } from '../utils'
 
 interface UseSelectContext extends Omit<SelectContext, 'id' | 'selectedOption'> {
   modelValue: SelectContext['selectedOption']
@@ -15,11 +16,10 @@ export const useSelect = (props: UseSelectProps) => {
   const reactiveProps = reactive(props)
   const { context, emit } = reactiveProps
   const reactiveContext = reactive(context)
-  const instance = getCurrentInstance()
   const [state, send] = useMachine(
     machine({
       ...reactiveContext,
-      id: instance?.uid.toString() as string,
+      id: useId().value,
       selectedOption: context.modelValue,
       onChange: (details) => {
         emit('change', { ...details })

--- a/packages/vue/src/tabs/use-tabs.ts
+++ b/packages/vue/src/tabs/use-tabs.ts
@@ -1,6 +1,7 @@
 import { connect, Context as TabsContext, machine } from '@zag-js/tabs'
 import { normalizeProps, useMachine } from '@zag-js/vue'
-import { computed, getCurrentInstance, reactive } from 'vue'
+import { computed, reactive } from 'vue'
+import { useId } from '../utils'
 
 export type UseTabsProps = {
   context: Omit<TabsContext, 'id' | 'value'>
@@ -12,11 +13,10 @@ export const useTabs = (props: UseTabsProps) => {
   const reactiveProps = reactive(props)
   const { context, defaultValue, emit } = reactiveProps
   const reactiveContext = reactive(context)
-  const instance = getCurrentInstance()
   const [state, send] = useMachine(
     machine({
       ...reactiveContext,
-      id: instance?.uid.toString() as string,
+      id: useId().value,
       value: defaultValue,
       onChange(details) {
         emit('change', details)

--- a/packages/vue/src/utils.ts
+++ b/packages/vue/src/utils.ts
@@ -2,7 +2,11 @@ import {
   AllowedComponentProps,
   cloneVNode,
   ComponentCustomProps,
+  computed,
   isVNode,
+  onBeforeMount,
+  onMounted,
+  ref,
   Slots,
   VNode,
   VNodeProps,
@@ -50,4 +54,41 @@ export function useUniqueChild(slots: Slots, componentName: string) {
   const DefaultSlot = cloneVNode(validChildren[0])
 
   return DefaultSlot
+}
+
+/**
+ * Credit for useId(): @codebender828 & https://github.com/reach/reach-ui/blob/develop/packages/auto-id/src/index.tsx
+ *
+ */
+
+let serverHandoffComplete = false
+let _id = 1
+const genId = () => ++_id
+
+/**
+ * Generates a unique id
+ *
+ * @param id external ID provided by consumer/user.
+ * @param prefix prefix to append before the id
+ */
+export const useId = (id?: string, prefix?: string) => {
+  const initialId = id || (serverHandoffComplete ? genId() : _id)
+  const uid = ref(initialId)
+
+  onBeforeMount(() => {
+    if (serverHandoffComplete === false) {
+      serverHandoffComplete = true
+    }
+  })
+
+  onMounted(() => {
+    if (uid.value === null) {
+      uid.value = genId()
+    }
+  })
+
+  return computed(() => {
+    const __id__ = uid.value !== null ? uid.value.toString() : undefined
+    return (prefix ? `${prefix}-${__id__}` : __id__) as string
+  })
 }


### PR DESCRIPTION
Adds a composable for Vue to generate unique id values to be used in each component machine's `id` prop for the given instance.

Credit to @codebender828 who originally built this in the [chakra-vue-next repo](https://github.com/chakra-ui/chakra-ui-vue-next/blob/develop/packages/vue-composables/src/use-id.ts)

This PR only adds `useId()` and not `useIds()` from that repo. The former was needed in place of Vue's `getCurrentInstance()` for SSR and the type casting of the uid type.