### PR TITLE
feat(docs): website main navigation hover event

### DIFF
--- a/website/src/components/navigation/navbar/Navbar.tsx
+++ b/website/src/components/navigation/navbar/Navbar.tsx
@@ -28,14 +28,30 @@ export const Navbar = () => (
         <HStack gap="8">
           <Link
             href="/docs/react/overview/introduction"
-            className={css({ textStyle: 'sm', fontWeight: 'medium', color: 'fg.emphasized' })}
+            className={css({
+              textStyle: 'sm',
+              fontWeight: 'medium',
+              color: 'fg.emphasized',
+              _hover: {
+                color: 'fg.default',
+                fontWeight: 'semibold',
+              },
+            })}
           >
             Docs
           </Link>
           <Link
             href="https://ark-ui.canny.io/"
             target="_blank"
-            className={css({ textStyle: 'sm', fontWeight: 'medium', color: 'fg.emphasized' })}
+            className={css({
+              textStyle: 'sm',
+              fontWeight: 'medium',
+              color: 'fg.emphasized',
+              _hover: {
+                color: 'fg.default',
+                fontWeight: 'semibold',
+              },
+            })}
           >
             Roadmap
           </Link>


### PR DESCRIPTION
## as is
![수정 전전](https://user-images.githubusercontent.com/49177223/236665293-9e74e95e-2a0b-4eb6-8583-38bb7ee67d7a.gif)

## to be
![수정 후 메인](https://user-images.githubusercontent.com/49177223/236665182-ecdb3a70-60b2-4550-8893-1641658fd72b.gif)

--- 

When I hovered main navigation in existing docs, I saw that there was no action other than the cursor changing, so I thought it would be bad for UX. 

So I changed the color of the link by adding css, which changes the color of the link when I hovered the navigation link, and improved the UX.