### PR TITLE
docs: add missing props in slider examples

### DIFF
--- a/packages/website/src/components/marketing/examples.ts
+++ b/packages/website/src/components/marketing/examples.ts
@@ -17,7 +17,7 @@ export const MySlider = () => {
         <Slider.Track>
           <Slider.Range />
         </Slider.Track>
-        <Slider.Thumb />
+        <Slider.Thumb key={0} index={0} />
       </Slider.Control>
     </Slider.Root>
   )
@@ -42,7 +42,7 @@ export const MySlider = () => {
         <Slider.Track>
           <Slider.Range />
         </Slider.Track>
-        <Slider.Thumb />
+        <Slider.Thumb index={0} />
       </Slider.Control>
     </Slider.Root>
   )
@@ -63,7 +63,7 @@ const sliderValue = ref<SliderProps['modelValue']>([30])
       <Slider.Track>
         <Slider.Range />
       </Slider.Track>
-      <Slider.Thumb />
+      <Slider.Thumb :key="0" :index="0" />
     </Slider.Control>
   </Slider.Root>
 </template>`

--- a/packages/website/src/content/overview/getting-started.mdx
+++ b/packages/website/src/content/overview/getting-started.mdx
@@ -59,7 +59,7 @@ export const MySlider = () => (
       <Slider.Track>
         <Slider.Range />
       </Slider.Track>
-      <Slider.Thumb />
+      <Slider.Thumb index={0} />
     </Slider.Control>
   </Slider.Root>
 )

--- a/packages/website/src/content/overview/getting-started.mdx
+++ b/packages/website/src/content/overview/getting-started.mdx
@@ -59,7 +59,7 @@ export const MySlider = () => (
       <Slider.Track>
         <Slider.Range />
       </Slider.Track>
-      <Slider.Thumb index={0} />
+      <Slider.Thumb key={0} index={0} />
     </Slider.Control>
   </Slider.Root>
 )


### PR DESCRIPTION
The `Slider.Thumb` component, which is used as an example in the [Getting Started page](https://ark-ui.com/docs/overview/getting-started), requires the `index` prop, so the example gets a type error. This PR adds the `index` prop to the example.

https://ark-ui.com/docs/components/slider

![image](https://github.com/chakra-ui/ark/assets/250407/22802def-7149-4b08-8d88-befe3cbf04b0)
