### PR TITLE
refactor(vue): simplify props reactivity in composables

### DIFF
--- a/packages/vue/src/accordion/accordion.test.tsx
+++ b/packages/vue/src/accordion/accordion.test.tsx
@@ -356,8 +356,7 @@ describe('Accordion', () => {
     expect(button).toHaveAttribute('aria-expanded', 'true')
   })
 
-  // TODO https://linear.app/chakra/issue/OSS-675/fixvue-accordiong-changes-v-model-value-on-external-trigger
-  it.skip('changes v-model value on external trigger', async () => {
+  it('changes v-model value on external trigger', async () => {
     render(VModelAccordion)
 
     const externalTrigger = screen.getByText('Trigger')

--- a/packages/vue/src/accordion/use-accordion.ts
+++ b/packages/vue/src/accordion/use-accordion.ts
@@ -14,9 +14,9 @@ export interface UseAccordionProps {
 }
 
 export const useAccordion = (props: UseAccordionProps) => {
-  const reactiveProps = reactive(props)
-  const { context, emit, defaultValue } = reactiveProps
-  const reactiveContext = reactive(context)
+  const emit = props.emit
+  const defaultValue = props.defaultValue
+  const reactiveContext = reactive(props.context)
   const [state, send] = useMachine(
     machine({
       ...reactiveContext,
@@ -39,7 +39,7 @@ export const useAccordion = (props: UseAccordionProps) => {
   })
 
   watch(
-    () => context.modelValue,
+    () => reactiveContext.modelValue,
     (value, prevValue) => {
       if (value === prevValue) return
       api.value.setValue(value as string | string[])

--- a/packages/vue/src/checkbox/use-checkbox.ts
+++ b/packages/vue/src/checkbox/use-checkbox.ts
@@ -13,14 +13,13 @@ export interface UseCheckboxProps {
 }
 
 export const useCheckbox = (props: UseCheckboxProps) => {
-  const reactiveProps = reactive(props)
-  const { context, emit } = reactiveProps
-  const reactiveContext = reactive(context)
+  const emit = props.emit
+  const reactiveContext = reactive(props.context)
   const [state, send] = useMachine(
     machine({
       ...reactiveContext,
       id: useId().value,
-      defaultChecked: context.modelValue,
+      defaultChecked: props.context.modelValue,
       onChange(details) {
         emit('change', details.checked)
         emit('update:modelValue', details.checked)

--- a/packages/vue/src/combobox/use-combobox.ts
+++ b/packages/vue/src/combobox/use-combobox.ts
@@ -14,9 +14,9 @@ export type UseComboboxProps = {
 }
 
 export const useCombobox = (props: UseComboboxProps) => {
-  const reactiveProps = reactive(props)
-  const { context, emit, defaultValue } = reactiveProps
-  const reactiveContext = reactive(context)
+  const emit = props.emit
+  const defaultValue = props.defaultValue
+  const reactiveContext = reactive(props.context)
 
   const [state, send] = useMachine(
     machine({
@@ -47,7 +47,7 @@ export const useCombobox = (props: UseComboboxProps) => {
   })
 
   watch(
-    () => context.modelValue,
+    () => reactiveContext.modelValue,
     (value, prevValue) => {
       if (value === prevValue) return
       if (value === undefined) return

--- a/packages/vue/src/dialog/use-dialog.ts
+++ b/packages/vue/src/dialog/use-dialog.ts
@@ -9,9 +9,8 @@ export type UseDialogProps = {
 }
 
 export const useDialog = (props: UseDialogProps) => {
-  const reactiveProps = reactive(props)
-  const { context, emit } = reactiveProps
-  const reactiveContext = reactive(context)
+  const emit = props.emit
+  const reactiveContext = reactive(props.context)
 
   const [state, send] = useMachine(
     machine({

--- a/packages/vue/src/editable/use-editable.ts
+++ b/packages/vue/src/editable/use-editable.ts
@@ -14,14 +14,13 @@ export type UseEditableProps = {
 }
 
 export const useEditable = (props: UseEditableProps) => {
-  const reactiveProps = reactive(props)
-  const { context, emit } = reactiveProps
-  const reactiveContext = reactive(context)
+  const emit = props.emit
+  const reactiveContext = reactive(props.context)
   const [state, send] = useMachine(
     machine({
       ...reactiveContext,
       id: useId().value,
-      value: reactiveContext.modelValue ?? reactiveContext.value,
+      value: props.context.modelValue ?? props.context.value,
       onCancel(details) {
         emit('cancel', details)
       },
@@ -41,7 +40,7 @@ export const useEditable = (props: UseEditableProps) => {
   const api = computed(() => connect(state.value, send, normalizeProps))
 
   watch(
-    () => context.modelValue,
+    () => reactiveContext.modelValue,
     (val, prevVal) => {
       if (val == undefined) return
 

--- a/packages/vue/src/hover-card/use-hover-card.ts
+++ b/packages/vue/src/hover-card/use-hover-card.ts
@@ -11,9 +11,8 @@ export type UseHoverCardProps = {
 }
 
 export const useHoverCard = (props: UseHoverCardProps) => {
-  const reactiveProps = reactive(props)
-  const { context, emit } = reactiveProps
-  const reactiveContext = reactive(context)
+  const emit = props.emit
+  const reactiveContext = reactive(props.context)
   const [state, send] = useMachine(
     machine({
       ...reactiveContext,

--- a/packages/vue/src/number-input/number-input.stories.vue
+++ b/packages/vue/src/number-input/number-input.stories.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { computed, ref } from 'vue'
+import { ref } from 'vue'
 import {
   NumberInput,
   NumberInputControl,

--- a/packages/vue/src/number-input/use-number-input.tsx
+++ b/packages/vue/src/number-input/use-number-input.tsx
@@ -13,14 +13,13 @@ export type UseNumberInputProps = {
 }
 
 export const useNumberInput = (props: UseNumberInputProps) => {
-  const reactiveProps = reactive(props)
-  const { context, emit } = reactiveProps
-  const reactiveContext = reactive(context)
+  const emit = props.emit
+  const reactiveContext = reactive(props.context)
   const [state, send] = useMachine(
     machine({
       ...reactiveContext,
       id: useId().value,
-      value: reactiveContext.modelValue ?? reactiveContext.value,
+      value: props.context.modelValue ?? props.context.value,
       onBlur(details) {
         emit('blur', details)
       },

--- a/packages/vue/src/pin-input/use-pin-input.ts
+++ b/packages/vue/src/pin-input/use-pin-input.ts
@@ -13,15 +13,14 @@ export type UsePinInputProps = {
 }
 
 export const usePinInput = (props: UsePinInputProps) => {
-  const reactiveProps = reactive(props)
-  const { context, emit } = reactiveProps
-  const reactiveContext = reactive(context)
+  const emit = props.emit
+  const reactiveContext = reactive(props.context)
 
   const [state, send] = useMachine(
     machine({
       ...reactiveContext,
       id: useId().value,
-      value: reactiveContext.modelValue ?? reactiveContext.value,
+      value: props.context.modelValue ?? props.context.value,
       onChange(details) {
         emit('change', details)
         emit('update:modelValue', Array.from(details.value))

--- a/packages/vue/src/pressable/use-pressable.tsx
+++ b/packages/vue/src/pressable/use-pressable.tsx
@@ -14,9 +14,8 @@ export type UsePressableProps = {
 }
 
 export const usePressable = (props: UsePressableProps) => {
-  const reactiveProps = reactive(props)
-  const { context, emit } = reactiveProps
-  const reactiveContext = reactive(context)
+  const emit = props.emit
+  const reactiveContext = reactive(props.context)
 
   const [state, send] = useMachine(
     machine({

--- a/packages/vue/src/rating-group/use-rating-group.ts
+++ b/packages/vue/src/rating-group/use-rating-group.ts
@@ -13,14 +13,13 @@ export type UseRatingGroupProps = {
 }
 
 export const useRatingGroup = (props: UseRatingGroupProps) => {
-  const reactiveProps = reactive(props)
-  const { context, emit } = reactiveProps
-  const reactiveContext = reactive(context)
+  const emit = props.emit
+  const reactiveContext = reactive(props.context)
   const [state, send] = useMachine(
     machine({
       ...reactiveContext,
       id: useId().value,
-      value: context.modelValue,
+      value: props.context.modelValue,
       onChange(details) {
         emit('change', details.value)
         emit('update:modelValue', details.value)

--- a/packages/vue/src/select/use-select.ts
+++ b/packages/vue/src/select/use-select.ts
@@ -13,14 +13,13 @@ export interface UseSelectProps {
 }
 
 export const useSelect = (props: UseSelectProps) => {
-  const reactiveProps = reactive(props)
-  const { context, emit } = reactiveProps
-  const reactiveContext = reactive(context)
+  const emit = props.emit
+  const reactiveContext = reactive(props.context)
   const [state, send] = useMachine(
     machine({
       ...reactiveContext,
       id: useId().value,
-      selectedOption: context.modelValue,
+      selectedOption: props.context.modelValue,
       onChange: (details) => {
         emit('change', { ...details })
         emit('update:modelValue', { ...details })
@@ -38,7 +37,7 @@ export const useSelect = (props: UseSelectProps) => {
   )
 
   watch(
-    () => context.modelValue,
+    () => reactiveContext.modelValue,
     (value, prevValue) => {
       if (value === prevValue) return
       api.value.setSelectedOption(value as { label: string; value: string })

--- a/packages/vue/src/splitter/use-splitter.ts
+++ b/packages/vue/src/splitter/use-splitter.ts
@@ -10,9 +10,8 @@ export type UseSplitterProps = {
 }
 
 export const useSplitter = (props: UseSplitterProps) => {
-  const reactiveProps = reactive(props)
-  const { context, emit } = reactiveProps
-  const reactiveContext = reactive(context)
+  const emit = props.emit
+  const reactiveContext = reactive(props.context)
 
   const [state, send] = useMachine(
     machine({

--- a/packages/vue/src/tabs/use-tabs.ts
+++ b/packages/vue/src/tabs/use-tabs.ts
@@ -10,9 +10,9 @@ export type UseTabsProps = {
 }
 
 export const useTabs = (props: UseTabsProps) => {
-  const reactiveProps = reactive(props)
-  const { context, defaultValue, emit } = reactiveProps
-  const reactiveContext = reactive(context)
+  const emit = props.emit
+  const defaultValue = props.defaultValue
+  const reactiveContext = reactive(props.context)
   const [state, send] = useMachine(
     machine({
       ...reactiveContext,

--- a/packages/vue/src/tooltip/use-tooltip.ts
+++ b/packages/vue/src/tooltip/use-tooltip.ts
@@ -11,9 +11,8 @@ export type UseTooltipProps = {
 }
 
 export const useTooltip = (props: UseTooltipProps) => {
-  const reactiveProps = reactive(props)
-  const { context, emit } = reactiveProps
-  const reactiveContext = reactive(context)
+  const emit = props.emit
+  const reactiveContext = reactive(props.context)
   const [state, send] = useMachine(
     machine({
       ...reactiveContext,


### PR DESCRIPTION
Simplify the variable declarations in all the component composables for Vue, matching the pattern implemented in the [Popover composable](https://github.com/chakra-ui/ark/blob/84dab8250988e26662052a59141c9407933dbb11/packages/vue/src/popover/use-popover.ts#L22-L23), where there is only the instance of a reactive context.

This PR also adds back in a test for Accordion that is now fixed.