### PR TITLE
test(react): write test code for tooltip interactive prop

### DIFF
--- a/packages/react/src/tooltip/tooltip.test.tsx
+++ b/packages/react/src/tooltip/tooltip.test.tsx
@@ -70,4 +70,14 @@ describe('Tooltip', () => {
     await user.keyboard('[Escape]')
     expect(screen.getByRole('tooltip')).toBeInTheDocument()
   })
+
+  it('should have pointer-events none style if interactive is set to false', async () => {
+    render(<Component interactive={false} />)
+
+    const tooltipTrigger = screen.getByText('hover me')
+    await user.hover(tooltipTrigger)
+
+    const tooltipContent = screen.getByText('content')
+    expect(tooltipContent).toHaveStyle({ 'pointer-events': 'none' })
+  })
 })


### PR DESCRIPTION
Thank you for providing a good library.

I wrote a test code to verify that the `interactive` prop of the `tooltip` is working properly.

FYI : I thought the default value of the interactive option was false, but it was true. I hope this part is also specified in docs.😃