### PR TITLE
feat(docs): SidebarExternalLinks hover css event add

### DIFF
--- a/website/src/components/navigation/sidebar/SidebarExternalLinks.tsx
+++ b/website/src/components/navigation/sidebar/SidebarExternalLinks.tsx
@@ -46,6 +46,9 @@ export const SidebarExternalLinks = () => (
           aria-current={link.isActive ? 'page' : false}
           href={link.href}
           target="_blank"
+          _hover={{
+            color: 'fg.default',
+          }}
         >
           <HStack gap="3">
             <Box


### PR DESCRIPTION
## as is

![hover 수정 전](https://user-images.githubusercontent.com/49177223/236631206-d896d3d6-2d8b-4205-b5e3-33d9e7f5e0a6.gif)

## to be
![수정 후 hover](https://user-images.githubusercontent.com/49177223/236631200-39ef8a87-7a49-4ed0-8cff-b39dc8cd2bf1.gif)

---
When I hovered Siderbar's external link in the existing docs, I saw that there was no action other than the cursor changing, so I thought it would be bad for UX. 

So we changed the color of the link by adding css, which changes the color of the link when the external link of the Siderbar is hovered, to improve the UX.

At the time of hover, the color was designated as the same color as when the sub-side bar items were hovered.