### PR TITLE
fix(website): center playground without clipping sliders

### DIFF
--- a/website/src/components/docs/Playground.tsx
+++ b/website/src/components/docs/Playground.tsx
@@ -62,7 +62,9 @@ const Canvas = (props: PropsWithChildren) => (
     overflow="auto"
     p={{ base: '4', md: '6' }}
   >
-    <Box m="auto">{props.children}</Box>
+    <Box m="auto" flex="1" display="flex" justifyContent="center" alignItems="center">
+      {props.children}
+    </Box>
   </Box>
 )
 


### PR DESCRIPTION
Before: https://ark-ui.com/docs/react/components/slider
<img width="711" alt="image" src="https://user-images.githubusercontent.com/16899513/215277865-78df9987-b87c-4f71-8ef8-735ce90c24fd.png">


Now: https://ark-website-git-fix-center-playground-chakra-ui.vercel.app/docs/react/components/slider

<img width="703" alt="image" src="https://user-images.githubusercontent.com/16899513/215277881-40dcfacd-42ab-447a-9ce4-9cc4a0631369.png">

