### PR TITLE
docs: fix typo in vue select component

### DIFF
--- a/packages/vue/src/select/docs/select.mdx
+++ b/packages/vue/src/select/docs/select.mdx
@@ -110,7 +110,7 @@ import {
 ### Selecting option on tab key
 
 While navigating the options, pressing the <kbd>Tab</kbd> key blurs the select
-and does nothing. In some cases, you might what the <kbd>Tab</kbd> key to select
+and does nothing. In some cases, you might want the <kbd>Tab</kbd> key to select
 the currently highlighted option. To enable this behaviour, set `selectOnTab` to
 `true`.
 


### PR DESCRIPTION
Fixed a little one word typo found in the docs for the vue select component