### PR TITLE
fix(docs): website button shadow

### DIFF
--- a/website/src/theme/recipes/select.ts
+++ b/website/src/theme/recipes/select.ts
@@ -72,7 +72,7 @@ export const select = defineRecipe({
               base: 'colors.orange.400',
               _dark: 'colors.orange.400',
             },
-            boxShadow: '0 0 0 1px var(--shadow)',
+            boxShadow: 'inset 0 0 0 1px var(--shadow)',
             borderColor: 'accent.default',
           },
         },


### PR DESCRIPTION
## as is
<img width="503" alt="스크린샷 2023-05-06 오후 5 50 44" src="https://user-images.githubusercontent.com/49177223/236613996-e7bc4983-1b2e-4034-9b44-b95f27c46b8f.png">

## to be

<img width="527" alt="스크린샷 2023-05-06 오후 5 50 38" src="https://user-images.githubusercontent.com/49177223/236613995-f5d01a9b-f588-4fef-981b-9fb260bad56e.png">

When a focus event occurs in the part where the framework of docs is selected, 
a box shadow occurs, and we found a problem of cutting. 

I thought it was showing the border thickly using box-shadow, 
and I gave the box-shadow inward to solve the problem without leaving this UI. 

As a result, the size of the select does not change and the border does not appear to be cut.


[Problem Occurrence Link
](https://ark-ui.com/docs/react/overview/introduction)
