### PR TITLE
fix(vue): [Carousel] CarouselControl wasn't returning a component and…

### DIFF
--- a/packages/vue/CHANGELOG.md
+++ b/packages/vue/CHANGELOG.md
@@ -6,6 +6,10 @@ description: All notable changes to this project will be documented in this file
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a bug in the `CarouselControl` component where it was returning a function instead of the expected component. Use the `CarouselControl` component in the `Vue` documentation just like in `React`.
+
 ## [0.6.0] - 2023-08-06
 
 ### Added

--- a/packages/vue/src/carousel/carousel-control.tsx
+++ b/packages/vue/src/carousel/carousel-control.tsx
@@ -15,8 +15,6 @@ export const CarouselControl = defineComponent({
       mergeProps(api.value.nextTriggerProps, attrs, carouselAnatomy.build().control.attrs),
     )
 
-    return () => {
-      return () => <ark.div {...mergedProps.value}>{slots.default?.()}</ark.div>
-    }
+    return () => <ark.div {...mergedProps.value}>{slots.default?.()}</ark.div>
   },
 })

--- a/packages/vue/src/carousel/carousel.stories.vue
+++ b/packages/vue/src/carousel/carousel.stories.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import {
   Carousel,
+  CarouselControl,
   CarouselNextSlideTrigger,
   CarouselPrevSlideTrigger,
   CarouselSlide,
@@ -22,12 +23,10 @@ const images = [
 </script>
 <template>
   <Carousel>
-    <CarouselPrevSlideTrigger>
-      Prev
-    </CarouselPrevSlideTrigger>
-    <CarouselNextSlideTrigger>
-      Next
-    </CarouselNextSlideTrigger>
+    <CarouselControl>
+      <CarouselPrevSlideTrigger>Prev</CarouselPrevSlideTrigger>
+      <CarouselNextSlideTrigger>Next</CarouselNextSlideTrigger>
+    </CarouselControl>
     <CarouselViewport>
       <CarouselSlideGroup>
         <CarouselSlide v-for="(image, idx) in images" :key="idx" :index="idx" data-testid="slide">

--- a/packages/vue/src/carousel/docs/carousel.mdx
+++ b/packages/vue/src/carousel/docs/carousel.mdx
@@ -24,17 +24,18 @@ import {
 
 Here's an example of how to use the Carousel component with a set of images:
 
-```html
+```vue
 <script setup>
 import {
   Carousel,
+  CarouselControl,
   CarouselNextSlideTrigger,
   CarouselPrevSlideTrigger,
   CarouselSlide,
   CarouselSlideGroup,
   CarouselViewport,
   CarouselIndicator,
-  CarouselIndicatorProps,
+  CarouselIndicatorGroup,
 } from '@ark-ui/vue'
 
 const images = [
@@ -48,12 +49,14 @@ const images = [
 
 <template>
   <Carousel>
-    <CarouselPrevSlideTrigger>
-      <button>Prev</button>
-    </CarouselPrevSlideTrigger>
-    <CarouselNextSlideTrigger>
-      <button>Next</button>
-    </CarouselNextSlideTrigger>
+    <CarouselControl>
+      <CarouselPrevSlideTrigger>
+        <button>Prev</button>
+      </CarouselPrevSlideTrigger>
+      <CarouselNextSlideTrigger>
+        <button>Next</button>
+      </CarouselNextSlideTrigger>
+    </CarouselControl>
     <CarouselIndicatorGroup>
       <CarouselIndicator v-for="(_, idx) in images" :key="idx" :index="idx" />
     </CarouselIndicatorGroup>
@@ -78,7 +81,7 @@ To create a controlled Carousel component, you can manage the state of the
 carousel using the `index` prop and update it when the `@slide-change` event
 handler is called:
 
-```tsx
+```vue
 <script>
 import { ref } from 'vue'
 import { Carousel } from '@ark-ui/vue'
@@ -102,7 +105,7 @@ You can customize the Carousel component by setting various props such as
 `align`, `loop`, `slidesPerView`, and `spacing`. Here's an example of a
 customized Carousel:
 
-```tsx
+```vue
 <script>
 import { Carousel } from '@ark-ui/vue'
 </script>


### PR DESCRIPTION
Hello, 

While using the `Carousel` component in Vue, I came across a minor issue in the documentation and found a bug within the `CarouselControl` component. The bug can be observed in the following code snippet:

```tsx
return () => {
  return () => [Component]
}
```

Additionally, I noticed a couple of minor things in the documentation for the Carousel component:
 - The MDX syntax used for `Vue` code examples was set as `html` or `tsx`, which caused some issues with syntax highlighting.
 - The documentation did not provide sufficient information about using the `CarouselControl` component in `Vue` compared to the details available for `React` documentation.
 
 Let me know if you have question or comments :D 
 
Thanks a lot for this library.
