### PR TITLE
fix(vue): add emit update:open on dialog component

### DIFF
--- a/packages/vue/src/dialog/dialog.tsx
+++ b/packages/vue/src/dialog/dialog.tsx
@@ -55,7 +55,7 @@ const VueDialogProps = createVueProps<UseDialogProps>({
 export const Dialog: ComponentWithProps<Partial<UseDialogProps>> = defineComponent({
   name: 'Dialog',
   props: VueDialogProps,
-  emits: ['close', 'outside-click', 'esc'],
+  emits: ['close', 'outside-click', 'esc','update:open'],
   setup(props, { slots, emit }) {
     const api = useDialog(emit, props as UseDialogProps)
 


### PR DESCRIPTION
fix missing `update:open` emits on dialog component. related issue https://github.com/chakra-ui/ark/issues/1035