### PR TITLE
fix(vue/combobox): add `emits` prop

### DIFF
--- a/packages/vue/src/combobox/combobox.tsx
+++ b/packages/vue/src/combobox/combobox.tsx
@@ -95,6 +95,7 @@ const VueComboboxProps = {
 export const Combobox: ComponentWithProps<ComboboxProps> = defineComponent({
   name: 'Combobox',
   props: VueComboboxProps,
+  emits: ['close', 'open', 'highlight', 'input-change', 'update:modelValue', 'select'],
   setup(props, { slots, attrs, emit, expose }) {
     const comboboxProps = computed<UseComboboxProps>(() => ({
       context: props,


### PR DESCRIPTION
Adds the missing `emits` prop of values to the `Combobox` component so the custom handlers can be exposed properly.