### PR TITLE
test(react/editable): write test code for verifying activationMode=`focus`

### DIFF
--- a/packages/react/src/editable/editable.test.tsx
+++ b/packages/react/src/editable/editable.test.tsx
@@ -13,7 +13,7 @@ import {
 } from './'
 
 const ComponentUnderTest = (props: Omit<EditableProps, 'children'>) => (
-  <Editable activationMode="dblclick" placeholder="Placeholder" {...props}>
+  <Editable activationMode={props.activationMode} placeholder="Placeholder" {...props}>
     {({ isEditing }) => (
       <>
         <EditableArea>
@@ -49,6 +49,14 @@ describe('Editable', () => {
   it('should be possible to dbl click the placeholder to enter a value', async () => {
     render(<ComponentUnderTest />)
     await user.dblClick(screen.getByText('Placeholder'))
+    await user.type(screen.getByLabelText('editable input'), 'React')
+
+    expect(await screen.findByText('React')).toBeInTheDocument()
+  })
+  
+  it('should be possible to click the placeholder to enter a value', async () => {
+    render(<ComponentUnderTest activationMode="focus" />)
+    await user.click(screen.getByText('Placeholder'))
     await user.type(screen.getByLabelText('editable input'), 'React')
 
     expect(await screen.findByText('React')).toBeInTheDocument()


### PR DESCRIPTION
I thought `focus` was the same as hover, but it wasn't.
`Focus` realized through the test code that it means the same as `click`.

I wrote a test code because I thought it would be good to have a test code for `focus` so that other people wouldn't get confused