### PR TITLE
[vue/carousel] Fix Prev/Next buttons render

### DIFF
--- a/packages/vue/src/carousel/carousel-next-slide-trigger.tsx
+++ b/packages/vue/src/carousel/carousel-next-slide-trigger.tsx
@@ -10,8 +10,8 @@ export const CarouselNextSlideTrigger = defineComponent({
   setup(_, { slots, attrs }) {
     const api = useCarouselContext()
     const mergedProps = computed(() => mergeProps(api.value.nextTriggerProps, attrs))
-    return () => {
-      return () => <ark.button {...mergedProps.value}>{slots.default?.()}</ark.button>
-    }
+    return () => (
+      <ark.button {...mergedProps.value}>{slots.default?.()}</ark.button>
+    )
   },
 })

--- a/packages/vue/src/carousel/carousel-prev-slide-trigger.tsx
+++ b/packages/vue/src/carousel/carousel-prev-slide-trigger.tsx
@@ -9,8 +9,8 @@ export const CarouselPrevSlideTrigger = defineComponent({
   setup(_, { slots, attrs }) {
     const api = useCarouselContext()
     const mergedProps = computed(() => mergeProps(api.value.nextTriggerProps, attrs))
-    return () => {
-      return () => <ark.button {...mergedProps.value}>{slots.default?.()}</ark.button>
-    }
+    return () => (
+      <ark.button {...mergedProps.value}>{slots.default?.()}</ark.button>
+    )
   },
 })

--- a/packages/vue/src/carousel/carousel-prev-slide-trigger.tsx
+++ b/packages/vue/src/carousel/carousel-prev-slide-trigger.tsx
@@ -8,7 +8,7 @@ export const CarouselPrevSlideTrigger = defineComponent({
   name: 'CarouselPrevSlideTrigger',
   setup(_, { slots, attrs }) {
     const api = useCarouselContext()
-    const mergedProps = computed(() => mergeProps(api.value.nextTriggerProps, attrs))
+    const mergedProps = computed(() => mergeProps(api.value.prevTriggerProps, attrs))
     return () => (
       <ark.button {...mergedProps.value}>{slots.default?.()}</ark.button>
     )

--- a/packages/vue/src/carousel/carousel.stories.vue
+++ b/packages/vue/src/carousel/carousel.stories.vue
@@ -21,10 +21,10 @@ const images = [
 <template>
   <Carousel>
     <CarouselPrevSlideTrigger>
-      <button>Prev</button>
+      Prev
     </CarouselPrevSlideTrigger>
     <CarouselNextSlideTrigger>
-      <button>Next</button>
+      Next
     </CarouselNextSlideTrigger>
     <CarouselViewport>
       <CarouselSlideGroup>

--- a/packages/vue/src/carousel/carousel.test.tsx
+++ b/packages/vue/src/carousel/carousel.test.tsx
@@ -1,0 +1,21 @@
+import user from '@testing-library/user-event'
+import { render } from '@testing-library/vue'
+import {
+  Carousel,
+  CarouselNextSlideTrigger,
+  CarouselPrevSlideTrigger,
+  CarouselSlide,
+  CarouselSlideGroup,
+  CarouselViewport,
+} from '.'
+import BasicComponentStory from './carousel.stories.vue'
+
+
+describe('Carousel', () => {
+  it('should render', async () => {
+    const { getByText } = render(BasicComponentStory)
+
+    expect(getByText('Prev')).toBeInTheDocument()
+    expect(getByText('Next')).toBeInTheDocument()
+  })
+})

--- a/packages/vue/src/carousel/carousel.test.tsx
+++ b/packages/vue/src/carousel/carousel.test.tsx
@@ -15,7 +15,18 @@ describe('Carousel', () => {
   it('should render', async () => {
     const { getByText } = render(BasicComponentStory)
 
-    expect(getByText('Prev')).toBeInTheDocument()
-    expect(getByText('Next')).toBeInTheDocument()
+    const prevTrigger = getByText('Prev')
+    expect(prevTrigger).toBeInTheDocument()
+    expect(prevTrigger).toHaveAttribute('data-part', 'previous-trigger')
+    expect(prevTrigger).toHaveAttribute('type', 'button')
+    expect(prevTrigger).toHaveAttribute('aria-label', 'Previous Slide')
+
+    const nextTrigger = getByText('Next')
+    expect(nextTrigger).toBeInTheDocument()
+    expect(nextTrigger).toBeInTheDocument()
+    expect(nextTrigger).toHaveAttribute('data-part', 'next-trigger')
+    expect(nextTrigger).toHaveAttribute('type', 'button')
+    expect(nextTrigger).toHaveAttribute('aria-label', 'Next Slide')
+
   })
 })


### PR DESCRIPTION
As previously reported, Prev/Next buttons were not being rendered correctly. In the meantime, found out that the merged attributes were also incorrectly bound — next trigger props were being merged to prev trigger. Added basic tests coverage (that's how I found out about the attributes issues).

Closes https://github.com/chakra-ui/ark/issues/1051

