### PR TITLE
docs: fix keyboard navigation in Menu component

### DIFF
--- a/packages/website/src/demos/menu.demo.tsx
+++ b/packages/website/src/demos/menu.demo.tsx
@@ -67,12 +67,14 @@ export const Demo = (props: MenuProps) => {
                   <Menu.Content>
                     <Menu.Item id="email">
                       <HStack gap="2">
-                        <MailIcon /> Email
+                        <MailIcon />
+                        Email
                       </HStack>
                     </Menu.Item>
                     <Menu.Item id="message">
                       <HStack gap="2">
-                        <MessageSquareIcon /> Message
+                        <MessageSquareIcon />
+                        Message
                       </HStack>
                     </Menu.Item>
                     <Menu.Separator />

--- a/packages/website/src/demos/menu.demo.tsx
+++ b/packages/website/src/demos/menu.demo.tsx
@@ -39,13 +39,15 @@ export const Demo = (props: MenuProps) => {
             </Menu.Item>
             <Menu.Item id="billing">
               <HStack gap="2">
-                <CreditCardIcon /> Billing
+                <CreditCardIcon />
+                Billing
               </HStack>
             </Menu.Item>
             <Menu.Item id="settings">
               <HStack gap="6" justify="space-between" flex="1">
                 <HStack gap="2">
-                  <SettingsIcon /> Settings
+                  <SettingsIcon />
+                  Settings
                 </HStack>
                 <Text as="span" color="fg.subtle" textStyle="xs">
                   ⌘,


### PR DESCRIPTION
I was playing with the example for the Menu component in the docs, and I realized that some items were unreachable when navigating with the keyboard and pressing their first letter.

It was caused by extra spaces in the item content. So this little PR fixes that by removing the extra spaces.