### PR TITLE
refactor(vue/dialog): Add missing onOpen events

### DIFF
--- a/packages/vue/src/dialog/use-dialog.ts
+++ b/packages/vue/src/dialog/use-dialog.ts
@@ -18,6 +18,10 @@ export const useDialog = <T extends ExtractPropTypes<DialogProps>>(
       ...reactiveContext,
       id: reactiveContext.id || useId().value,
       getRootNode,
+      onOpen() {
+        emit('open')
+        emit('update:open', true)
+      },
       onClose() {
         emit('close')
         emit('update:open', false)


### PR DESCRIPTION
Adds the missing `onOpen` events which were originally added in #898 and then removed in #918 