### PR TITLE
fix(docs): main page showcase carousel button bg remove

### DIFF
--- a/website/src/components/marketing/Showcase.tsx
+++ b/website/src/components/marketing/Showcase.tsx
@@ -89,10 +89,18 @@ export const Showcase = () => {
                 </TabList>
               </Tabs>
               <HStack gap="3" justify="space-between" flex="1">
-                <CarouselPrevSlideTrigger>
+                <CarouselPrevSlideTrigger
+                  style={{
+                    backgroundColor: 'transparent',
+                  }}
+                >
                   <IconButton icon={<FiArrowLeft />} aria-label="Previous component" />
                 </CarouselPrevSlideTrigger>
-                <CarouselNextSlideTrigger>
+                <CarouselNextSlideTrigger
+                  style={{
+                    backgroundColor: 'transparent',
+                  }}
+                >
                   <IconButton icon={<FiArrowRight />} aria-label="Next component" />
                 </CarouselNextSlideTrigger>
               </HStack>

--- a/website/src/theme/recipes/select.ts
+++ b/website/src/theme/recipes/select.ts
@@ -72,7 +72,7 @@ export const select = defineRecipe({
               base: 'colors.orange.400',
               _dark: 'colors.orange.400',
             },
-            boxShadow: '0 0 0 1px var(--shadow)',
+            boxShadow: 'inset 0 0 0 1px var(--shadow)',
             borderColor: 'accent.default',
           },
         },


### PR DESCRIPTION
## as is
![수정 전 메인 캐로셀 버튼](https://user-images.githubusercontent.com/49177223/236756052-17a8770c-327c-41ea-aefd-6d9a3aa24b9c.gif)

## to be
![수정 후 캐로셀 버튼](https://user-images.githubusercontent.com/49177223/236756059-2bbb5026-0876-4dc9-9d5c-c0c12c8f202c.gif)

---
I found and removed the gray background on the carousel button of the show case on the main page.