### PR TITLE
chore(react): `<Editable />` flushsync onChange function

### DIFF
--- a/packages/frameworks/react/CHANGELOG.md
+++ b/packages/frameworks/react/CHANGELOG.md
@@ -10,6 +10,10 @@ description: All notable changes to this project will be documented in this file
 
 - Add memoization to `Select` and `Combobox` item collection to improve performance.
 
+### Fixed
+
+- Resolved an issue when controlling the `Editable` component.
+
 ### Removed
 
 - Removed anatomy exports. These exports are now available in `@ark-ui/anatomy`.

--- a/packages/frameworks/react/src/editable/use-editable.ts
+++ b/packages/frameworks/react/src/editable/use-editable.ts
@@ -12,17 +12,17 @@ export type UseEditableReturn = editable.Api
 
 export const useEditable = (props: UseEditableProps): UseEditableReturn => {
   const getRootNode = useEnvironmentContext()
-  const initialContext = {
+  const initialContext: editable.Context = {
     id: useId(),
     getRootNode,
     ...props,
     value: props.defaultValue,
   }
 
-  const context = {
+  const context: editable.Context = {
     ...initialContext,
     value: props.value,
-    onChange: useEvent(props.onValueChange, { sync: true }),
+    onValueChange: useEvent(props.onValueChange, { sync: true }),
   }
 
   const [state, send] = useMachine(editable.machine(initialContext), { context })

--- a/packages/frameworks/react/src/editable/use-editable.ts
+++ b/packages/frameworks/react/src/editable/use-editable.ts
@@ -3,6 +3,7 @@ import { normalizeProps, useMachine } from '@zag-js/react'
 import { useId } from 'react'
 import { useEnvironmentContext } from '../environment'
 import { type Optional } from '../types'
+import { useEvent } from '../use-event'
 
 export interface UseEditableProps extends Optional<editable.Context, 'id'> {
   defaultValue?: editable.Context['value']
@@ -21,6 +22,7 @@ export const useEditable = (props: UseEditableProps): UseEditableReturn => {
   const context = {
     ...initialContext,
     value: props.value,
+    onChange: useEvent(props.onValueChange, { sync: true }),
   }
 
   const [state, send] = useMachine(editable.machine(initialContext), { context })


### PR DESCRIPTION
There is currently an issue in `@zag-js/editable` 0.21.0 where passing an object with a state value of `useState` and using the `<Editable />` component in controlled form does not control the value as desired.

You can see a demo below.
(Currently, the logic is set up so that the value is fixed at 10000, but you can see that any value above 10000 will be input).

- [demo](https://stackblitz.com/edit/stackblitz-starters-m4rdhb?file=src%2FApp.tsx,src%2Fstyle.css)

To fix this, modify the code for `zag` and `ark`.

In `zag`, we'll add logic to synchronize if the externally input value is different from the internal value.
- [zag PR](https://github.com/chakra-ui/zag/pull/883)

In `ark`, we apply `flushSync` to `onChange`.

If there is a better form, please let me know.

cc. @malangcat 