### PR TITLE
fix(vue/accordion-item): set default for `disabled` prop to `undefined`

### DIFF
--- a/packages/frameworks/vue/src/accordion/accordion-item.tsx
+++ b/packages/frameworks/vue/src/accordion/accordion-item.tsx
@@ -15,7 +15,7 @@ export const AccordionItem = defineComponent({
     },
     disabled: {
       type: Boolean,
-      default: false,
+      default: undefined,
     },
   },
   setup(props, { slots, attrs }) {

--- a/packages/frameworks/vue/src/accordion/tests/accordion.test.tsx
+++ b/packages/frameworks/vue/src/accordion/tests/accordion.test.tsx
@@ -49,7 +49,7 @@ describe('Accordion', () => {
     )
   })
 
-  it.skip('should disable all items when disabled is true', async () => {
+  it('should disable all items when disabled is true', async () => {
     render(ComponentUnderTest, { props: { disabled: true } })
     expect(screen.getByRole('button', { name: 'React Trigger' })).toBeDisabled()
   })


### PR DESCRIPTION
This PR addresses the issue where setting the `disabled` prop for `Accordion.Root` to true was not propagating to the items.

In `Accordion.Item`, the `disabled` prop was declared with a default value of `false`, perpetually taking precedent when checking item state. This is because `getItemState` in the [Zag Accordion Connect](https://github.com/chakra-ui/zag/blob/305ac564f33c05a209d403dc2008984cc7520e17/packages/machines/accordion/src/accordion.connect.ts#L25) is running a nullish coalescing for `isDisabled` to obtain its value .

The default value still needs to be declared, but it should be `undefined` so the nullish coalescing returns false in the check and obtains that context's disabled value instead.

Also, remove the skip for the related test.