### PR TITLE
docs(react): fix typo

### DIFF
--- a/packages/react/docs/getting-started.mdx
+++ b/packages/react/docs/getting-started.mdx
@@ -91,4 +91,4 @@ a fully accessible Slider component that:
 - Supports RTL languages.
 
 > The components are low-level and atomic by design to allow you wrap them into
-> your own high-leverl API that suits your team's conventions.
+> your own high-level API that suits your team's conventions.


### PR DESCRIPTION
thanks for maintaining awesome library
there is some type so I fixed it up