### PR TITLE
[vue][Slider] fix: hiddenInputProps not being spread correctly rendering hidden input to the DOM

### DIFF
--- a/packages/vue/src/slider/slider-thumb.tsx
+++ b/packages/vue/src/slider/slider-thumb.tsx
@@ -10,17 +10,12 @@ export const SliderThumb: ComponentWithProps<SliderThumbProps> = defineComponent
   setup(_, { slots, attrs }) {
     const api = useSliderContext()
 
-    const hiddenInputProps = computed(() => ({
-      ...api.value.hiddenInputProps,
-      modelValue: api.value.value,
-    }))
-
     return () => (
       <>
         <ark.div {...api.value.thumbProps} {...attrs}>
           {slots.default?.()}
         </ark.div>
-        <input {...hiddenInputProps} />
+        <input {...api.value.hiddenInputProps} />
       </>
     )
   },

--- a/packages/vue/src/slider/stories/basic.stories.vue
+++ b/packages/vue/src/slider/stories/basic.stories.vue
@@ -24,7 +24,7 @@ const sliderValue = ref<SliderProps['modelValue']>(30)
       <SliderTrack>
         <SliderRange />
       </SliderTrack>
-      <SliderThumb />
+      <SliderThumb data-test-id="slider-thumb"/>
     </SliderControl>
     <SliderMarkerGroup>
       <SliderMarker :value="-30">-30</SliderMarker>

--- a/packages/vue/src/slider/tests/slider.test.tsx
+++ b/packages/vue/src/slider/tests/slider.test.tsx
@@ -83,4 +83,10 @@ describe('Slider', () => {
 
     expect(getByTestId('slider-value')).toHaveTextContent('22')
   })
+
+  it('renders SliderThumb hidden input correctly', async () => {
+    const { container } = render(BasicComponentStory)
+    await nextTick()
+    expect(container.querySelector('input[hidden]')).toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
## TL;DR
- the computed property `hiddenProps` needs to be spread by `.value`
- the computed property was actually redundant because the `modelValue` is not bindable to a `input` element, so I've removed it and used `api.value.hiddenInputProps` directly in template.
- added basic spec (because docs demos are written in react, this bug was visually caught)

## Details

- I only caught this because I have a "smoke-snapshot" test on my Ark-ui component wrappers, and my CI broke when upgrading to `ark/vue@0.7.0`
- [Reproduction example](https://stackblitz.com/edit/vitejs-vite-r3j91c?file=src%2FApp.vue&terminal=dev)


<img width="863" alt="Screenshot 2023-09-04 at 12 40 29" src="https://github.com/chakra-ui/ark/assets/5116633/311e1368-6160-48df-b59d-6cc810e12c4a">

<img width="2318" alt="Screenshot 2023-09-04 at 12 45 20" src="https://github.com/chakra-ui/ark/assets/5116633/34166507-fb52-4abf-9dd6-747fcc3ab8dd">


