### PR TITLE
fix(docs): add missing ref implementation on vue pagination docs

### DIFF
--- a/packages/vue/src/pagination/docs/pagination.mdx
+++ b/packages/vue/src/pagination/docs/pagination.mdx
@@ -46,7 +46,7 @@ import {
 const paginationRef = ref()
 </script>
 <template>
-  <Pagination :count="5000" :page-size="10" :sibling-count="2">
+  <Pagination ref="paginationRef" :count="5000" :page-size="10" :sibling-count="2">
     <PaginationList>
       <PaginationListItem>
         <PaginationPrevPageTrigger>


### PR DESCRIPTION
this commit add ref attribute on vue pagination example