### PR TITLE
update number-input precision doc

### DIFF
--- a/packages/website/src/content/components/number-input.mdx
+++ b/packages/website/src/content/components/number-input.mdx
@@ -66,10 +66,15 @@ range.
 ### Adjusting the precision of the value
 
 In some cases, you might need the value to be rounded to specific decimal
-points. Pass the precision prop and set it to the number of decimal points.
+points. Pass the `formatOptions` prop and provide `maximumFractionDigits` or
+`minimumFractionDigits`.
 
 ```tsx
-<NumberInput precision={3}>{/*...*/}</NumberInput>
+<NumberInput
+  formatOptions={{ minimumFractionDigits: 2, maximumFractionDigits: 4 }}
+>
+  {/*...*/}
+</NumberInput>
 ```
 
 ### Scrubbing the input value


### PR DESCRIPTION
`number-input` component docs is out of date regarding the precision props available to set.

Looking at the story examples [this](https://github.com/chakra-ui/ark/blob/b8d44379fe07720f173b783fae25ce3e64f69e1b/packages/frameworks/react/src/number-input/number-input.stories.tsx#L40) is the correct way to use precision

[Preview link](https://ark-docs-git-fork-rodrigoslino-main-chakra-ui.vercel.app/docs/components/number-input)