### PR TITLE
fix(docs): TableOfContent scrollspy doesn't work

### DIFF
--- a/website/src/components/docs/TableOfContent.tsx
+++ b/website/src/components/docs/TableOfContent.tsx
@@ -11,8 +11,7 @@ interface Props {
 
 export const TableOfContent = (props: Props) => {
   const { entries } = props
-  const activeId = useScrollSpy(props.entries.map((item) => '#' + item.slug))
-
+  const activeId = useScrollSpy(entries.map((item) => item.slug))
   return (
     <Box
       display={{ base: 'none', xl: 'flex' }}
@@ -31,6 +30,7 @@ export const TableOfContent = (props: Props) => {
           {entries.map((item, id) => (
             <Link
               key={id}
+              id={item.slug}
               href={`#${item.slug}`}
               variant="toc"
               aria-current={(activeId ?? entries[0].slug) === item.slug ? 'page' : false}

--- a/website/src/lib/useScrollSpy.ts
+++ b/website/src/lib/useScrollSpy.ts
@@ -5,7 +5,7 @@ export const useScrollSpy = (selectors: string[]) => {
   const observer = useRef<IntersectionObserver | null>(null)
 
   useEffect(() => {
-    const elements = selectors.map((selector) => document.querySelector(CSS.escape(selector)))
+    const elements = selectors.map((selector) => document.querySelector(`#${CSS.escape(selector)}`))
     observer.current = new IntersectionObserver(
       (entries) => {
         entries.forEach((entry) => {


### PR DESCRIPTION
There is a problem that when a page is scrolling, the appearance of the `Link` component inside the `TableOfContent` component does not change automatically.

This is because the `useScrollSpy` hook is not working properly. Instead of getting `"#" + item.slug` injected, we got `item.slug` injected and added `"#"` inside the hook.

Also, I assigned `item.slug` as the ID of Link, so that the `querySelector` works properly.

### asis
![ark_asis](https://user-images.githubusercontent.com/82137004/236673397-1958aeff-4b64-4f79-b155-a0bbb9bd3fc7.gif)


### tobe
![ark_tobe](https://user-images.githubusercontent.com/82137004/236673417-3e93d285-dcb7-424a-9cd6-7a9056b92cd1.gif)

