### PR TITLE
docs: add anatomies

### DIFF
--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -15,6 +15,7 @@
     "@astrojs/sitemap": "3.0.0",
     "@fontsource-variable/fira-code": "5.0.8",
     "@fontsource-variable/inter": "5.0.8",
+    "@zag-js/anatomy-icons": "0.22.0",
     "astro": "3.1.1",
     "lucide-react": "0.279.0",
     "react": "18.2.0",

--- a/packages/website/src/components/anatomy-image.tsx
+++ b/packages/website/src/components/anatomy-image.tsx
@@ -3,7 +3,7 @@ import { Box } from 'styled-system/jsx'
 
 import { allComponents as Anatomies, createGradient } from '@zag-js/anatomy-icons'
 
-export const AnatomyImage = ({ id }: { id: string }) => {
+export const AnatomyImage = ({ id }: { id: keyof typeof Anatomies }) => {
   const Anatomy = Anatomies[id]
 
   return (

--- a/packages/website/src/components/anatomy-image.tsx
+++ b/packages/website/src/components/anatomy-image.tsx
@@ -1,0 +1,20 @@
+import { css } from 'styled-system/css'
+import { Box } from 'styled-system/jsx'
+
+import { allComponents as Anatomies, createGradient } from '@zag-js/anatomy-icons'
+
+export const AnatomyImage = ({ id }: { id: string }) => {
+  const Anatomy = Anatomies[id]
+
+  return (
+    <Box my="8" style={{ background: createGradient('red').value }}>
+      <Anatomy
+        accentColor="red"
+        className={css({
+          maxW: '100%',
+          h: 'auto',
+        })}
+      />
+    </Box>
+  )
+}

--- a/packages/website/src/components/anatomy.astro
+++ b/packages/website/src/components/anatomy.astro
@@ -1,8 +1,9 @@
 ---
+import { allComponents as Anatomies } from '@zag-js/anatomy-icons';
 import { AnatomyImage } from './anatomy-image'
 
 interface Props {
-  id: string
+  id: keyof typeof Anatomies
 }
 const { id } = Astro.props
 ---

--- a/packages/website/src/components/anatomy.astro
+++ b/packages/website/src/components/anatomy.astro
@@ -1,0 +1,10 @@
+---
+import { AnatomyImage } from './anatomy-image'
+
+interface Props {
+  id: string
+}
+const { id } = Astro.props
+---
+
+<AnatomyImage id={id} client:load />

--- a/packages/website/src/content/components/accordion.mdx
+++ b/packages/website/src/content/components/accordion.mdx
@@ -16,16 +16,6 @@ we name its parts.
 
 <Anatomy id="accordion" />
 
-On a high level, the accordion consists of:
-
-- **Root**: The root container for the accordion
-- **Item**: The container for each accordion item
-
-For each accordion item, it consists of:
-
-- **Trigger**: The trigger for the accordion item
-- **Content**: The content area that is revealed when the trigger is clicked
-
 ## Usage
 
 Let's start with a basic Accordion component:

--- a/packages/website/src/content/components/accordion.mdx
+++ b/packages/website/src/content/components/accordion.mdx
@@ -4,7 +4,27 @@ title: Accordion
 description: A collapsible component that displays content in a vertical stack.
 ---
 
+import Anatomy from '~/components/anatomy.astro'
 import Story from '~/components/story.astro'
+
+## Anatomy
+
+To set up the accordion correctly, you'll need to understand its anatomy and how
+we name its parts.
+
+> Each part includes a `data-part` attribute to help identify them in the DOM.
+
+<Anatomy id="accordion" />
+
+On a high level, the accordion consists of:
+
+- **Root**: The root container for the accordion
+- **Item**: The container for each accordion item
+
+For each accordion item, it consists of:
+
+- **Trigger**: The trigger for the accordion item
+- **Content**: The content area that is revealed when the trigger is clicked
 
 ## Usage
 

--- a/packages/website/src/content/components/avatar.mdx
+++ b/packages/website/src/content/components/avatar.mdx
@@ -5,7 +5,24 @@ description:
   A graphical representation of the user, often used in profile sections.
 ---
 
+import Anatomy from '~/components/anatomy.astro'
 import Story from '~/components/story.astro'
+
+## Anatomy
+
+To set up the avatar correctly, you'll need to understand its anatomy and how we
+name its parts.
+
+> Each part includes a `data-part` attribute to help identify them in the DOM.
+
+<Anatomy id="avatar" />
+
+On a high level, the avatar consists of:
+
+- **Root**: The root container for the avatar
+- **Fallback**: The fallback element to display when the image fails to load or
+  is not provided
+- **Image**: The image element for the avatar
 
 ## Getting Started
 

--- a/packages/website/src/content/components/avatar.mdx
+++ b/packages/website/src/content/components/avatar.mdx
@@ -17,13 +17,6 @@ name its parts.
 
 <Anatomy id="avatar" />
 
-On a high level, the avatar consists of:
-
-- **Root**: The root container for the avatar
-- **Fallback**: The fallback element to display when the image fails to load or
-  is not provided
-- **Image**: The image element for the avatar
-
 ## Getting Started
 
 <Story id="Basic" />

--- a/packages/website/src/content/components/checkbox.mdx
+++ b/packages/website/src/content/components/checkbox.mdx
@@ -6,7 +6,25 @@ description:
   unchecked states. It supports basic, controlled, and indeterminate states.
 ---
 
+import Anatomy from '~/components/anatomy.astro'
 import Story from '~/components/story.astro'
+
+## Anatomy
+
+To set up the checkbox correctly, you'll need to understand its anatomy and how
+we name its parts.
+
+> Each part includes a `data-part` attribute to help identify them in the DOM.
+
+<Anatomy id="checkbox" />
+
+On a high level, the checkbox consists of:
+
+- **Root**: The root container for the checkbox
+- **Label**: The label that gives the user information on the checkbox
+- **Control**: The element that visually represents the checkbox.
+- **Hidden Input**: The hidden input that holds the value of the checkbox. Used
+  within forms.
 
 ## Usage
 

--- a/packages/website/src/content/components/checkbox.mdx
+++ b/packages/website/src/content/components/checkbox.mdx
@@ -18,14 +18,6 @@ we name its parts.
 
 <Anatomy id="checkbox" />
 
-On a high level, the checkbox consists of:
-
-- **Root**: The root container for the checkbox
-- **Label**: The label that gives the user information on the checkbox
-- **Control**: The element that visually represents the checkbox.
-- **Hidden Input**: The hidden input that holds the value of the checkbox. Used
-  within forms.
-
 ## Usage
 
 To get started, import the necessary components from the package:

--- a/packages/website/src/content/components/combobox.mdx
+++ b/packages/website/src/content/components/combobox.mdx
@@ -17,19 +17,6 @@ we name its parts.
 
 <Anatomy id="combobox" />
 
-On a high level, the combobox consists of:
-
-- **Root**: The root container for the combobox
-- **Label**: The label that gives the user information on the combobox
-- **Positioner**: The element that positions the combobox dynamically.
-- **Content**: The element that contains the options.
-- **Trigger**: The element that toggles the combobox menu.
-- **Control**: The element that contains the input and trigger.
-- **Input**: The element that receives user input.
-- **Item**: The combobox item or option element.
-- **ItemIndicator**: The element that indicates the selected item.
-- **ItemGroup**: The element used to group related items.
-
 ## Basic Usage
 
 Straightforward implementation using a simple array to populate the dropdown.

--- a/packages/website/src/content/components/combobox.mdx
+++ b/packages/website/src/content/components/combobox.mdx
@@ -5,7 +5,30 @@ description:
   An intelligent input box with a dropdown for suggesting possible options.
 ---
 
+import Anatomy from '~/components/anatomy.astro'
 import Story from '~/components/story.astro'
+
+## Anatomy
+
+To set up the combobox correctly, you'll need to understand its anatomy and how
+we name its parts.
+
+> Each part includes a `data-part` attribute to help identify them in the DOM.
+
+<Anatomy id="combobox" />
+
+On a high level, the combobox consists of:
+
+- **Root**: The root container for the combobox
+- **Label**: The label that gives the user information on the combobox
+- **Positioner**: The element that positions the combobox dynamically.
+- **Content**: The element that contains the options.
+- **Trigger**: The element that toggles the combobox menu.
+- **Control**: The element that contains the input and trigger.
+- **Input**: The element that receives user input.
+- **Item**: The combobox item or option element.
+- **ItemIndicator**: The element that indicates the selected item.
+- **ItemGroup**: The element used to group related items.
 
 ## Basic Usage
 

--- a/packages/website/src/content/components/dialog.mdx
+++ b/packages/website/src/content/components/dialog.mdx
@@ -7,7 +7,31 @@ description:
   essential elements such as triggers, content, and close triggers.
 ---
 
+import Anatomy from '~/components/anatomy.astro'
 import Story from '~/components/story.astro'
+
+## Anatomy
+
+To use the dialog component correctly, you'll need to understand its anatomy and
+how we name its parts.
+
+> Each part includes a `data-part` attribute to help identify them in the DOM.
+
+<Anatomy id="dialog" />
+
+The dialog pattern consists of:
+
+- **Trigger**: The button that triggers the dialog
+- **Backdrop**: The dim background overlay that's usually behind the dialog
+  element.
+- **Container**: The container for the dialog's content.
+- **Content**: Used to house the content of the dialog.
+
+The dialog's content consists of:
+
+- **Title**: The title of the dialog.
+- **Description**: The description that supports the title.
+- **Close Button**: The button used to close the dialog.
 
 ## Usage
 

--- a/packages/website/src/content/components/dialog.mdx
+++ b/packages/website/src/content/components/dialog.mdx
@@ -19,20 +19,6 @@ how we name its parts.
 
 <Anatomy id="dialog" />
 
-The dialog pattern consists of:
-
-- **Trigger**: The button that triggers the dialog
-- **Backdrop**: The dim background overlay that's usually behind the dialog
-  element.
-- **Container**: The container for the dialog's content.
-- **Content**: Used to house the content of the dialog.
-
-The dialog's content consists of:
-
-- **Title**: The title of the dialog.
-- **Description**: The description that supports the title.
-- **Close Button**: The button used to close the dialog.
-
 ## Usage
 
 Begin by importing the necessary components from the package:

--- a/packages/website/src/content/components/editable.mdx
+++ b/packages/website/src/content/components/editable.mdx
@@ -7,7 +7,31 @@ description:
   interaction is triggered (click, focus, or double-click).
 ---
 
+import Anatomy from '~/components/anatomy.astro'
 import Story from '~/components/story.astro'
+
+## Anatomy
+
+To set up the editable correctly, you'll need to understand its anatomy and how
+we name its parts.
+
+> Each part includes a `data-part` attribute to help identify them in the DOM.
+
+<Anatomy id="editable" />
+
+On a high level, the editable consists of:
+
+- **Root**: The root container for the editable.
+- **Area**: The container that wraps the preview and input.
+- **Preview**: The readonly element that displays the value.
+- **Input**: The input used to edit the value.
+
+If you're going to use custom controls to trigger edit, save and cancel, you'll
+need these parts:
+
+- **Edit Button**: The button to trigger the edit mode.
+- **Submit Button**: The button to submit or save the value.
+- **Cancel Button**: The button to cancel and revert to previous value.
 
 ## Import
 

--- a/packages/website/src/content/components/editable.mdx
+++ b/packages/website/src/content/components/editable.mdx
@@ -19,20 +19,6 @@ we name its parts.
 
 <Anatomy id="editable" />
 
-On a high level, the editable consists of:
-
-- **Root**: The root container for the editable.
-- **Area**: The container that wraps the preview and input.
-- **Preview**: The readonly element that displays the value.
-- **Input**: The input used to edit the value.
-
-If you're going to use custom controls to trigger edit, save and cancel, you'll
-need these parts:
-
-- **Edit Button**: The button to trigger the edit mode.
-- **Submit Button**: The button to submit or save the value.
-- **Cancel Button**: The button to cancel and revert to previous value.
-
 ## Import
 
 ```ts

--- a/packages/website/src/content/components/hover-card.mdx
+++ b/packages/website/src/content/components/hover-card.mdx
@@ -21,12 +21,6 @@ how we name its parts.
 
 <Anatomy id="hover-card" />
 
-On a high level, the hover card consists of:
-
-- **Trigger**: The trigger for the Hover Card - Usually a link.
-- **Positioner**: The element that positions the hover card.
-- **Content**: The container for the hover card's content.
-
 ## Usage
 
 To get started, import the necessary components from the package:

--- a/packages/website/src/content/components/hover-card.mdx
+++ b/packages/website/src/content/components/hover-card.mdx
@@ -9,7 +9,23 @@ description:
   experience.
 ---
 
+import Anatomy from '~/components/anatomy.astro'
 import Story from '~/components/story.astro'
+
+## Anatomy
+
+To set up the hover card correctly, you'll need to understand its anatomy and
+how we name its parts.
+
+> Each part includes a `data-part` attribute to help identify them in the DOM.
+
+<Anatomy id="hover-card" />
+
+On a high level, the hover card consists of:
+
+- **Trigger**: The trigger for the Hover Card - Usually a link.
+- **Positioner**: The element that positions the hover card.
+- **Content**: The container for the hover card's content.
 
 ## Usage
 

--- a/packages/website/src/content/components/menu.mdx
+++ b/packages/website/src/content/components/menu.mdx
@@ -18,19 +18,6 @@ name its parts.
 
 <Anatomy id="menu" />
 
-On a high level, the menu consists of:
-
-- **Trigger**: The element that toggles the menu.
-- **Positioner**: The element that positions the menu dynamically.
-- **Content**: The element that contains the menu items and groups.
-- **Item**: The menu item used to trigger an action.
-
-The optional parts include:
-
-- **Option Item**: The menu item that acts as a radio or checkbox.
-- **Context Trigger**: The trigger for the menu item.
-- **Separator**: The element that is used to visually separate menu items.
-
 ## Import
 
 ```ts

--- a/packages/website/src/content/components/menu.mdx
+++ b/packages/website/src/content/components/menu.mdx
@@ -6,7 +6,30 @@ description:
   actions or options that a user can choose.
 ---
 
+import Anatomy from '~/components/anatomy.astro'
 import Story from '~/components/story.astro'
+
+## Anatomy
+
+To set up the menu correctly, you'll need to understand its anatomy and how we
+name its parts.
+
+> Each part includes a `data-part` attribute to help identify them in the DOM.
+
+<Anatomy id="menu" />
+
+On a high level, the menu consists of:
+
+- **Trigger**: The element that toggles the menu.
+- **Positioner**: The element that positions the menu dynamically.
+- **Content**: The element that contains the menu items and groups.
+- **Item**: The menu item used to trigger an action.
+
+The optional parts include:
+
+- **Option Item**: The menu item that acts as a radio or checkbox.
+- **Context Trigger**: The trigger for the menu item.
+- **Separator**: The element that is used to visually separate menu items.
 
 ## Import
 

--- a/packages/website/src/content/components/number-input.mdx
+++ b/packages/website/src/content/components/number-input.mdx
@@ -18,15 +18,6 @@ how we name its parts.
 
 <Anatomy id="number-input" />
 
-On a high level, the number input consists of:
-
-- **Root**: The root container for the number input.
-- **Input**: The editable field to change the value.
-- **Label**: The accessible label for the input.
-- **Increment Trigger**: The spin button to increment the value.
-- **Decrement Trigger**: The spin button to decrement the value.
-- **Scrubber**: The element that allows you to change the value by scrubbing.
-
 ## Import
 
 ```ts

--- a/packages/website/src/content/components/number-input.mdx
+++ b/packages/website/src/content/components/number-input.mdx
@@ -6,7 +6,26 @@ description:
   numeric values using the keyboard or pointer.
 ---
 
+import Anatomy from '~/components/anatomy.astro'
 import Story from '~/components/story.astro'
+
+## Anatomy
+
+To set up the number input correctly, you'll need to understand its anatomy and
+how we name its parts.
+
+> Each part includes a `data-part` attribute to help identify them in the DOM.
+
+<Anatomy id="number-input" />
+
+On a high level, the number input consists of:
+
+- **Root**: The root container for the number input.
+- **Input**: The editable field to change the value.
+- **Label**: The accessible label for the input.
+- **Increment Trigger**: The spin button to increment the value.
+- **Decrement Trigger**: The spin button to decrement the value.
+- **Scrubber**: The element that allows you to change the value by scrubbing.
 
 ## Import
 

--- a/packages/website/src/content/components/pagination.mdx
+++ b/packages/website/src/content/components/pagination.mdx
@@ -7,7 +7,25 @@ description:
   your application.
 ---
 
+import Anatomy from '~/components/anatomy.astro'
 import Story from '~/components/story.astro'
+
+## Anatomy
+
+To set up the pagination correctly, you'll need to understand its anatomy and
+how we name its parts.
+
+> Each part includes a `data-part` attribute to help identify them in the DOM.
+
+<Anatomy id="pagination" />
+
+On a high level, the pagination consists of:
+
+- **Root**: The root container for the pagination
+- **Item**: Each pagination item
+- **Ellipsis**: Ellipsis shown when some items are hidden
+- **Previous Button**: Used to go to previous page in pagination
+- **Next Button**: Used to go to next page in pagination
 
 ## Basic Usage
 

--- a/packages/website/src/content/components/pagination.mdx
+++ b/packages/website/src/content/components/pagination.mdx
@@ -19,14 +19,6 @@ how we name its parts.
 
 <Anatomy id="pagination" />
 
-On a high level, the pagination consists of:
-
-- **Root**: The root container for the pagination
-- **Item**: Each pagination item
-- **Ellipsis**: Ellipsis shown when some items are hidden
-- **Previous Button**: Used to go to previous page in pagination
-- **Next Button**: Used to go to next page in pagination
-
 ## Basic Usage
 
 First, import the required components from the package:

--- a/packages/website/src/content/components/pin-input.mdx
+++ b/packages/website/src/content/components/pin-input.mdx
@@ -8,7 +8,22 @@ description:
   is filled.
 ---
 
+import Anatomy from '~/components/anatomy.astro'
 import Story from '~/components/story.astro'
+
+## Anatomy
+
+To set up the pin input correctly, you'll need to understand its anatomy and how
+we name its parts.
+
+> Each part includes a `data-part` attribute to help identify them in the DOM.
+
+<Anatomy id="pin-input" />
+
+On a high level, the pin input consists of:
+
+- **Root**: The root container for the pin input.
+- **Input**: The editable field for users to enter values.
 
 ## Import
 

--- a/packages/website/src/content/components/pin-input.mdx
+++ b/packages/website/src/content/components/pin-input.mdx
@@ -20,11 +20,6 @@ we name its parts.
 
 <Anatomy id="pin-input" />
 
-On a high level, the pin input consists of:
-
-- **Root**: The root container for the pin input.
-- **Input**: The editable field for users to enter values.
-
 ## Import
 
 ```ts

--- a/packages/website/src/content/components/popover.mdx
+++ b/packages/website/src/content/components/popover.mdx
@@ -19,21 +19,6 @@ we name its parts.
 
 <Anatomy id="popover" />
 
-On a high level, the popover consists of:
-
-- **Trigger**: The trigger for the popover.
-- **Positioner**: The element that positions the popover.
-- **Content**: The container for the popover's content.
-- **Title**: The accessible title for the popover.
-- **Description**: The accessible description for the popover.
-- **Close Button**: The trigger to close the popover.
-
-When positioning the popover, you might use these parts:
-
-- **Arrow**: The arrow element that points to the trigger.
-- **Anchor**: The optional reference element that the popover is anchored or
-  positioned. By default, we use the trigger as the anchor element.
-
 ## Import
 
 ```ts

--- a/packages/website/src/content/components/popover.mdx
+++ b/packages/website/src/content/components/popover.mdx
@@ -7,10 +7,32 @@ description:
   clickable trigger element.
 ---
 
-
+import Anatomy from '~/components/anatomy.astro'
 import Story from '~/components/story.astro'
 
+## Anatomy
 
+To set up the popover correctly, you'll need to understand its anatomy and how
+we name its parts.
+
+> Each part includes a `data-part` attribute to help identify them in the DOM.
+
+<Anatomy id="popover" />
+
+On a high level, the popover consists of:
+
+- **Trigger**: The trigger for the popover.
+- **Positioner**: The element that positions the popover.
+- **Content**: The container for the popover's content.
+- **Title**: The accessible title for the popover.
+- **Description**: The accessible description for the popover.
+- **Close Button**: The trigger to close the popover.
+
+When positioning the popover, you might use these parts:
+
+- **Arrow**: The arrow element that points to the trigger.
+- **Anchor**: The optional reference element that the popover is anchored or
+  positioned. By default, we use the trigger as the anchor element.
 
 ## Import
 

--- a/packages/website/src/content/components/radio-group.mdx
+++ b/packages/website/src/content/components/radio-group.mdx
@@ -18,16 +18,6 @@ how we name its parts.
 
 <Anatomy id="radio-group" />
 
-On a high level, the radio group consists of:
-
-- **Root**: The root container for the radio group
-- **Label**: The label that gives the user information on the radio group
-- **Radio**: The root container for the each radio item
-- **Radio Label**: The label that gives the user information on each radio item
-- **Radio Control**: The element that visually represents the each radio item.
-- **Radio Hidden Input**: The native html input that is visually hidden in each
-  radio item.
-
 ## Import
 
 ```ts

--- a/packages/website/src/content/components/radio-group.mdx
+++ b/packages/website/src/content/components/radio-group.mdx
@@ -6,7 +6,27 @@ description:
   options.
 ---
 
+import Anatomy from '~/components/anatomy.astro'
 import Story from '~/components/story.astro'
+
+## Anatomy
+
+To set up the radio group correctly, you'll need to understand its anatomy and
+how we name its parts.
+
+> Each part includes a `data-part` attribute to help identify them in the DOM.
+
+<Anatomy id="radio-group" />
+
+On a high level, the radio group consists of:
+
+- **Root**: The root container for the radio group
+- **Label**: The label that gives the user information on the radio group
+- **Radio**: The root container for the each radio item
+- **Radio Label**: The label that gives the user information on each radio item
+- **Radio Control**: The element that visually represents the each radio item.
+- **Radio Hidden Input**: The native html input that is visually hidden in each
+  radio item.
 
 ## Import
 

--- a/packages/website/src/content/components/range-slider.mdx
+++ b/packages/website/src/content/components/range-slider.mdx
@@ -18,16 +18,6 @@ name its parts.
 
 <Anatomy id="slider" />
 
-On a high level, the slider consists of:
-
-- **Root**: The root container for the slider
-- **Label**: The accessible label for the slider
-- **Control**: The container for the slider's track and thumb
-- **Track**: The slider's track element
-- **Range**: The element that visually represents the slider's range
-- **Thumb**: The control element used to drag the slider
-- **Output**: The element that displays the current value of the slider
-
 ## Import
 
 ```ts

--- a/packages/website/src/content/components/range-slider.mdx
+++ b/packages/website/src/content/components/range-slider.mdx
@@ -6,7 +6,27 @@ description:
   numbers.
 ---
 
+import Anatomy from '~/components/anatomy.astro'
 import Story from '~/components/story.astro'
+
+## Anatomy
+
+To set up the slider correctly, you'll need to understand its anatomy and how we
+name its parts.
+
+> Each part includes a `data-part` attribute to help identify them in the DOM.
+
+<Anatomy id="slider" />
+
+On a high level, the slider consists of:
+
+- **Root**: The root container for the slider
+- **Label**: The accessible label for the slider
+- **Control**: The container for the slider's track and thumb
+- **Track**: The slider's track element
+- **Range**: The element that visually represents the slider's range
+- **Thumb**: The control element used to drag the slider
+- **Output**: The element that displays the current value of the slider
 
 ## Import
 

--- a/packages/website/src/content/components/rating-group.mdx
+++ b/packages/website/src/content/components/rating-group.mdx
@@ -5,10 +5,25 @@ description:
   The RatingGroup allows a user to add and remove ratings for an item.
 ---
 
-
+import Anatomy from '~/components/anatomy.astro'
 import Story from '~/components/story.astro'
 
+## Anatomy
 
+To set up the rating correctly, you'll need to understand its anatomy and how we
+name its parts.
+
+> Each part includes a `data-part` attribute to help identify them in the DOM.
+
+<Anatomy id="rating-group" />
+
+On a high level, the rating consists of:
+
+- **Root**: The root container for the rating
+- **Label**: The label that gives the user information on the rating
+- **Item**: The element that visually represents the each rating item.
+- **Item Group**: The radiogroup wrapper for the rating items.
+- **Input**: The native html input that is visually hidden in the rating.
 
 ## Import
 

--- a/packages/website/src/content/components/rating-group.mdx
+++ b/packages/website/src/content/components/rating-group.mdx
@@ -17,14 +17,6 @@ name its parts.
 
 <Anatomy id="rating-group" />
 
-On a high level, the rating consists of:
-
-- **Root**: The root container for the rating
-- **Label**: The label that gives the user information on the rating
-- **Item**: The element that visually represents the each rating item.
-- **Item Group**: The radiogroup wrapper for the rating items.
-- **Input**: The native html input that is visually hidden in the rating.
-
 ## Import
 
 ```ts

--- a/packages/website/src/content/components/segment-group.mdx
+++ b/packages/website/src/content/components/segment-group.mdx
@@ -7,7 +7,26 @@ description:
   compact option to improve usability and accessibility.
 ---
 
+import Anatomy from '~/components/anatomy.astro'
 import Story from '~/components/story.astro'
+
+## Anatomy
+
+To set up the segmented control correctly, you'll need to understand its anatomy
+and how we name its parts.
+
+> Each part includes a `data-part` attribute to help identify them in the DOM.
+
+<Anatomy id="segmented-control" />
+
+On a high level, the segmented control consists of:
+
+- **Root**: The root container for the segmented control
+- **Indicator**: The element that visually represents the active radio item.
+- **Radio**: The root container for the each radio item
+- **Radio Label**: The label that gives the user information on each radio item
+- **Radio Hidden Input**: The native html input that is visually hidden in each
+  radio item.
 
 ## Usage
 

--- a/packages/website/src/content/components/segment-group.mdx
+++ b/packages/website/src/content/components/segment-group.mdx
@@ -19,15 +19,6 @@ and how we name its parts.
 
 <Anatomy id="segmented-control" />
 
-On a high level, the segmented control consists of:
-
-- **Root**: The root container for the segmented control
-- **Indicator**: The element that visually represents the active radio item.
-- **Radio**: The root container for the each radio item
-- **Radio Label**: The label that gives the user information on each radio item
-- **Radio Hidden Input**: The native html input that is visually hidden in each
-  radio item.
-
 ## Usage
 
 Start by importing the necessary components from the package:

--- a/packages/website/src/content/components/select.mdx
+++ b/packages/website/src/content/components/select.mdx
@@ -4,7 +4,27 @@ title: Select
 description: A flexible and customizable dropdown select component.
 ---
 
+import Anatomy from '~/components/anatomy.astro'
 import Story from '~/components/story.astro'
+
+## Anatomy
+
+To set up the select correctly, you'll need to understand its anatomy and how we
+name its parts.
+
+> Each part includes a `data-part` attribute to help identify them in the DOM.
+
+<Anatomy id="select" />
+
+On a high level, the select consists of:
+
+- **Label**: The element that labels the select.
+- **Trigger**: The element that is used to open/close the select.
+- **Positioner**: The element that positions the select dynamically.
+- **Content**: The popup element that contains the options.
+- **Item**: The select item or option element.
+- **ItemIndicator**: The element that indicates the selected item.
+- **ItemGroup**: The element used to group related items.
 
 ## Basic Usage
 

--- a/packages/website/src/content/components/select.mdx
+++ b/packages/website/src/content/components/select.mdx
@@ -16,16 +16,6 @@ name its parts.
 
 <Anatomy id="select" />
 
-On a high level, the select consists of:
-
-- **Label**: The element that labels the select.
-- **Trigger**: The element that is used to open/close the select.
-- **Positioner**: The element that positions the select dynamically.
-- **Content**: The popup element that contains the options.
-- **Item**: The select item or option element.
-- **ItemIndicator**: The element that indicates the selected item.
-- **ItemGroup**: The element used to group related items.
-
 ## Basic Usage
 
 For a straightforward implementation of the Select component:

--- a/packages/website/src/content/components/slider.mdx
+++ b/packages/website/src/content/components/slider.mdx
@@ -7,7 +7,27 @@ description:
   and accessibility.
 ---
 
+import Anatomy from '~/components/anatomy.astro'
 import Story from '~/components/story.astro'
+
+## Anatomy
+
+To set up the slider correctly, you'll need to understand its anatomy and how we
+name its parts.
+
+> Each part includes a `data-part` attribute to help identify them in the DOM.
+
+<Anatomy id="slider" />
+
+On a high level, the slider consists of:
+
+- **Root**: The root container for the slider
+- **Label**: The accessible label for the slider
+- **Control**: The container for the slider's track and thumb
+- **Track**: The slider's track element
+- **Range**: The element that visually represents the slider's range
+- **Thumb**: The control element used to drag the slider
+- **Output**: The element that displays the current value of the slider
 
 ## Import
 

--- a/packages/website/src/content/components/slider.mdx
+++ b/packages/website/src/content/components/slider.mdx
@@ -19,16 +19,6 @@ name its parts.
 
 <Anatomy id="slider" />
 
-On a high level, the slider consists of:
-
-- **Root**: The root container for the slider
-- **Label**: The accessible label for the slider
-- **Control**: The container for the slider's track and thumb
-- **Track**: The slider's track element
-- **Range**: The element that visually represents the slider's range
-- **Thumb**: The control element used to drag the slider
-- **Output**: The element that displays the current value of the slider
-
 ## Import
 
 ```ts

--- a/packages/website/src/content/components/splitter.mdx
+++ b/packages/website/src/content/components/splitter.mdx
@@ -18,13 +18,6 @@ name its parts.
 
 <Anatomy id="splitter" />
 
-On a high level, the splitter consists of:
-
-- **Root**: The root container for the splitter
-- **Primary Pane**: The primary pane of the splitter
-- **Separator**: The splitter's interactive separator
-- **Secondary Pane**: The secondary pane of the splitter
-
 ## Getting Started
 
 Start by importing the necessary components from the package:

--- a/packages/website/src/content/components/splitter.mdx
+++ b/packages/website/src/content/components/splitter.mdx
@@ -6,7 +6,24 @@ description:
   screen or a section into multiple resizable areas.
 ---
 
+import Anatomy from '~/components/anatomy.astro'
 import Story from '~/components/story.astro'
+
+## Anatomy
+
+To set up the splitter correctly, you'll need to understand its anatomy and how we
+name its parts.
+
+> Each part includes a `data-part` attribute to help identify them in the DOM.
+
+<Anatomy id="splitter" />
+
+On a high level, the splitter consists of:
+
+- **Root**: The root container for the splitter
+- **Primary Pane**: The primary pane of the splitter
+- **Separator**: The splitter's interactive separator
+- **Secondary Pane**: The secondary pane of the splitter
 
 ## Getting Started
 

--- a/packages/website/src/content/components/switch.mdx
+++ b/packages/website/src/content/components/switch.mdx
@@ -7,7 +7,25 @@ description:
   settings, features, or functionalities.
 ---
 
+import Anatomy from '~/components/anatomy.astro'
 import Story from '~/components/story.astro'
+
+## Anatomy
+
+To set up the switch correctly, you'll need to understand its anatomy and how we
+name its parts.
+
+> Each part includes a `data-part` attribute to help identify them in the DOM.
+
+<Anatomy id="switch" />
+
+On a high level, the switch consists of:
+
+- **Root**: The root container for the switch
+- **Label**: The label that gives the user information on the switch
+- **Control**: The element that visually represents the switch.
+- **Thumb**: The element that visually represents the thumb within the control.
+- **Input**: The native html input that is visually hidden.
 
 ## Usage
 

--- a/packages/website/src/content/components/switch.mdx
+++ b/packages/website/src/content/components/switch.mdx
@@ -19,14 +19,6 @@ name its parts.
 
 <Anatomy id="switch" />
 
-On a high level, the switch consists of:
-
-- **Root**: The root container for the switch
-- **Label**: The label that gives the user information on the switch
-- **Control**: The element that visually represents the switch.
-- **Thumb**: The element that visually represents the thumb within the control.
-- **Input**: The native html input that is visually hidden.
-
 ## Usage
 
 To use the Switch component in your project, import the necessary sub-components

--- a/packages/website/src/content/components/tabs.mdx
+++ b/packages/website/src/content/components/tabs.mdx
@@ -19,14 +19,6 @@ name its parts.
 
 <Anatomy id="tabs" />
 
-On a high level, the tabs consists of:
-
-- **Root**: The root container for the trigger and content elements.
-- **Trigger**: The button that activates a tab panel.
-- **Content**: The element that holds the content of the tab.
-- **Indicator**: The element that holds the content of the tab.
-- **Delete Button**: An optional element used to close or delete a tab.
-
 ## Usage
 
 To get started, import the necessary components from the package:

--- a/packages/website/src/content/components/tabs.mdx
+++ b/packages/website/src/content/components/tabs.mdx
@@ -7,7 +7,25 @@ description:
   the ability to display different contents based on the selected tab.
 ---
 
+import Anatomy from '~/components/anatomy.astro'
 import Story from '~/components/story.astro'
+
+## Anatomy
+
+To set up the tabs correctly, you'll need to understand its anatomy and how we
+name its parts.
+
+> Each part includes a `data-part` attribute to help identify them in the DOM.
+
+<Anatomy id="tabs" />
+
+On a high level, the tabs consists of:
+
+- **Root**: The root container for the trigger and content elements.
+- **Trigger**: The button that activates a tab panel.
+- **Content**: The element that holds the content of the tab.
+- **Indicator**: The element that holds the content of the tab.
+- **Delete Button**: An optional element used to close or delete a tab.
 
 ## Usage
 

--- a/packages/website/src/content/components/tags-input.mdx
+++ b/packages/website/src/content/components/tags-input.mdx
@@ -20,22 +20,6 @@ how we name its parts.
 
 <Anatomy id="tags-input" />
 
-On a high level, the tags input consists of:
-
-- **Root**: The root container for the tags input.
-- **Label**: The accessible label for the tags input textbox.
-- **Control**: The container for the tags and the input's textbox.
-- **Tag**: The element that represents a tag.
-- **Input**: The textbox for adding new tags.
-- **Hidden Input**: The hidden input that holds the value of the tags input.
-  Used within forms.
-- **Clear Button**: The button that clears all tags.
-
-Each tag consists of:
-
-- **Tag Input**: The input element that is used to edit a tag.
-- **Tag Delete Button**: The button to delete a tag.
-
 ## Import
 
 ```ts

--- a/packages/website/src/content/components/tags-input.mdx
+++ b/packages/website/src/content/components/tags-input.mdx
@@ -8,7 +8,33 @@ description:
   input element.
 ---
 
+import Anatomy from '~/components/anatomy.astro'
 import Story from '~/components/story.astro'
+
+## Anatomy
+
+To set up the tags input correctly, you'll need to understand its anatomy and
+how we name its parts.
+
+> Each part includes a `data-part` attribute to help identify them in the DOM.
+
+<Anatomy id="tags-input" />
+
+On a high level, the tags input consists of:
+
+- **Root**: The root container for the tags input.
+- **Label**: The accessible label for the tags input textbox.
+- **Control**: The container for the tags and the input's textbox.
+- **Tag**: The element that represents a tag.
+- **Input**: The textbox for adding new tags.
+- **Hidden Input**: The hidden input that holds the value of the tags input.
+  Used within forms.
+- **Clear Button**: The button that clears all tags.
+
+Each tag consists of:
+
+- **Tag Input**: The input element that is used to edit a tag.
+- **Tag Delete Button**: The button to delete a tag.
 
 ## Import
 

--- a/packages/website/src/content/components/toast.mdx
+++ b/packages/website/src/content/components/toast.mdx
@@ -6,7 +6,25 @@ description:
   unobtrusive notifications or simple messages in your application.
 ---
 
+import Anatomy from '~/components/anatomy.astro'
 import Story from '~/components/story.astro'
+
+## Anatomy
+
+To set up the toast correctly, you'll need to understand its anatomy and how we
+name its parts.
+
+> Each part includes a `data-part` attribute to help identify them in the DOM.
+
+<Anatomy id="toast" />
+
+On a high level, the toast consists of:
+
+- **Group**: The element that serves as a container for all the toasts.
+- **Root**: The root container for the toast.
+- **Title**: The element that contains the title of the toast.
+- **Description**: The element that contains the description of the toast.
+- **Close Button**: The action button that is used to dimiss a toast.
 
 ## Usage
 

--- a/packages/website/src/content/components/toast.mdx
+++ b/packages/website/src/content/components/toast.mdx
@@ -18,14 +18,6 @@ name its parts.
 
 <Anatomy id="toast" />
 
-On a high level, the toast consists of:
-
-- **Group**: The element that serves as a container for all the toasts.
-- **Root**: The root container for the toast.
-- **Title**: The element that contains the title of the toast.
-- **Description**: The element that contains the description of the toast.
-- **Close Button**: The action button that is used to dimiss a toast.
-
 ## Usage
 
 To get started, import the necessary components from the package:

--- a/packages/website/src/content/components/toggle-group.mdx
+++ b/packages/website/src/content/components/toggle-group.mdx
@@ -4,7 +4,22 @@ title: Toggle Group
 description: A set of toggle buttons for selection within a group.
 ---
 
+import Anatomy from '~/components/anatomy.astro'
 import Story from '~/components/story.astro'
+
+## Anatomy
+
+To set up the toggle group correctly, you'll need to understand its anatomy and
+how we name its parts.
+
+> Each part includes a `data-part` attribute to help identify them in the DOM.
+
+<Anatomy id="toggle-group" />
+
+On a high level, the toggle group consists of:
+
+- **Root**: The root container for the toggle group
+- **Toggle**: The individual toggle button
 
 ## Basic Usage
 

--- a/packages/website/src/content/components/toggle-group.mdx
+++ b/packages/website/src/content/components/toggle-group.mdx
@@ -16,11 +16,6 @@ how we name its parts.
 
 <Anatomy id="toggle-group" />
 
-On a high level, the toggle group consists of:
-
-- **Root**: The root container for the toggle group
-- **Toggle**: The individual toggle button
-
 ## Basic Usage
 
 A simple example with three toggles: A, B, and C.

--- a/packages/website/src/content/components/tooltip.mdx
+++ b/packages/website/src/content/components/tooltip.mdx
@@ -7,7 +7,24 @@ description:
   where you need to offer users tips or help text.
 ---
 
+import Anatomy from '~/components/anatomy.astro'
 import Story from '~/components/story.astro'
+
+## Anatomy
+
+To set up the tooltip correctly, you'll need to understand its anatomy and how
+we name its parts.
+
+> Each part includes a `data-part` attribute to help identify them in the DOM.
+
+<Anatomy id="tooltip" />
+
+On a high level, the tooltip consists of:
+
+- **Trigger**: The trigger for the tooltip.
+- **Positioner**: The element that dynamically positions the tooltip.
+- **Arrow**: The arrow that points to the trigger.
+- **Content**: The element that houses the content of the tooltip.
 
 ## Usage
 

--- a/packages/website/src/content/components/tooltip.mdx
+++ b/packages/website/src/content/components/tooltip.mdx
@@ -19,13 +19,6 @@ we name its parts.
 
 <Anatomy id="tooltip" />
 
-On a high level, the tooltip consists of:
-
-- **Trigger**: The trigger for the tooltip.
-- **Positioner**: The element that dynamically positions the tooltip.
-- **Arrow**: The arrow that points to the trigger.
-- **Content**: The element that houses the content of the tooltip.
-
 ## Usage
 
 Start by importing the necessary components from the package:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -805,6 +805,9 @@ importers:
       '@fontsource-variable/inter':
         specifier: 5.0.8
         version: 5.0.8
+      '@zag-js/anatomy-icons':
+        specifier: 0.22.0
+        version: 0.22.0(react@18.2.0)(typescript@5.2.2)
       astro:
         specifier: 3.1.1
         version: 3.1.1(@types/node@20.5.1)
@@ -6430,6 +6433,132 @@ packages:
       file-system-cache: 2.4.4
     dev: true
 
+  /@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.22.20):
+    resolution: {integrity: sha512-b9MIk7yhdS1pMCZM8VeNfUlSKVRhsHZNMl5O9SfaX0l0t5wjdgu4IDzGB8bpnGBBOjGST3rRFVsaaEtI4W6f7g==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.22.20
+    dev: false
+
+  /@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.22.20):
+    resolution: {integrity: sha512-BcCkm/STipKvbCl6b7QFrMh/vx00vIP63k2eM66MfHJzPr6O2U0jYEViXkHJWqXqQYjdeA9cuCl5KWmlwjDvbA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.22.20
+    dev: false
+
+  /@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.22.20):
+    resolution: {integrity: sha512-5BcGCBfBxB5+XSDSWnhTThfI9jcO5f0Ai2V24gZpG+wXF14BzwxxdDb4g6trdOux0rhibGs385BeFMSmxtS3uA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.22.20
+    dev: false
+
+  /@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.22.20):
+    resolution: {integrity: sha512-KVQ+PtIjb1BuYT3ht8M5KbzWBhdAjjUPdlMtpuw/VjT8coTrItWX6Qafl9+ji831JaJcu6PJNKCV0bp01lBNzQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.22.20
+    dev: false
+
+  /@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.22.20):
+    resolution: {integrity: sha512-omNiKqwjNmOQJ2v6ge4SErBbkooV2aAWwaPFs2vUY7p7GhVkzRkJ00kILXQvRhA6miHnNpXv7MRnnSjdRjK8og==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.22.20
+    dev: false
+
+  /@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.22.20):
+    resolution: {integrity: sha512-mURHYnu6Iw3UBTbhGwE/vsngtCIbHE43xCRK7kCw4t01xyGqb2Pd+WXekRRoFOBIY29ZoOhUCTEweDMdrjfi9g==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.22.20
+    dev: false
+
+  /@svgr/babel-plugin-transform-react-native-svg@8.1.0(@babel/core@7.22.20):
+    resolution: {integrity: sha512-Tx8T58CHo+7nwJ+EhUwx3LfdNSG9R2OKfaIXXs5soiy5HtgoAEkDay9LIimLOcG8dJQH1wPZp/cnAv6S9CrR1Q==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.22.20
+    dev: false
+
+  /@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.22.20):
+    resolution: {integrity: sha512-DFx8xa3cZXTdb/k3kfPeaixecQLgKh5NVBMwD0AQxOzcZawK4oo1Jh9LbrcACUivsCA7TLG8eeWgrDXjTMhRmw==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.22.20
+    dev: false
+
+  /@svgr/babel-preset@8.1.0(@babel/core@7.22.20):
+    resolution: {integrity: sha512-7EYDbHE7MxHpv4sxvnVPngw5fuR6pw79SkcrILHJ/iMpuKySNCl5W1qcwPEpU+LgyRXOaAFgH0KhwD18wwg6ug==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.22.20
+      '@svgr/babel-plugin-add-jsx-attribute': 8.0.0(@babel/core@7.22.20)
+      '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0(@babel/core@7.22.20)
+      '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0(@babel/core@7.22.20)
+      '@svgr/babel-plugin-replace-jsx-attribute-value': 8.0.0(@babel/core@7.22.20)
+      '@svgr/babel-plugin-svg-dynamic-title': 8.0.0(@babel/core@7.22.20)
+      '@svgr/babel-plugin-svg-em-dimensions': 8.0.0(@babel/core@7.22.20)
+      '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.22.20)
+      '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.22.20)
+    dev: false
+
+  /@svgr/core@8.1.0(typescript@5.2.2):
+    resolution: {integrity: sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==}
+    engines: {node: '>=14'}
+    dependencies:
+      '@babel/core': 7.22.20
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.22.20)
+      camelcase: 6.3.0
+      cosmiconfig: 8.3.6(typescript@5.2.2)
+      snake-case: 3.0.4
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: false
+
+  /@svgr/hast-util-to-babel-ast@8.0.0:
+    resolution: {integrity: sha512-EbDKwO9GpfWP4jN9sGdYwPBU0kdomaPIL2Eu4YwmgP+sJeXT+L7bMwJUBnhzfH8Q2qMBqZ4fJwpCyYsAN3mt2Q==}
+    engines: {node: '>=14'}
+    dependencies:
+      '@babel/types': 7.22.19
+      entities: 4.5.0
+    dev: false
+
+  /@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0):
+    resolution: {integrity: sha512-0xiIyBsLlr8quN+WyuxooNW9RJ0Dpr8uOnH/xrCVO8GLUcwHISwj1AG0k+LFzteTkAA0GbX0kj9q6Dk70PTiPA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@svgr/core': '*'
+    dependencies:
+      '@babel/core': 7.22.20
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.22.20)
+      '@svgr/core': 8.1.0(typescript@5.2.2)
+      '@svgr/hast-util-to-babel-ast': 8.0.0
+      svg-parser: 2.0.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@swc/helpers@0.5.1:
     resolution: {integrity: sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==}
     dependencies:
@@ -7596,6 +7725,20 @@ packages:
       '@zag-js/dom-query': 0.22.0
       '@zag-js/types': 0.22.0
       '@zag-js/utils': 0.22.0
+    dev: false
+
+  /@zag-js/anatomy-icons@0.22.0(react@18.2.0)(typescript@5.2.2):
+    resolution: {integrity: sha512-bUeweiUzMj2gq9tKquyJGbPRZs44VmQMIwTPgcs+h6iVKu8NUTOmDQ8hzEpD9yJgpfs0HDx4FOjn84sdYjIUWw==}
+    peerDependencies:
+      react: '>=16.8.0'
+    dependencies:
+      '@svgr/core': 8.1.0(typescript@5.2.2)
+      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0)
+      color2k: 2.0.2
+      react: 18.2.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
     dev: false
 
   /@zag-js/anatomy@0.12.0:
@@ -10128,7 +10271,6 @@ packages:
   /callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
-    dev: true
 
   /camel-case@4.1.2:
     resolution: {integrity: sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==}
@@ -10154,7 +10296,6 @@ packages:
   /camelcase@6.3.0:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
-    dev: true
 
   /camelcase@7.0.1:
     resolution: {integrity: sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==}
@@ -10399,6 +10540,10 @@ packages:
       color-name: 1.1.4
       simple-swizzle: 0.2.2
     optional: true
+
+  /color2k@2.0.2:
+    resolution: {integrity: sha512-kJhwH5nAwb34tmyuqq/lgjEKzlFXn1U99NlnB6Ws4qVaERcRUYeYP1cBw6BJ4vxaWStAUEef4WMr7WjOCnBt8w==}
+    dev: false
 
   /color@4.2.3:
     resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
@@ -10649,7 +10794,6 @@ packages:
       parse-json: 5.2.0
       path-type: 4.0.0
       typescript: 5.2.2
-    dev: true
 
   /create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
@@ -11071,7 +11215,6 @@ packages:
     dependencies:
       no-case: 3.0.4
       tslib: 2.6.2
-    dev: true
 
   /dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
@@ -11172,7 +11315,6 @@ packages:
   /entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
-    dev: true
 
   /envinfo@7.10.0:
     resolution: {integrity: sha512-ZtUjZO6l5mwTHvc1L9+1q5p/R3wTopcfqMW8r5t8SJSKqeVI/LtajORwRFEKpEFuekjD0VBjwu1HMxL4UalIRw==}
@@ -11184,7 +11326,6 @@ packages:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
     dependencies:
       is-arrayish: 0.2.1
-    dev: true
 
   /es-abstract@1.22.1:
     resolution: {integrity: sha512-ioRRcXMO6OFyRpyzV3kE1IIBd4WG5/kltnzdxSCqoP8CMGs/Li+M1uF5o7lOkZVFjDs+NLesthnF66Pg/0q0Lw==}
@@ -12890,7 +13031,6 @@ packages:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
-    dev: true
 
   /import-lazy@4.0.0:
     resolution: {integrity: sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==}
@@ -13024,7 +13164,6 @@ packages:
 
   /is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
-    dev: true
 
   /is-arrayish@0.3.2:
     resolution: {integrity: sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==}
@@ -13741,7 +13880,6 @@ packages:
 
   /json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
-    dev: true
 
   /json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -13868,7 +14006,6 @@ packages:
 
   /lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
-    dev: true
 
   /linkify-it@3.0.3:
     resolution: {integrity: sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==}
@@ -14078,7 +14215,6 @@ packages:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
     dependencies:
       tslib: 2.6.2
-    dev: true
 
   /lowercase-keys@3.0.0:
     resolution: {integrity: sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==}
@@ -15039,7 +15175,6 @@ packages:
     dependencies:
       lower-case: 2.0.2
       tslib: 2.6.2
-    dev: true
 
   /node-abi@3.47.0:
     resolution: {integrity: sha512-2s6B2CWZM//kPgwnuI0KrYwNjfdByE25zvAaEpq9IH4zcNsarH8Ihu/UuX6XMPEogDAxkuUFeZn60pXNHAqn3A==}
@@ -15479,7 +15614,6 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       callsites: 3.1.0
-    dev: true
 
   /parse-entities@4.0.1:
     resolution: {integrity: sha512-SWzvYcSJh4d/SGLIOQfZ/CoNv6BTlI6YEQ7Nj82oDVnRpwe/Z/F1EMx42x3JAOwGBlCjeCH0BRJQbQ/opHL17w==}
@@ -15502,7 +15636,6 @@ packages:
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
-    dev: true
 
   /parse-latin@5.0.1:
     resolution: {integrity: sha512-b/K8ExXaWC9t34kKeDV8kGXBkXZ1HCSAZRYE7HR14eA1GlXX5L8iWhs8USJNhQU9q5ci413jCKF0gOyovvyRBg==}
@@ -16627,7 +16760,6 @@ packages:
   /resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
-    dev: true
 
   /resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
@@ -17097,7 +17229,6 @@ packages:
     dependencies:
       dot-case: 3.0.4
       tslib: 2.6.2
-    dev: true
 
   /socks-proxy-agent@8.0.2:
     resolution: {integrity: sha512-8zuqoLv1aP/66PHF5TqwJ7Czm3Yv32urJQHrVyhD7mmA6d61Zv8cIXQYPTWwmg6qlupnPvs/QKDmfa4P/qct2g==}
@@ -17483,6 +17614,10 @@ packages:
   /supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  /svg-parser@2.0.4:
+    resolution: {integrity: sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==}
+    dev: false
 
   /svg-tags@1.0.0:
     resolution: {integrity: sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==}
@@ -18055,7 +18190,6 @@ packages:
     resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}
     engines: {node: '>=14.17'}
     hasBin: true
-    dev: true
 
   /uc.micro@1.0.6:
     resolution: {integrity: sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==}


### PR DESCRIPTION
As I've checked, we don't have Zag icons for:
- Carousel
- Color Picker
- Date Picker
- Environment
- Presence

There are no components in Ark UI:
- File Upload

There are no pages in Ark UI:
- Nested Menu

There are no anatomies on Zag page:
- Splitter (`split-view` almost empty page hidden in sidebar)
in this case I've added own description, so please check this (if it's good then I'll add it in Zag docs)

There is no anatomy at all:
- Pressable