### PR TITLE
refactor: solid as-child props

### DIFF
--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -40,7 +40,6 @@
     "storydocs": "ts-node ../../scripts/generate-stories.ts"
   },
   "dependencies": {
-    "@polymorphic-factory/solid": "0.3.1",
     "@zag-js/accordion": "0.7.0",
     "@zag-js/anatomy": "0.1.4",
     "@zag-js/checkbox": "0.7.0",

--- a/packages/solid/src/factory.tsx
+++ b/packages/solid/src/factory.tsx
@@ -1,19 +1,75 @@
-/**
- * All html and svg elements for ark components.
- * This is mostly for `ark.<element>` syntax.
- */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import {
-  polymorphicFactory,
-  type HTMLPolymorphicComponents,
-  type HTMLPolymorphicProps,
-} from '@polymorphic-factory/solid'
-import { type JSX } from 'solid-js'
+  children,
+  createEffect,
+  splitProps,
+  type Component,
+  type ComponentProps,
+  type JSX,
+  type ParentProps,
+} from 'solid-js'
+import { Dynamic } from 'solid-js/web'
+import { spread } from './spread'
+import { ssrSpread } from './ssr-spread'
 
-export type HTMLArkComponents = HTMLPolymorphicComponents
+type ElementType = keyof JSX.IntrinsicElements | Component<any>
 
-export type HTMLArkProps<T extends keyof JSX.IntrinsicElements> = HTMLPolymorphicProps<T>
+export type AsChildProps = {
+  asChild?: boolean
+}
 
-/**
- * The ark factory serves as an object of JSX elements to render React components which accept the `as` prop
- */
-export const ark = polymorphicFactory()
+type JsxElements = {
+  [E in keyof JSX.IntrinsicElements]: AsChildForwardRefComponent<E>
+}
+
+export type AsChildForwardRefComponent<E extends ElementType> = ParentProps<
+  AsChildComponentProps<E>
+>
+
+export type AsChildComponentProps<E extends ElementType> = ComponentProps<E> & AsChildProps
+
+export type HTMLArkProps<T extends ElementType> = AsChildComponentProps<T>
+
+function withAsChild(Component: ElementType) {
+  return function jsx(props: ParentProps<AsChildProps>) {
+    const [localProps, restProps] = splitProps(props, ['asChild', 'children'])
+
+    if (!localProps.asChild) {
+      return (
+        <Dynamic component={Component} {...restProps}>
+          {localProps.children}
+        </Dynamic>
+      )
+    }
+
+    const getChildren = children(() => ssrSpread(localProps.children, restProps))
+
+    createEffect(() => {
+      const children = getChildren()
+      if (children instanceof HTMLElement) {
+        spread(children, restProps)
+      }
+    })
+
+    return getChildren
+  }
+}
+
+export function jsxFactory() {
+  const cache = new Map()
+
+  return new Proxy(withAsChild, {
+    apply(target, thisArg, argArray) {
+      return withAsChild(argArray[0])
+    },
+    get(_, element) {
+      const asElement = element as ElementType
+      if (!cache.has(asElement)) {
+        cache.set(asElement, withAsChild(asElement))
+      }
+      return cache.get(asElement)
+    },
+  }) as unknown as JsxElements
+}
+
+export const ark = jsxFactory()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -273,9 +273,6 @@ importers:
 
   packages/solid:
     dependencies:
-      '@polymorphic-factory/solid':
-        specifier: 0.3.1
-        version: 0.3.1(solid-js@1.7.5)
       '@zag-js/accordion':
         specifier: 0.7.0
         version: 0.7.0
@@ -4054,14 +4051,6 @@ packages:
       react: '>=16.8 || >=17 || >18'
     dependencies:
       react: 18.2.0
-    dev: false
-
-  /@polymorphic-factory/solid@0.3.1(solid-js@1.7.5):
-    resolution: {integrity: sha512-TvYSj8d0lZrB3IfqJyv1DgOMFTollSXUGHEh0vSEneP1BHHYbsRTvq9BNrZbxX8gJyLZLkGsm6WgqnGe4HZ6qQ==}
-    peerDependencies:
-      solid-js: '>=1.6.0'
-    dependencies:
-      solid-js: 1.7.5
     dev: false
 
   /@polymorphic-factory/vue@0.2.0(vue@3.2.47):


### PR DESCRIPTION
This PR refactors the solid polymorphic factory to now use the `asChild` props instead