### PR TITLE
refactor(vue): function signature

### DIFF
--- a/packages/frameworks/vue/CHANGELOG.md
+++ b/packages/frameworks/vue/CHANGELOG.md
@@ -15,6 +15,7 @@ description: All notable changes to this project will be documented in this file
 
 ### Changed
 
+- Rewritten all components `defineComponent` to Function Signature (without combobox and select)
 - Revised `Dialog` component stories and tests
 - Revised `HoverCard` component stories and tests
 - Revised `Menu` component

--- a/packages/frameworks/vue/src/accordion/accordion-item-content.tsx
+++ b/packages/frameworks/vue/src/accordion/accordion-item-content.tsx
@@ -7,11 +7,8 @@ import { useAccordionItemContext } from './accordion-item-context'
 
 export interface AccordionItemContentProps extends HTMLArkProps<'div'> {}
 
-export const AccordionItemContent = defineComponent({
-  name: 'AccordionItemContent',
-  props,
-  emits,
-  setup(props, { slots, attrs }) {
+export const AccordionItemContent = defineComponent<AccordionItemContentProps>(
+  (props, { slots, attrs }) => {
     const api = useAccordionContext()
     const item = useAccordionItemContext()
     const presenceApi = usePresenceContext()
@@ -26,4 +23,9 @@ export const AccordionItemContent = defineComponent({
       </>
     )
   },
-})
+  {
+    name: 'AccordionItemContent',
+    props,
+    emits,
+  },
+)

--- a/packages/frameworks/vue/src/accordion/accordion-item-indicator.tsx
+++ b/packages/frameworks/vue/src/accordion/accordion-item-indicator.tsx
@@ -5,9 +5,8 @@ import { useAccordionItemContext } from './accordion-item-context'
 
 export interface AccordionItemIndicatorProps extends HTMLArkProps<'div'> {}
 
-export const AccordionItemIndicator = defineComponent({
-  name: 'AccordionItemIndicator',
-  setup(_, { attrs, slots }) {
+export const AccordionItemIndicator = defineComponent<AccordionItemIndicatorProps>(
+  (_, { attrs, slots }) => {
     const api = useAccordionContext()
     const item = useAccordionItemContext()
 
@@ -17,4 +16,7 @@ export const AccordionItemIndicator = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'AccordionItemIndicator',
+  },
+)

--- a/packages/frameworks/vue/src/accordion/accordion-item-trigger.tsx
+++ b/packages/frameworks/vue/src/accordion/accordion-item-trigger.tsx
@@ -6,9 +6,8 @@ import { useAccordionItemContext } from './accordion-item-context'
 
 export interface AccordionItemTriggerProps extends HTMLArkProps<'button'> {}
 
-export const AccordionItemTrigger = defineComponent({
-  name: 'AccordionItemTrigger',
-  setup(_, { attrs, slots }) {
+export const AccordionItemTrigger = defineComponent<AccordionItemTriggerProps>(
+  (_, { attrs, slots }) => {
     const api = useAccordionContext()
     const item = useAccordionItemContext()
     const presenceApi = usePresenceContext()
@@ -26,4 +25,7 @@ export const AccordionItemTrigger = defineComponent({
       </ark.button>
     )
   },
-})
+  {
+    name: 'AccordionItemTrigger',
+  },
+)

--- a/packages/frameworks/vue/src/accordion/accordion-item.tsx
+++ b/packages/frameworks/vue/src/accordion/accordion-item.tsx
@@ -9,20 +9,8 @@ import { AccordionItemProvider } from './accordion-item-context'
 
 export interface AccordionItemProps extends Assign<HTMLArkProps<'div'>, ItemProps> {}
 
-export const AccordionItem = defineComponent({
-  name: 'AccordionItem',
-  props: {
-    value: {
-      type: String as PropType<ItemProps['value']>,
-      required: true,
-    },
-    disabled: {
-      type: Boolean as PropType<ItemProps['disabled']>,
-      default: undefined,
-    },
-  },
-  emits,
-  setup(props, { slots, attrs, emit }) {
+export const AccordionItem = defineComponent<AccordionItemProps>(
+  (props, { slots, attrs, emit }) => {
     const api = useAccordionContext()
     const itemState = computed(() => api.value.getItemState(props))
 
@@ -43,4 +31,18 @@ export const AccordionItem = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'AccordionItem',
+    props: {
+      value: {
+        type: String as PropType<ItemProps['value']>,
+        required: true,
+      },
+      disabled: {
+        type: Boolean as PropType<ItemProps['disabled']>,
+        default: undefined,
+      },
+    },
+    emits,
+  },
+)

--- a/packages/frameworks/vue/src/accordion/accordion.tsx
+++ b/packages/frameworks/vue/src/accordion/accordion.tsx
@@ -10,25 +10,8 @@ export interface AccordionProps
   extends Assign<HTMLArkProps<'div'>, UseAccordionProps>,
     UsePresenceProps {}
 
-export const Accordion = defineComponent({
-  name: 'Accordion',
-  props: {
-    ...props,
-    present: {
-      type: Boolean as PropType<UsePresenceProps['present']>,
-      default: undefined,
-    },
-    lazyMount: {
-      type: Boolean as PropType<UsePresenceProps['lazyMount']>,
-      default: false,
-    },
-    unmountOnExit: {
-      type: Boolean as PropType<UsePresenceProps['unmountOnExit']>,
-      default: false,
-    },
-  },
-  emits,
-  setup(props, { slots, attrs, emit }) {
+export const Accordion = defineComponent<AccordionProps>(
+  (props, { slots, attrs, emit }) => {
     const api = useAccordion(props, emit)
 
     const presenceProps = computed(() => ({
@@ -45,4 +28,23 @@ export const Accordion = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'Accordion',
+    props: {
+      ...props,
+      present: {
+        type: Boolean as PropType<UsePresenceProps['present']>,
+        default: undefined,
+      },
+      lazyMount: {
+        type: Boolean as PropType<UsePresenceProps['lazyMount']>,
+        default: false,
+      },
+      unmountOnExit: {
+        type: Boolean as PropType<UsePresenceProps['unmountOnExit']>,
+        default: false,
+      },
+    },
+    emits,
+  },
+)

--- a/packages/frameworks/vue/src/avatar/avatar-fallback.tsx
+++ b/packages/frameworks/vue/src/avatar/avatar-fallback.tsx
@@ -1,13 +1,11 @@
 import { defineComponent } from 'vue'
 import { ark, type HTMLArkProps } from '../factory'
-import type { ComponentWithProps } from '../utils'
 import { useAvatarContext } from './avatar-context'
 
 export interface AvatarFallbackProps extends HTMLArkProps<'span'> {}
 
-export const AvatarFallback: ComponentWithProps<AvatarFallbackProps> = defineComponent({
-  name: 'AvatarFallback',
-  setup(_, { slots, attrs }) {
+export const AvatarFallback = defineComponent<AvatarFallbackProps>(
+  (_, { slots, attrs }) => {
     const api = useAvatarContext()
 
     return () => (
@@ -16,4 +14,7 @@ export const AvatarFallback: ComponentWithProps<AvatarFallbackProps> = defineCom
       </ark.span>
     )
   },
-})
+  {
+    name: 'AvatarFallback',
+  },
+)

--- a/packages/frameworks/vue/src/avatar/avatar-image.tsx
+++ b/packages/frameworks/vue/src/avatar/avatar-image.tsx
@@ -1,14 +1,15 @@
 import { defineComponent } from 'vue'
 import { ark, type HTMLArkProps } from '../factory'
-import type { ComponentWithProps } from '../utils'
 import { useAvatarContext } from './avatar-context'
 
 export interface AvatarImageProps extends HTMLArkProps<'img'> {}
 
-export const AvatarImage: ComponentWithProps<AvatarImageProps> = defineComponent({
-  name: 'AvatarImage',
-  setup(_, { attrs }) {
+export const AvatarImage = defineComponent<AvatarImageProps>(
+  (_, { attrs }) => {
     const api = useAvatarContext()
     return () => <ark.img {...api.value.imageProps} {...attrs} />
   },
-})
+  {
+    name: 'AvatarImage',
+  },
+)

--- a/packages/frameworks/vue/src/avatar/avatar.props.ts
+++ b/packages/frameworks/vue/src/avatar/avatar.props.ts
@@ -12,5 +12,5 @@ export const props = {
   id: {
     type: String as PropType<Context['id']>,
   },
-}
+} as const
 export const emits = declareEmits(['loading-status-change'])

--- a/packages/frameworks/vue/src/avatar/avatar.tsx
+++ b/packages/frameworks/vue/src/avatar/avatar.tsx
@@ -7,11 +7,8 @@ import { useAvatar, type UseAvatarProps } from './use-avatar'
 
 export interface AvatarProps extends Assign<HTMLArkProps<'div'>, UseAvatarProps> {}
 
-export const Avatar = defineComponent({
-  name: 'Avatar',
-  props,
-  emits,
-  setup(props, { slots, attrs, emit }) {
+export const Avatar = defineComponent<AvatarProps>(
+  (props, { slots, attrs, emit }) => {
     const api = useAvatar(props, emit)
     AvatarProvider(api)
 
@@ -21,4 +18,9 @@ export const Avatar = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'Avatar',
+    props,
+    emits,
+  },
+)

--- a/packages/frameworks/vue/src/carousel/carousel-control.tsx
+++ b/packages/frameworks/vue/src/carousel/carousel-control.tsx
@@ -4,13 +4,15 @@ import { ark, type HTMLArkProps } from '../factory'
 
 export interface CarouselControlProps extends HTMLArkProps<'div'> {}
 
-export const CarouselControl = defineComponent({
-  name: 'CarouselControl',
-  setup(_, { slots, attrs }) {
+export const CarouselControl = defineComponent<CarouselControlProps>(
+  (_, { slots, attrs }) => {
     return () => (
       <ark.div {...carouselAnatomy.build().control.attrs} {...attrs}>
         {slots.default?.()}
       </ark.div>
     )
   },
-})
+  {
+    name: 'CarouselControl',
+  },
+)

--- a/packages/frameworks/vue/src/carousel/carousel-indicator-group.tsx
+++ b/packages/frameworks/vue/src/carousel/carousel-indicator-group.tsx
@@ -4,9 +4,8 @@ import { useCarouselContext } from './carousel-context'
 
 export interface CarouselIndicatorGroupProps extends HTMLArkProps<'div'> {}
 
-export const CarouselIndicatorGroup = defineComponent({
-  name: 'CarouselIndicatorGroup',
-  setup(_, { slots, attrs }) {
+export const CarouselIndicatorGroup = defineComponent<CarouselIndicatorGroupProps>(
+  (_, { slots, attrs }) => {
     const api = useCarouselContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const CarouselIndicatorGroup = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'CarouselIndicatorGroup',
+  },
+)

--- a/packages/frameworks/vue/src/carousel/carousel-indicator.tsx
+++ b/packages/frameworks/vue/src/carousel/carousel-indicator.tsx
@@ -6,19 +6,8 @@ import { useCarouselContext } from './carousel-context'
 
 export interface CarouselIndicatorProps extends Assign<HTMLArkProps<'button'>, IndicatorProps> {}
 
-export const CarouselIndicator = defineComponent({
-  name: 'CarouselIndicator',
-  props: {
-    index: {
-      type: Number as PropType<CarouselIndicatorProps['index']>,
-      required: true,
-    },
-    readOnly: {
-      type: Boolean as PropType<CarouselIndicatorProps['readOnly']>,
-      default: false,
-    },
-  },
-  setup(props, { slots, attrs }) {
+export const CarouselIndicator = defineComponent<CarouselIndicatorProps>(
+  (props, { slots, attrs }) => {
     const api = useCarouselContext()
 
     return () => (
@@ -27,4 +16,17 @@ export const CarouselIndicator = defineComponent({
       </ark.button>
     )
   },
-})
+  {
+    name: 'CarouselIndicator',
+    props: {
+      index: {
+        type: Number as PropType<CarouselIndicatorProps['index']>,
+        required: true,
+      },
+      readOnly: {
+        type: Boolean as PropType<CarouselIndicatorProps['readOnly']>,
+        default: false,
+      },
+    },
+  },
+)

--- a/packages/frameworks/vue/src/carousel/carousel-item-group.tsx
+++ b/packages/frameworks/vue/src/carousel/carousel-item-group.tsx
@@ -4,9 +4,8 @@ import { useCarouselContext } from './carousel-context'
 
 export interface CarouselItemGroupProps extends HTMLArkProps<'div'> {}
 
-export const CarouselItemGroup = defineComponent({
-  name: 'CarouselItemGroup',
-  setup(_, { slots, attrs }) {
+export const CarouselItemGroup = defineComponent<CarouselItemGroupProps>(
+  (_, { slots, attrs }) => {
     const api = useCarouselContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const CarouselItemGroup = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'CarouselItemGroup',
+  },
+)

--- a/packages/frameworks/vue/src/carousel/carousel-item.tsx
+++ b/packages/frameworks/vue/src/carousel/carousel-item.tsx
@@ -6,15 +6,8 @@ import { useCarouselContext } from './carousel-context'
 
 export interface CarouselItemProps extends Assign<HTMLArkProps<'div'>, ItemProps> {}
 
-export const CarouselItem = defineComponent({
-  name: 'CarouselItem',
-  props: {
-    index: {
-      type: Number as PropType<CarouselItemProps['index']>,
-      required: true,
-    },
-  },
-  setup(props, { slots, attrs }) {
+export const CarouselItem = defineComponent<CarouselItemProps>(
+  (props, { slots, attrs }) => {
     const api = useCarouselContext()
 
     return () => (
@@ -23,4 +16,13 @@ export const CarouselItem = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'CarouselItem',
+    props: {
+      index: {
+        type: Number as PropType<CarouselItemProps['index']>,
+        required: true,
+      },
+    },
+  },
+)

--- a/packages/frameworks/vue/src/carousel/carousel-next-trigger.tsx
+++ b/packages/frameworks/vue/src/carousel/carousel-next-trigger.tsx
@@ -4,9 +4,8 @@ import { useCarouselContext } from './carousel-context'
 
 export interface CarouselNextTriggerProps extends HTMLArkProps<'button'> {}
 
-export const CarouselNextTrigger = defineComponent({
-  name: 'CarouselNextTrigger',
-  setup(_, { slots, attrs }) {
+export const CarouselNextTrigger = defineComponent<CarouselNextTriggerProps>(
+  (_, { slots, attrs }) => {
     const api = useCarouselContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const CarouselNextTrigger = defineComponent({
       </ark.button>
     )
   },
-})
+  {
+    name: 'CarouselNextTrigger',
+  },
+)

--- a/packages/frameworks/vue/src/carousel/carousel-prev-trigger.tsx
+++ b/packages/frameworks/vue/src/carousel/carousel-prev-trigger.tsx
@@ -4,9 +4,8 @@ import { useCarouselContext } from './carousel-context'
 
 export interface CarouselPrevTriggerProps extends HTMLArkProps<'button'> {}
 
-export const CarouselPrevTrigger = defineComponent({
-  name: 'CarouselPrevTrigger',
-  setup(_, { slots, attrs }) {
+export const CarouselPrevTrigger = defineComponent<CarouselPrevTriggerProps>(
+  (_, { slots, attrs }) => {
     const api = useCarouselContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const CarouselPrevTrigger = defineComponent({
       </ark.button>
     )
   },
-})
+  {
+    name: 'CarouselPrevTrigger',
+  },
+)

--- a/packages/frameworks/vue/src/carousel/carousel-viewport.tsx
+++ b/packages/frameworks/vue/src/carousel/carousel-viewport.tsx
@@ -4,9 +4,8 @@ import { useCarouselContext } from './carousel-context'
 
 export interface CarouselViewportProps extends HTMLArkProps<'div'> {}
 
-export const CarouselViewport = defineComponent({
-  name: 'CarouselViewport',
-  setup(_, { slots, attrs }) {
+export const CarouselViewport = defineComponent<CarouselViewportProps>(
+  (_, { slots, attrs }) => {
     const api = useCarouselContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const CarouselViewport = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'CarouselViewport',
+  },
+)

--- a/packages/frameworks/vue/src/carousel/carousel.props.ts
+++ b/packages/frameworks/vue/src/carousel/carousel.props.ts
@@ -35,5 +35,5 @@ export const props = {
   spacing: {
     type: String as PropType<Context['spacing']>,
   },
-}
+} as const
 export const emits = declareEmits(['index-change'])

--- a/packages/frameworks/vue/src/carousel/carousel.tsx
+++ b/packages/frameworks/vue/src/carousel/carousel.tsx
@@ -7,11 +7,8 @@ import { useCarousel, type UseCarouselProps } from './use-carousel'
 
 export interface CarouselProps extends Assign<HTMLArkProps<'div'>, UseCarouselProps> {}
 
-export const Carousel = defineComponent({
-  name: 'Carousel',
-  props,
-  emits,
-  setup(props, { slots, attrs, emit }) {
+export const Carousel = defineComponent<CarouselProps>(
+  (props, { slots, attrs, emit }) => {
     const api = useCarousel(props, emit)
     CarouselProvider(api)
 
@@ -21,4 +18,9 @@ export const Carousel = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'Carousel',
+    props,
+    emits,
+  },
+)

--- a/packages/frameworks/vue/src/checkbox/checkbox-control.tsx
+++ b/packages/frameworks/vue/src/checkbox/checkbox-control.tsx
@@ -1,13 +1,11 @@
 import { defineComponent } from 'vue'
 import { ark, type HTMLArkProps } from '../factory'
-import { type ComponentWithProps } from '../utils'
 import { useCheckboxContext } from './checkbox-context'
 
 export interface CheckboxControlProps extends HTMLArkProps<'div'> {}
 
-export const CheckboxControl: ComponentWithProps<CheckboxControlProps> = defineComponent({
-  name: 'CheckboxControl',
-  setup(_, { attrs, slots }) {
+export const CheckboxControl = defineComponent<CheckboxControlProps>(
+  (_, { attrs, slots }) => {
     const api = useCheckboxContext()
 
     return () => (
@@ -19,4 +17,7 @@ export const CheckboxControl: ComponentWithProps<CheckboxControlProps> = defineC
       </>
     )
   },
-})
+  {
+    name: 'CheckboxControl',
+  },
+)

--- a/packages/frameworks/vue/src/checkbox/checkbox-indicator.tsx
+++ b/packages/frameworks/vue/src/checkbox/checkbox-indicator.tsx
@@ -1,13 +1,11 @@
 import { defineComponent } from 'vue'
 import { ark, type HTMLArkProps } from '../factory'
-import { type ComponentWithProps } from '../utils'
 import { useCheckboxContext } from './checkbox-context'
 
 export interface CheckboxIndicatorProps extends HTMLArkProps<'div'> {}
 
-export const CheckboxIndicator: ComponentWithProps<CheckboxIndicatorProps> = defineComponent({
-  name: 'CheckboxIndicator',
-  setup(_, { attrs, slots }) {
+export const CheckboxIndicator = defineComponent<CheckboxIndicatorProps>(
+  (_, { attrs, slots }) => {
     const api = useCheckboxContext()
 
     return () => (
@@ -16,4 +14,7 @@ export const CheckboxIndicator: ComponentWithProps<CheckboxIndicatorProps> = def
       </ark.div>
     )
   },
-})
+  {
+    name: 'CheckboxIndicator',
+  },
+)

--- a/packages/frameworks/vue/src/checkbox/checkbox-label.tsx
+++ b/packages/frameworks/vue/src/checkbox/checkbox-label.tsx
@@ -1,13 +1,11 @@
 import { defineComponent } from 'vue'
 import { ark, type HTMLArkProps } from '../factory'
-import { type ComponentWithProps } from '../utils'
 import { useCheckboxContext } from './checkbox-context'
 
 export interface CheckboxLabelProps extends HTMLArkProps<'span'> {}
 
-export const CheckboxLabel: ComponentWithProps<CheckboxLabelProps> = defineComponent({
-  name: 'CheckboxLabel',
-  setup(_, { attrs, slots }) {
+export const CheckboxLabel = defineComponent<CheckboxLabelProps>(
+  (_, { attrs, slots }) => {
     const api = useCheckboxContext()
 
     return () => (
@@ -16,4 +14,7 @@ export const CheckboxLabel: ComponentWithProps<CheckboxLabelProps> = defineCompo
       </ark.span>
     )
   },
-})
+  {
+    name: 'CheckboxLabel',
+  },
+)

--- a/packages/frameworks/vue/src/checkbox/checkbox.tsx
+++ b/packages/frameworks/vue/src/checkbox/checkbox.tsx
@@ -7,11 +7,8 @@ import { useCheckbox, type UseCheckboxProps } from './use-checkbox'
 
 export interface CheckboxProps extends Assign<HTMLArkProps<'label'>, UseCheckboxProps> {}
 
-export const Checkbox = defineComponent({
-  name: 'Checkbox',
-  props,
-  emits,
-  setup(props, { slots, attrs, emit }) {
+export const Checkbox = defineComponent<CheckboxProps>(
+  (props, { slots, attrs, emit }) => {
     const api = useCheckbox(emit, props)
     CheckboxProvider(api)
 
@@ -21,4 +18,9 @@ export const Checkbox = defineComponent({
       </ark.label>
     )
   },
-})
+  {
+    name: 'Checkbox',
+    props,
+    emits,
+  },
+)

--- a/packages/frameworks/vue/src/color-picker/color-picker-area-background.tsx
+++ b/packages/frameworks/vue/src/color-picker/color-picker-area-background.tsx
@@ -5,9 +5,8 @@ import { useColorPickerContext } from './color-picker-context'
 
 export interface ColorPickerAreaBackgroundProps extends HTMLArkProps<'div'> {}
 
-export const ColorPickerAreaBackground = defineComponent({
-  name: 'ColorPickerAreaBackground',
-  setup(_, { slots, attrs }) {
+export const ColorPickerAreaBackground = defineComponent<ColorPickerAreaBackgroundProps>(
+  (_, { slots, attrs }) => {
     const api = useColorPickerContext()
     const areaProps = useColorPickerAreaContext()
 
@@ -17,4 +16,7 @@ export const ColorPickerAreaBackground = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'ColorPickerAreaBackground',
+  },
+)

--- a/packages/frameworks/vue/src/color-picker/color-picker-area-thumb.tsx
+++ b/packages/frameworks/vue/src/color-picker/color-picker-area-thumb.tsx
@@ -1,14 +1,12 @@
 import { defineComponent } from 'vue'
 import { ark, type HTMLArkProps } from '../factory'
-import type { ComponentWithProps } from '../utils'
 import { useColorPickerAreaContext } from './color-picker-area-context'
 import { useColorPickerContext } from './color-picker-context'
 
 export interface ColorPickerAreaThumbProps extends HTMLArkProps<'div'> {}
 
-export const ColorPickerAreaThumb: ComponentWithProps<ColorPickerAreaThumbProps> = defineComponent({
-  name: 'ColorPickerAreaThumb',
-  setup(_, { slots, attrs }) {
+export const ColorPickerAreaThumb = defineComponent<ColorPickerAreaThumbProps>(
+  (_, { slots, attrs }) => {
     const api = useColorPickerContext()
     const areaProps = useColorPickerAreaContext()
 
@@ -18,4 +16,7 @@ export const ColorPickerAreaThumb: ComponentWithProps<ColorPickerAreaThumbProps>
       </ark.div>
     )
   },
-})
+  {
+    name: 'ColorPickerAreaThumb',
+  },
+)

--- a/packages/frameworks/vue/src/color-picker/color-picker-area.tsx
+++ b/packages/frameworks/vue/src/color-picker/color-picker-area.tsx
@@ -7,17 +7,8 @@ import { useColorPickerContext } from './color-picker-context'
 
 export interface ColorPickerAreaProps extends Assign<HTMLArkProps<'div'>, AreaProps> {}
 
-export const ColorPickerArea = defineComponent({
-  name: 'ColorPickerArea',
-  props: {
-    xChannel: {
-      type: String as PropType<ColorPickerAreaProps['xChannel']>,
-    },
-    yChannel: {
-      type: String as PropType<ColorPickerAreaProps['yChannel']>,
-    },
-  },
-  setup(props, { slots, attrs }) {
+export const ColorPickerArea = defineComponent<ColorPickerAreaProps>(
+  (props, { slots, attrs }) => {
     const api = useColorPickerContext()
     const areaProps = computed<AreaProps>(() => ({
       xChannel: props.xChannel,
@@ -31,4 +22,15 @@ export const ColorPickerArea = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'ColorPickerArea',
+    props: {
+      xChannel: {
+        type: String as PropType<ColorPickerAreaProps['xChannel']>,
+      },
+      yChannel: {
+        type: String as PropType<ColorPickerAreaProps['yChannel']>,
+      },
+    },
+  },
+)

--- a/packages/frameworks/vue/src/color-picker/color-picker-channel-input.tsx
+++ b/packages/frameworks/vue/src/color-picker/color-picker-channel-input.tsx
@@ -7,18 +7,8 @@ import { useColorPickerContext } from './color-picker-context'
 export interface ColorPickerChannelInputProps
   extends Assign<HTMLArkProps<'input'>, ChannelInputProps> {}
 
-export const ColorPickerChannelInput = defineComponent({
-  name: 'ColorPickerChannelInput',
-  props: {
-    channel: {
-      type: String as PropType<ChannelInputProps['channel']>,
-      required: true,
-    },
-    orientation: {
-      type: String as PropType<ChannelInputProps['orientation']>,
-    },
-  },
-  setup(props, { slots, attrs }) {
+export const ColorPickerChannelInput = defineComponent<ColorPickerChannelInputProps>(
+  (props, { slots, attrs }) => {
     const api = useColorPickerContext()
 
     const channelProps = computed(() => ({
@@ -32,4 +22,16 @@ export const ColorPickerChannelInput = defineComponent({
       </ark.input>
     )
   },
-})
+  {
+    name: 'ColorPickerChannelInput',
+    props: {
+      channel: {
+        type: String as PropType<ChannelInputProps['channel']>,
+        required: true,
+      },
+      orientation: {
+        type: String as PropType<ChannelInputProps['orientation']>,
+      },
+    },
+  },
+)

--- a/packages/frameworks/vue/src/color-picker/color-picker-channel-slider-thumb.tsx
+++ b/packages/frameworks/vue/src/color-picker/color-picker-channel-slider-thumb.tsx
@@ -1,22 +1,22 @@
 import { defineComponent } from 'vue'
 import { ark, type HTMLArkProps } from '../factory'
-import type { ComponentWithProps } from '../utils'
 import { useColorPickerChannelSliderContext } from './color-picker-channel-slider-context'
 import { useColorPickerContext } from './color-picker-context'
 
 export interface ColorPickerChannelSliderThumbProps extends HTMLArkProps<'div'> {}
 
-export const ColorPickerChannelSliderThumb: ComponentWithProps<ColorPickerChannelSliderThumbProps> =
-  defineComponent({
-    name: 'ColorPickerChannelSliderThumb',
-    setup(_, { slots, attrs }) {
-      const api = useColorPickerContext()
-      const sliderProps = useColorPickerChannelSliderContext()
+export const ColorPickerChannelSliderThumb = defineComponent<ColorPickerChannelSliderThumbProps>(
+  (_, { slots, attrs }) => {
+    const api = useColorPickerContext()
+    const sliderProps = useColorPickerChannelSliderContext()
 
-      return () => (
-        <ark.div {...api.value.getChannelSliderThumbProps(sliderProps)} {...attrs}>
-          {slots.default?.()}
-        </ark.div>
-      )
-    },
-  })
+    return () => (
+      <ark.div {...api.value.getChannelSliderThumbProps(sliderProps)} {...attrs}>
+        {slots.default?.()}
+      </ark.div>
+    )
+  },
+  {
+    name: 'ColorPickerChannelSliderThumb',
+  },
+)

--- a/packages/frameworks/vue/src/color-picker/color-picker-channel-slider-track.tsx
+++ b/packages/frameworks/vue/src/color-picker/color-picker-channel-slider-track.tsx
@@ -5,9 +5,8 @@ import { useColorPickerContext } from './color-picker-context'
 
 export interface ColorPickerChannelSliderTrackProps extends HTMLArkProps<'div'> {}
 
-export const ColorPickerChannelSliderTrack = defineComponent({
-  name: 'ColorPickerChannelSliderTrack',
-  setup(_, { slots, attrs }) {
+export const ColorPickerChannelSliderTrack = defineComponent<ColorPickerChannelSliderTrackProps>(
+  (_, { slots, attrs }) => {
     const api = useColorPickerContext()
     const sliderProps = useColorPickerChannelSliderContext()
 
@@ -17,4 +16,7 @@ export const ColorPickerChannelSliderTrack = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'ColorPickerChannelSliderTrack',
+  },
+)

--- a/packages/frameworks/vue/src/color-picker/color-picker-channel-slider.tsx
+++ b/packages/frameworks/vue/src/color-picker/color-picker-channel-slider.tsx
@@ -7,18 +7,8 @@ import { useColorPickerContext } from './color-picker-context'
 
 export interface ColorPickerChannelSliderProps extends Assign<HTMLArkProps<'div'>, ChannelProps> {}
 
-export const ColorPickerChannelSlider = defineComponent({
-  name: 'ColorPickerChannelSlider',
-  props: {
-    channel: {
-      type: String as PropType<ColorPickerChannelSliderProps['channel']>,
-      required: true,
-    },
-    orientation: {
-      type: String as PropType<ColorPickerChannelSliderProps['orientation']>,
-    },
-  },
-  setup(props, { slots, attrs }) {
+export const ColorPickerChannelSlider = defineComponent<ColorPickerChannelSliderProps>(
+  (props, { slots, attrs }) => {
     const api = useColorPickerContext()
     ColorPickerChannelSliderProvider(reactive(props))
 
@@ -28,4 +18,16 @@ export const ColorPickerChannelSlider = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'ColorPickerChannelSlider',
+    props: {
+      channel: {
+        type: String as PropType<ColorPickerChannelSliderProps['channel']>,
+        required: true,
+      },
+      orientation: {
+        type: String as PropType<ColorPickerChannelSliderProps['orientation']>,
+      },
+    },
+  },
+)

--- a/packages/frameworks/vue/src/color-picker/color-picker-content.tsx
+++ b/packages/frameworks/vue/src/color-picker/color-picker-content.tsx
@@ -7,11 +7,8 @@ import { useColorPickerContext } from './color-picker-context'
 
 export interface ColorPickerContentProps extends Assign<HTMLArkProps<'div'>, PresenceProps> {}
 
-export const ColorPickerContent = defineComponent({
-  name: 'ColorPickerContent',
-  props,
-  emits,
-  setup(props, { slots, attrs }) {
+export const ColorPickerContent = defineComponent<ColorPickerContentProps>(
+  (props, { slots, attrs }) => {
     const api = useColorPickerContext()
 
     return () => (
@@ -22,4 +19,9 @@ export const ColorPickerContent = defineComponent({
       </Presence>
     )
   },
-})
+  {
+    name: 'ColorPickerContent',
+    props,
+    emits,
+  },
+)

--- a/packages/frameworks/vue/src/color-picker/color-picker-control.tsx
+++ b/packages/frameworks/vue/src/color-picker/color-picker-control.tsx
@@ -4,9 +4,8 @@ import { useColorPickerContext } from './color-picker-context'
 
 export interface ColorPickerControlProps extends HTMLArkProps<'div'> {}
 
-export const ColorPickerControl = defineComponent({
-  name: 'ColorPickerControl',
-  setup(_, { slots, attrs }) {
+export const ColorPickerControl = defineComponent<ColorPickerControlProps>(
+  (_, { slots, attrs }) => {
     const api = useColorPickerContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const ColorPickerControl = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'ColorPickerControl',
+  },
+)

--- a/packages/frameworks/vue/src/color-picker/color-picker-eye-dropper-trigger.tsx
+++ b/packages/frameworks/vue/src/color-picker/color-picker-eye-dropper-trigger.tsx
@@ -4,9 +4,8 @@ import { useColorPickerContext } from './color-picker-context'
 
 export interface ColorPickerEyeDropperTriggerProps extends HTMLArkProps<'button'> {}
 
-export const ColorPickerEyeDropperTrigger = defineComponent({
-  name: 'ColorPickerEyeDropperTrigger',
-  setup(_, { slots, attrs }) {
+export const ColorPickerEyeDropperTrigger = defineComponent<ColorPickerEyeDropperTriggerProps>(
+  (_, { slots, attrs }) => {
     const api = useColorPickerContext()
     return () => (
       <ark.button {...api.value.eyeDropperTriggerProps} {...attrs}>
@@ -14,4 +13,7 @@ export const ColorPickerEyeDropperTrigger = defineComponent({
       </ark.button>
     )
   },
-})
+  {
+    name: 'ColorPickerEyeDropperTrigger',
+  },
+)

--- a/packages/frameworks/vue/src/color-picker/color-picker-format-select.tsx
+++ b/packages/frameworks/vue/src/color-picker/color-picker-format-select.tsx
@@ -4,9 +4,8 @@ import { useColorPickerContext } from './color-picker-context'
 
 export interface ColorPickerFormatSelectProps extends HTMLArkProps<'button'> {}
 
-export const ColorPickerFormatSelect = defineComponent({
-  name: 'ColorPickerFormatSelect',
-  setup(_, { attrs }) {
+export const ColorPickerFormatSelect = defineComponent<ColorPickerFormatSelectProps>(
+  (_, { attrs }) => {
     const api = useColorPickerContext()
 
     return () => (
@@ -19,4 +18,7 @@ export const ColorPickerFormatSelect = defineComponent({
       </ark.select>
     )
   },
-})
+  {
+    name: 'ColorPickerFormatSelect',
+  },
+)

--- a/packages/frameworks/vue/src/color-picker/color-picker-format-trigger.tsx
+++ b/packages/frameworks/vue/src/color-picker/color-picker-format-trigger.tsx
@@ -4,9 +4,8 @@ import { useColorPickerContext } from './color-picker-context'
 
 export interface ColorPickerFormatTriggerProps extends HTMLArkProps<'button'> {}
 
-export const ColorPickerFormatTrigger = defineComponent({
-  name: 'ColorPickerFormatTrigger',
-  setup(_, { slots, attrs }) {
+export const ColorPickerFormatTrigger = defineComponent<ColorPickerFormatTriggerProps>(
+  (_, { slots, attrs }) => {
     const api = useColorPickerContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const ColorPickerFormatTrigger = defineComponent({
       </ark.button>
     )
   },
-})
+  {
+    name: 'ColorPickerFormatTrigger',
+  },
+)

--- a/packages/frameworks/vue/src/color-picker/color-picker-label.tsx
+++ b/packages/frameworks/vue/src/color-picker/color-picker-label.tsx
@@ -4,9 +4,8 @@ import { useColorPickerContext } from './color-picker-context'
 
 export interface ColorPickerLabelProps extends HTMLArkProps<'label'> {}
 
-export const ColorPickerLabel = defineComponent({
-  name: 'ColorPickerLabel',
-  setup(_, { slots, attrs }) {
+export const ColorPickerLabel = defineComponent<ColorPickerLabelProps>(
+  (_, { slots, attrs }) => {
     const api = useColorPickerContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const ColorPickerLabel = defineComponent({
       </ark.label>
     )
   },
-})
+  {
+    name: 'ColorPickerLabel',
+  },
+)

--- a/packages/frameworks/vue/src/color-picker/color-picker-positioner.tsx
+++ b/packages/frameworks/vue/src/color-picker/color-picker-positioner.tsx
@@ -4,9 +4,8 @@ import { useColorPickerContext } from './color-picker-context'
 
 export interface ColorPickerPositionerProps extends HTMLArkProps<'div'> {}
 
-export const ColorPickerPositioner = defineComponent({
-  name: 'ColorPickerPositioner',
-  setup(_, { slots, attrs }) {
+export const ColorPickerPositioner = defineComponent<ColorPickerPositionerProps>(
+  (_, { slots, attrs }) => {
     const api = useColorPickerContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const ColorPickerPositioner = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'ColorPickerPositioner',
+  },
+)

--- a/packages/frameworks/vue/src/color-picker/color-picker-swatch-group.tsx
+++ b/packages/frameworks/vue/src/color-picker/color-picker-swatch-group.tsx
@@ -4,13 +4,15 @@ import { ark, type HTMLArkProps } from '../factory'
 
 export interface ColorPickerSwatchGroupProps extends HTMLArkProps<'div'> {}
 
-export const ColorPickerSwatchGroup = defineComponent({
-  name: 'ColorPickerSwatchGroup',
-  setup(_, { slots, attrs }) {
+export const ColorPickerSwatchGroup = defineComponent<ColorPickerSwatchGroupProps>(
+  (_, { slots, attrs }) => {
     return () => (
       <ark.div {...colorPickerAnatomy.build().swatchGroup.attrs} {...attrs}>
         {slots.default?.()}
       </ark.div>
     )
   },
-})
+  {
+    name: 'ColorPickerSwatchGroup',
+  },
+)

--- a/packages/frameworks/vue/src/color-picker/color-picker-swatch-indicator.tsx
+++ b/packages/frameworks/vue/src/color-picker/color-picker-swatch-indicator.tsx
@@ -7,9 +7,8 @@ import { useColorPickerSwatchContext } from './color-picker-swatch-context'
 
 export interface ColorPickerSwatchIndicatorProps extends Assign<HTMLArkProps<'div'>, SwatchProps> {}
 
-export const ColorPickerSwatchIndicator = defineComponent({
-  name: 'ColorPickerSwatchIndicator',
-  setup(_, { slots, attrs }) {
+export const ColorPickerSwatchIndicator = defineComponent<ColorPickerSwatchIndicatorProps>(
+  (_, { slots, attrs }) => {
     const api = useColorPickerContext()
     const swatchProps = useColorPickerSwatchContext()
 
@@ -19,4 +18,7 @@ export const ColorPickerSwatchIndicator = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'ColorPickerSwatchIndicator',
+  },
+)

--- a/packages/frameworks/vue/src/color-picker/color-picker-swatch-trigger.tsx
+++ b/packages/frameworks/vue/src/color-picker/color-picker-swatch-trigger.tsx
@@ -7,18 +7,8 @@ import { useColorPickerContext } from './color-picker-context'
 export interface ColorPickerSwatchTriggerProps
   extends Assign<HTMLArkProps<'button'>, SwatchTriggerProps> {}
 
-export const ColorPickerSwatchTrigger = defineComponent({
-  name: 'ColorPickerSwatchTrigger',
-  props: {
-    value: {
-      type: [String, Object] as PropType<SwatchTriggerProps['value']>,
-      required: true,
-    },
-    disabled: {
-      type: [String, Object] as PropType<SwatchTriggerProps['disabled']>,
-    },
-  },
-  setup(props, { slots, attrs }) {
+export const ColorPickerSwatchTrigger = defineComponent<ColorPickerSwatchTriggerProps>(
+  (props, { slots, attrs }) => {
     const api = useColorPickerContext()
 
     return () => (
@@ -27,4 +17,16 @@ export const ColorPickerSwatchTrigger = defineComponent({
       </ark.button>
     )
   },
-})
+  {
+    name: 'ColorPickerSwatchTrigger',
+    props: {
+      value: {
+        type: [String, Object] as PropType<SwatchTriggerProps['value']>,
+        required: true,
+      },
+      disabled: {
+        type: [String, Object] as PropType<SwatchTriggerProps['disabled']>,
+      },
+    },
+  },
+)

--- a/packages/frameworks/vue/src/color-picker/color-picker-swatch.tsx
+++ b/packages/frameworks/vue/src/color-picker/color-picker-swatch.tsx
@@ -7,19 +7,8 @@ import { ColorPickerSwatchProvider } from './color-picker-swatch-context'
 
 export interface ColorPickerSwatchProps extends Assign<HTMLArkProps<'button'>, SwatchProps> {}
 
-export const ColorPickerSwatch = defineComponent({
-  name: 'ColorPickerSwatch',
-  props: {
-    readOnly: {
-      type: Boolean as PropType<SwatchProps['respectAlpha']>,
-      default: undefined,
-    },
-    value: {
-      type: [String, Object] as PropType<SwatchProps['value']>,
-      required: true,
-    },
-  },
-  setup(props, { slots, attrs }) {
+export const ColorPickerSwatch = defineComponent<ColorPickerSwatchProps>(
+  (props, { slots, attrs }) => {
     const api = useColorPickerContext()
     ColorPickerSwatchProvider(reactive(props))
 
@@ -29,4 +18,17 @@ export const ColorPickerSwatch = defineComponent({
       </ark.button>
     )
   },
-})
+  {
+    name: 'ColorPickerSwatch',
+    props: {
+      readOnly: {
+        type: Boolean as PropType<SwatchProps['respectAlpha']>,
+        default: undefined,
+      },
+      value: {
+        type: [String, Object] as PropType<SwatchProps['value']>,
+        required: true,
+      },
+    },
+  },
+)

--- a/packages/frameworks/vue/src/color-picker/color-picker-transparency-grid.tsx
+++ b/packages/frameworks/vue/src/color-picker/color-picker-transparency-grid.tsx
@@ -7,14 +7,8 @@ import { useColorPickerContext } from './color-picker-context'
 export interface ColorPickerTransparencyGridProps
   extends Assign<HTMLArkProps<'div'>, TransparencyGridProps> {}
 
-export const ColorPickerTransparencyGrid = defineComponent({
-  name: 'ColorPickerTransparencyGrid',
-  props: {
-    size: {
-      type: String as PropType<ColorPickerTransparencyGridProps['size']>,
-    },
-  },
-  setup(props, { slots, attrs }) {
+export const ColorPickerTransparencyGrid = defineComponent<ColorPickerTransparencyGridProps>(
+  (props, { slots, attrs }) => {
     const api = useColorPickerContext()
 
     return () => (
@@ -23,4 +17,12 @@ export const ColorPickerTransparencyGrid = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'ColorPickerTransparencyGrid',
+    props: {
+      size: {
+        type: String as PropType<ColorPickerTransparencyGridProps['size']>,
+      },
+    },
+  },
+)

--- a/packages/frameworks/vue/src/color-picker/color-picker-trigger.tsx
+++ b/packages/frameworks/vue/src/color-picker/color-picker-trigger.tsx
@@ -4,9 +4,8 @@ import { useColorPickerContext } from './color-picker-context'
 
 export interface ColorPickerTriggerProps extends HTMLArkProps<'button'> {}
 
-export const ColorPickerTrigger = defineComponent({
-  name: 'ColorPickerTrigger',
-  setup(_, { slots, attrs }) {
+export const ColorPickerTrigger = defineComponent<ColorPickerTriggerProps>(
+  (_, { slots, attrs }) => {
     const api = useColorPickerContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const ColorPickerTrigger = defineComponent({
       </ark.button>
     )
   },
-})
+  {
+    name: 'ColorPickerTrigger',
+  },
+)

--- a/packages/frameworks/vue/src/color-picker/color-picker-value-text.tsx
+++ b/packages/frameworks/vue/src/color-picker/color-picker-value-text.tsx
@@ -5,14 +5,8 @@ import { useColorPickerContext } from './color-picker-context'
 
 export interface ColorPickerValueTextProps extends HTMLArkProps<'span'> {}
 
-export const ColorPickerValueText = defineComponent({
-  name: 'ColorPickerValueText',
-  props: {
-    placeholder: {
-      type: String,
-    },
-  },
-  setup(_, { slots, attrs }) {
+export const ColorPickerValueText = defineComponent<ColorPickerValueTextProps>(
+  (_, { slots, attrs }) => {
     const api = useColorPickerContext()
 
     return () => (
@@ -21,4 +15,12 @@ export const ColorPickerValueText = defineComponent({
       </ark.span>
     )
   },
-})
+  {
+    name: 'ColorPickerValueText',
+    props: {
+      placeholder: {
+        type: String,
+      },
+    },
+  },
+)

--- a/packages/frameworks/vue/src/color-picker/color-picker-view.tsx
+++ b/packages/frameworks/vue/src/color-picker/color-picker-view.tsx
@@ -9,15 +9,8 @@ export interface ColorPickerViewProps {
   format: ColorFormat
 }
 
-export const ColorPickerView = defineComponent({
-  name: 'ColorPickerView',
-  props: {
-    format: {
-      type: String as PropType<ColorPickerViewProps['format']>,
-      required: true,
-    },
-  },
-  setup(props, { slots, attrs }) {
+export const ColorPickerView = defineComponent<ColorPickerViewProps>(
+  (props, { slots, attrs }) => {
     const api = useColorPickerContext()
     return () =>
       api.value.format === props.format ? (
@@ -26,4 +19,13 @@ export const ColorPickerView = defineComponent({
         </ark.div>
       ) : null
   },
-})
+  {
+    name: 'ColorPickerView',
+    props: {
+      format: {
+        type: String as PropType<ColorPickerViewProps['format']>,
+        required: true,
+      },
+    },
+  },
+)

--- a/packages/frameworks/vue/src/color-picker/color-picker.tsx
+++ b/packages/frameworks/vue/src/color-picker/color-picker.tsx
@@ -7,11 +7,8 @@ import { useColorPicker, type UseColorPickerProps } from './use-color-picker'
 
 export interface ColorPickerProps extends Assign<HTMLArkProps<'div'>, UseColorPickerProps> {}
 
-export const ColorPicker = defineComponent({
-  name: 'ColorPicker',
-  props,
-  emits,
-  setup(props, { slots, emit, attrs }) {
+export const ColorPicker = defineComponent<ColorPickerProps>(
+  (props, { slots, emit, attrs }) => {
     const api = useColorPicker(props, emit)
     ColorPickerProvider(api)
 
@@ -24,4 +21,9 @@ export const ColorPicker = defineComponent({
       </>
     )
   },
-})
+  {
+    name: 'ColorPicker',
+    props,
+    emits,
+  },
+)

--- a/packages/frameworks/vue/src/combobox/combobox-clear-trigger.tsx
+++ b/packages/frameworks/vue/src/combobox/combobox-clear-trigger.tsx
@@ -4,8 +4,8 @@ import { useComboboxContext } from './combobox-context'
 
 export interface ComboboxClearTriggerProps extends HTMLArkProps<'button'> {}
 
-export const ComboboxClearTrigger = defineComponent({
-  setup(_, { slots, attrs }) {
+export const ComboboxClearTrigger = defineComponent<ComboboxClearTriggerProps>(
+  (_, { slots, attrs }) => {
     const api = useComboboxContext()
 
     return () => (
@@ -14,4 +14,5 @@ export const ComboboxClearTrigger = defineComponent({
       </ark.button>
     )
   },
-})
+  {},
+)

--- a/packages/frameworks/vue/src/combobox/combobox-content.tsx
+++ b/packages/frameworks/vue/src/combobox/combobox-content.tsx
@@ -6,11 +6,8 @@ import { useComboboxContext } from './combobox-context'
 
 export interface ComboboxContentProps extends HTMLArkProps<'div'>, PresenceProps {}
 
-export const ComboboxContent = defineComponent({
-  name: 'ComboboxContent',
-  props,
-  emits,
-  setup(props, { slots, attrs }) {
+export const ComboboxContent = defineComponent<ComboboxContentProps>(
+  (props, { slots, attrs }) => {
     const api = useComboboxContext()
 
     return () => (
@@ -21,4 +18,9 @@ export const ComboboxContent = defineComponent({
       </Presence>
     )
   },
-})
+  {
+    name: 'ComboboxContent',
+    props,
+    emits,
+  },
+)

--- a/packages/frameworks/vue/src/combobox/combobox-control.tsx
+++ b/packages/frameworks/vue/src/combobox/combobox-control.tsx
@@ -4,9 +4,8 @@ import { useComboboxContext } from './combobox-context'
 
 export interface ComboboxControlProps extends HTMLArkProps<'div'> {}
 
-export const ComboboxControl = defineComponent({
-  name: 'ComboboxControl',
-  setup(_, { slots, attrs }) {
+export const ComboboxControl = defineComponent<ComboboxControlProps>(
+  (_, { slots, attrs }) => {
     const api = useComboboxContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const ComboboxControl = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'ComboboxControl',
+  },
+)

--- a/packages/frameworks/vue/src/combobox/combobox-input.tsx
+++ b/packages/frameworks/vue/src/combobox/combobox-input.tsx
@@ -4,9 +4,8 @@ import { useComboboxContext } from './combobox-context'
 
 export interface ComboboxInputProps extends HTMLArkProps<'input'> {}
 
-export const ComboboxInput = defineComponent({
-  name: 'ComboboxInput',
-  setup(_, { slots, attrs }) {
+export const ComboboxInput = defineComponent<ComboboxInputProps>(
+  (_, { slots, attrs }) => {
     const api = useComboboxContext()
 
     const inputProps = computed(() => ({
@@ -20,4 +19,7 @@ export const ComboboxInput = defineComponent({
       </ark.input>
     )
   },
-})
+  {
+    name: 'ComboboxInput',
+  },
+)

--- a/packages/frameworks/vue/src/combobox/combobox-item-group-label.tsx
+++ b/packages/frameworks/vue/src/combobox/combobox-item-group-label.tsx
@@ -7,15 +7,8 @@ import { useComboboxContext } from './combobox-context'
 export interface ComboboxItemGroupLabelProps
   extends Assign<HTMLArkProps<'div'>, ItemGroupLabelProps> {}
 
-export const ComboboxItemGroupLabel = defineComponent({
-  name: 'ComboboxItemGroupLabel',
-  props: {
-    htmlFor: {
-      type: String as PropType<ComboboxItemGroupLabelProps['htmlFor']>,
-      required: true,
-    },
-  },
-  setup(props, { slots, attrs }) {
+export const ComboboxItemGroupLabel = defineComponent<ComboboxItemGroupLabelProps>(
+  (props, { slots, attrs }) => {
     const api = useComboboxContext()
 
     return () => (
@@ -24,4 +17,13 @@ export const ComboboxItemGroupLabel = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'ComboboxItemGroupLabel',
+    props: {
+      htmlFor: {
+        type: String as PropType<ComboboxItemGroupLabelProps['htmlFor']>,
+        required: true,
+      },
+    },
+  },
+)

--- a/packages/frameworks/vue/src/combobox/combobox-item-group.tsx
+++ b/packages/frameworks/vue/src/combobox/combobox-item-group.tsx
@@ -6,15 +6,8 @@ import { useComboboxContext } from './combobox-context'
 
 export interface ComboboxItemGroupProps extends Assign<HTMLArkProps<'div'>, ItemGroupProps> {}
 
-export const ComboboxItemGroup = defineComponent({
-  name: 'ComboboxItemGroup',
-  props: {
-    id: {
-      type: String as PropType<ComboboxItemGroupProps['id']>,
-      required: true,
-    },
-  },
-  setup(props, { slots, attrs }) {
+export const ComboboxItemGroup = defineComponent<ComboboxItemGroupProps>(
+  (props, { slots, attrs }) => {
     const api = useComboboxContext()
 
     return () => (
@@ -23,4 +16,13 @@ export const ComboboxItemGroup = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'ComboboxItemGroup',
+    props: {
+      id: {
+        type: String as PropType<ComboboxItemGroupProps['id']>,
+        required: true,
+      },
+    },
+  },
+)

--- a/packages/frameworks/vue/src/combobox/combobox-item-indicator.tsx
+++ b/packages/frameworks/vue/src/combobox/combobox-item-indicator.tsx
@@ -5,9 +5,8 @@ import { useComboboxItemContext } from './combobox-item-context'
 
 export interface ComboboxItemIndicatorProps extends HTMLArkProps<'div'> {}
 
-export const ComboboxItemIndicator = defineComponent({
-  name: 'ComboboxItemIndicator',
-  setup(_, { slots, attrs }) {
+export const ComboboxItemIndicator = defineComponent<ComboboxItemIndicatorProps>(
+  (_, { slots, attrs }) => {
     const api = useComboboxContext()
     const itemProps = useComboboxItemContext()
 
@@ -17,4 +16,7 @@ export const ComboboxItemIndicator = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'ComboboxItemIndicator',
+  },
+)

--- a/packages/frameworks/vue/src/combobox/combobox-item-text.tsx
+++ b/packages/frameworks/vue/src/combobox/combobox-item-text.tsx
@@ -5,9 +5,8 @@ import { useComboboxItemContext } from './combobox-item-context'
 
 export interface ComboboxItemTextProps extends HTMLArkProps<'span'> {}
 
-export const ComboboxItemText = defineComponent({
-  name: 'ComboboxItemText',
-  setup(_, { slots, attrs }) {
+export const ComboboxItemText = defineComponent<ComboboxItemTextProps>(
+  (_, { slots, attrs }) => {
     const api = useComboboxContext()
     const itemProps = useComboboxItemContext()
 
@@ -17,4 +16,7 @@ export const ComboboxItemText = defineComponent({
       </ark.span>
     )
   },
-})
+  {
+    name: 'ComboboxItemText',
+  },
+)

--- a/packages/frameworks/vue/src/combobox/combobox-item.tsx
+++ b/packages/frameworks/vue/src/combobox/combobox-item.tsx
@@ -7,15 +7,8 @@ import { ComboboxItemProvider } from './combobox-item-context'
 
 export interface ComboboxItemProps extends Assign<HTMLArkProps<'div'>, ItemProps> {}
 
-export const ComboboxItem = defineComponent({
-  name: 'ComboboxItem',
-  props: {
-    item: {
-      type: Object as PropType<ComboboxItemProps['item']>,
-      required: true,
-    },
-  },
-  setup(props, { slots, attrs }) {
+export const ComboboxItem = defineComponent<ComboboxItemProps>(
+  (props, { slots, attrs }) => {
     const api = useComboboxContext()
     ComboboxItemProvider(computed(() => props))
 
@@ -25,4 +18,13 @@ export const ComboboxItem = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'ComboboxItem',
+    props: {
+      item: {
+        type: Object as PropType<ComboboxItemProps['item']>,
+        required: true,
+      },
+    },
+  },
+)

--- a/packages/frameworks/vue/src/combobox/combobox-label.tsx
+++ b/packages/frameworks/vue/src/combobox/combobox-label.tsx
@@ -4,9 +4,8 @@ import { useComboboxContext } from './combobox-context'
 
 export interface ComboboxLabelProps extends HTMLArkProps<'label'> {}
 
-export const ComboboxLabel = defineComponent({
-  name: 'ComboboxLabel',
-  setup(_, { slots, attrs }) {
+export const ComboboxLabel = defineComponent<ComboboxLabelProps>(
+  (_, { slots, attrs }) => {
     const api = useComboboxContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const ComboboxLabel = defineComponent({
       </ark.label>
     )
   },
-})
+  {
+    name: 'ComboboxLabel',
+  },
+)

--- a/packages/frameworks/vue/src/combobox/combobox-positioner.tsx
+++ b/packages/frameworks/vue/src/combobox/combobox-positioner.tsx
@@ -4,9 +4,8 @@ import { useComboboxContext } from './combobox-context'
 
 export interface ComboboxPositionerProps extends HTMLArkProps<'div'> {}
 
-export const ComboboxPositioner = defineComponent({
-  name: 'ComboboxPositioner',
-  setup(_, { slots, attrs }) {
+export const ComboboxPositioner = defineComponent<ComboboxPositionerProps>(
+  (_, { slots, attrs }) => {
     const api = useComboboxContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const ComboboxPositioner = defineComponent({
       </ark.ul>
     )
   },
-})
+  {
+    name: 'ComboboxPositioner',
+  },
+)

--- a/packages/frameworks/vue/src/combobox/combobox-trigger.tsx
+++ b/packages/frameworks/vue/src/combobox/combobox-trigger.tsx
@@ -4,8 +4,8 @@ import { useComboboxContext } from './combobox-context'
 
 export interface ComboboxTriggerProps extends HTMLArkProps<'button'> {}
 
-export const ComboboxTrigger = defineComponent({
-  setup(_, { slots, attrs }) {
+export const ComboboxTrigger = defineComponent<ComboboxTriggerProps>(
+  (_, { slots, attrs }) => {
     const api = useComboboxContext()
 
     return () => (
@@ -14,4 +14,7 @@ export const ComboboxTrigger = defineComponent({
       </ark.button>
     )
   },
-})
+  {
+    name: 'ComboboxTrigger',
+  },
+)

--- a/packages/frameworks/vue/src/date-picker/date-picker-clear-trigger.tsx
+++ b/packages/frameworks/vue/src/date-picker/date-picker-clear-trigger.tsx
@@ -4,9 +4,8 @@ import { useDatePickerContext } from './date-picker-context'
 
 export interface DatePickerClearTriggerProps extends HTMLArkProps<'button'> {}
 
-export const DatePickerClearTrigger = defineComponent({
-  name: 'DatePickerClearTrigger',
-  setup(_, { attrs, slots }) {
+export const DatePickerClearTrigger = defineComponent<DatePickerClearTriggerProps>(
+  (_, { attrs, slots }) => {
     const api = useDatePickerContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const DatePickerClearTrigger = defineComponent({
       </ark.button>
     )
   },
-})
+  {
+    name: 'DatePickerClearTrigger',
+  },
+)

--- a/packages/frameworks/vue/src/date-picker/date-picker-content.tsx
+++ b/packages/frameworks/vue/src/date-picker/date-picker-content.tsx
@@ -4,9 +4,8 @@ import { useDatePickerContext } from './date-picker-context'
 
 export interface DatePickerContentProps extends HTMLArkProps<'div'> {}
 
-export const DatePickerContent = defineComponent({
-  name: 'DatePickerContent',
-  setup(_, { attrs, slots }) {
+export const DatePickerContent = defineComponent<DatePickerContentProps>(
+  (_, { attrs, slots }) => {
     const api = useDatePickerContext()
 
     // if (presenceApi.isUnmounted) {
@@ -19,4 +18,7 @@ export const DatePickerContent = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'DatePickerContent',
+  },
+)

--- a/packages/frameworks/vue/src/date-picker/date-picker-control.tsx
+++ b/packages/frameworks/vue/src/date-picker/date-picker-control.tsx
@@ -4,9 +4,8 @@ import { useDatePickerContext } from './date-picker-context'
 
 export interface DatePickerControlProps extends HTMLArkProps<'div'> {}
 
-export const DatePickerControl = defineComponent({
-  name: 'DatePickerControl',
-  setup(_, { attrs, slots }) {
+export const DatePickerControl = defineComponent<DatePickerControlProps>(
+  (_, { attrs, slots }) => {
     const api = useDatePickerContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const DatePickerControl = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'DatePickerControl',
+  },
+)

--- a/packages/frameworks/vue/src/date-picker/date-picker-input.tsx
+++ b/packages/frameworks/vue/src/date-picker/date-picker-input.tsx
@@ -4,11 +4,13 @@ import { useDatePickerContext } from './date-picker-context'
 
 export interface DatePickerInputProps extends HTMLArkProps<'input'> {}
 
-export const DatePickerInput = defineComponent({
-  name: 'DatePickerInput',
-  setup(_, { attrs }) {
+export const DatePickerInput = defineComponent<DatePickerInputProps>(
+  (_, { attrs }) => {
     const api = useDatePickerContext()
 
     return () => <ark.input {...api.value.inputProps} {...attrs} />
   },
-})
+  {
+    name: 'DatePickerInput',
+  },
+)

--- a/packages/frameworks/vue/src/date-picker/date-picker-label.tsx
+++ b/packages/frameworks/vue/src/date-picker/date-picker-label.tsx
@@ -4,9 +4,8 @@ import { useDatePickerContext } from './date-picker-context'
 
 export interface DatePickerLabelProps extends HTMLArkProps<'label'> {}
 
-export const DatePickerLabel = defineComponent({
-  name: 'DatePickerLabel',
-  setup(_, { attrs, slots }) {
+export const DatePickerLabel = defineComponent<DatePickerLabelProps>(
+  (_, { attrs, slots }) => {
     const api = useDatePickerContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const DatePickerLabel = defineComponent({
       </ark.label>
     )
   },
-})
+  {
+    name: 'DatePickerLabel',
+  },
+)

--- a/packages/frameworks/vue/src/date-picker/date-picker-month-select.tsx
+++ b/packages/frameworks/vue/src/date-picker/date-picker-month-select.tsx
@@ -4,9 +4,8 @@ import { useDatePickerContext } from './date-picker-context'
 
 export interface DatePickerMonthSelectProps extends HTMLArkProps<'select'> {}
 
-export const DatePickerMonthSelect = defineComponent({
-  name: 'DatePickerMonthSelect',
-  setup(_, { attrs }) {
+export const DatePickerMonthSelect = defineComponent<DatePickerMonthSelectProps>(
+  (_, { attrs }) => {
     const api = useDatePickerContext()
 
     return () => (
@@ -19,4 +18,7 @@ export const DatePickerMonthSelect = defineComponent({
       </ark.select>
     )
   },
-})
+  {
+    name: 'DatePickerMonthSelect',
+  },
+)

--- a/packages/frameworks/vue/src/date-picker/date-picker-next-trigger.tsx
+++ b/packages/frameworks/vue/src/date-picker/date-picker-next-trigger.tsx
@@ -5,9 +5,8 @@ import { useDatePickerViewContext } from './date-picker-view-context'
 
 export interface DatePickerNextTriggerProps extends HTMLArkProps<'button'> {}
 
-export const DatePickerNextTrigger = defineComponent({
-  name: 'DatePickerNextTrigger',
-  setup(_, { attrs, slots }) {
+export const DatePickerNextTrigger = defineComponent<DatePickerNextTriggerProps>(
+  (_, { attrs, slots }) => {
     const api = useDatePickerContext()
     const view = useDatePickerViewContext()
 
@@ -17,4 +16,7 @@ export const DatePickerNextTrigger = defineComponent({
       </ark.button>
     )
   },
-})
+  {
+    name: 'DatePickerNextTrigger',
+  },
+)

--- a/packages/frameworks/vue/src/date-picker/date-picker-positioner.tsx
+++ b/packages/frameworks/vue/src/date-picker/date-picker-positioner.tsx
@@ -4,9 +4,8 @@ import { useDatePickerContext } from './date-picker-context'
 
 export interface DatePickerPositionerProps extends HTMLArkProps<'div'> {}
 
-export const DatePickerPositioner = defineComponent({
-  name: 'DatePickerPositioner',
-  setup(_, { attrs, slots }) {
+export const DatePickerPositioner = defineComponent<DatePickerPositionerProps>(
+  (_, { attrs, slots }) => {
     const api = useDatePickerContext()
 
     // if (presenceApi.isUnmounted) {
@@ -19,4 +18,7 @@ export const DatePickerPositioner = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'DatePickerPositioner',
+  },
+)

--- a/packages/frameworks/vue/src/date-picker/date-picker-prev-trigger.tsx
+++ b/packages/frameworks/vue/src/date-picker/date-picker-prev-trigger.tsx
@@ -5,9 +5,8 @@ import { useDatePickerViewContext } from './date-picker-view-context'
 
 export interface DatePickerPrevTriggerProps extends HTMLArkProps<'button'> {}
 
-export const DatePickerPrevTrigger = defineComponent({
-  name: 'DatePickerPrevTrigger',
-  setup(_, { attrs, slots }) {
+export const DatePickerPrevTrigger = defineComponent<DatePickerPrevTriggerProps>(
+  (_, { attrs, slots }) => {
     const api = useDatePickerContext()
     const view = useDatePickerViewContext()
 
@@ -17,4 +16,7 @@ export const DatePickerPrevTrigger = defineComponent({
       </ark.button>
     )
   },
-})
+  {
+    name: 'DatePickerPrevTrigger',
+  },
+)

--- a/packages/frameworks/vue/src/date-picker/date-picker-range-text.tsx
+++ b/packages/frameworks/vue/src/date-picker/date-picker-range-text.tsx
@@ -4,9 +4,8 @@ import { useDatePickerContext } from './date-picker-context'
 
 export interface DatePickerRangeTextProps extends HTMLArkProps<'div'> {}
 
-export const DatePickerRangeText = defineComponent({
-  name: 'DatePickerRangeText',
-  setup(_, { attrs }) {
+export const DatePickerRangeText = defineComponent<DatePickerRangeTextProps>(
+  (_, { attrs }) => {
     const api = useDatePickerContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const DatePickerRangeText = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'DatePickerRangeText',
+  },
+)

--- a/packages/frameworks/vue/src/date-picker/date-picker-table-body.tsx
+++ b/packages/frameworks/vue/src/date-picker/date-picker-table-body.tsx
@@ -5,9 +5,8 @@ import { useDatePickerTableContext } from './date-picker-table-context'
 
 export interface DatePickerTableBodyProps extends HTMLArkProps<'tbody'> {}
 
-export const DatePickerTableBody = defineComponent({
-  name: 'DatePickerTableBody',
-  setup(_, { attrs, slots }) {
+export const DatePickerTableBody = defineComponent<DatePickerTableBodyProps>(
+  (_, { attrs, slots }) => {
     const api = useDatePickerContext()
     const table = useDatePickerTableContext()
 
@@ -17,4 +16,7 @@ export const DatePickerTableBody = defineComponent({
       </ark.tbody>
     )
   },
-})
+  {
+    name: 'DatePickerTableBody',
+  },
+)

--- a/packages/frameworks/vue/src/date-picker/date-picker-table-cell-trigger.tsx
+++ b/packages/frameworks/vue/src/date-picker/date-picker-table-cell-trigger.tsx
@@ -6,9 +6,8 @@ import { useDatePickerViewContext } from './date-picker-view-context'
 
 export interface DatePickerTableCellTriggerProps extends HTMLArkProps<'button'> {}
 
-export const DatePickerTableCellTrigger = defineComponent({
-  name: 'DatePickerTableCellTrigger',
-  setup(_, { slots, attrs }) {
+export const DatePickerTableCellTrigger = defineComponent<DatePickerTableCellTriggerProps>(
+  (_, { slots, attrs }) => {
     const api = useDatePickerContext()
     const cell = useDatePickerTableCellContext()
     const view = useDatePickerViewContext()
@@ -28,4 +27,7 @@ export const DatePickerTableCellTrigger = defineComponent({
       </ark.button>
     )
   },
-})
+  {
+    name: 'DatePickerTableCellTrigger',
+  },
+)

--- a/packages/frameworks/vue/src/date-picker/date-picker-table-cell.tsx
+++ b/packages/frameworks/vue/src/date-picker/date-picker-table-cell.tsx
@@ -9,24 +9,8 @@ import { useDatePickerViewContext } from './date-picker-view-context'
 
 export interface DatePickerTableCellProps extends HTMLArkProps<'td'>, DatePickerTableCellContext {}
 
-export const DatePickerTableCell = defineComponent({
-  name: 'DatePickerTableCell',
-  props: {
-    columns: {
-      type: Number as PropType<DatePickerTableCellContext['columns']>,
-    },
-    disabled: {
-      type: Boolean as PropType<DatePickerTableCellContext['disabled']>,
-    },
-    value: {
-      type: [Number, Object] as PropType<DatePickerTableCellContext['value']>,
-      required: true,
-    },
-    visibleRange: {
-      type: Object as PropType<DatePickerTableCellContext['visibleRange']>,
-    },
-  },
-  setup(props, { slots, attrs }) {
+export const DatePickerTableCell = defineComponent<DatePickerTableCellProps>(
+  (props, { slots, attrs }) => {
     const api = useDatePickerContext()
     const view = useDatePickerViewContext()
     // @ts-ignore
@@ -47,4 +31,22 @@ export const DatePickerTableCell = defineComponent({
       </ark.td>
     )
   },
-})
+  {
+    name: 'DatePickerTableCell',
+    props: {
+      columns: {
+        type: Number as PropType<DatePickerTableCellContext['columns']>,
+      },
+      disabled: {
+        type: Boolean as PropType<DatePickerTableCellContext['disabled']>,
+      },
+      value: {
+        type: [Number, Object] as PropType<DatePickerTableCellContext['value']>,
+        required: true,
+      },
+      visibleRange: {
+        type: Object as PropType<DatePickerTableCellContext['visibleRange']>,
+      },
+    },
+  },
+)

--- a/packages/frameworks/vue/src/date-picker/date-picker-table-head.tsx
+++ b/packages/frameworks/vue/src/date-picker/date-picker-table-head.tsx
@@ -5,9 +5,8 @@ import { useDatePickerTableContext } from './date-picker-table-context'
 
 export interface DatePickerTableHeadProps extends HTMLArkProps<'thead'> {}
 
-export const DatePickerTableHead = defineComponent({
-  name: 'DatePickerTableHead',
-  setup(_, { attrs, slots }) {
+export const DatePickerTableHead = defineComponent<DatePickerTableHeadProps>(
+  (_, { attrs, slots }) => {
     const api = useDatePickerContext()
     const table = useDatePickerTableContext()
 
@@ -17,4 +16,7 @@ export const DatePickerTableHead = defineComponent({
       </ark.thead>
     )
   },
-})
+  {
+    name: 'DatePickerTableHead',
+  },
+)

--- a/packages/frameworks/vue/src/date-picker/date-picker-table-header.tsx
+++ b/packages/frameworks/vue/src/date-picker/date-picker-table-header.tsx
@@ -5,9 +5,8 @@ import { useDatePickerTableContext } from './date-picker-table-context'
 
 export interface DatePickerTableHeaderProps extends HTMLArkProps<'th'> {}
 
-export const DatePickerTableHeader = defineComponent({
-  name: 'DatePickerTableHeader',
-  setup(_, { attrs, slots }) {
+export const DatePickerTableHeader = defineComponent<DatePickerTableHeaderProps>(
+  (_, { attrs, slots }) => {
     const api = useDatePickerContext()
     const table = useDatePickerTableContext()
 
@@ -17,4 +16,7 @@ export const DatePickerTableHeader = defineComponent({
       </ark.th>
     )
   },
-})
+  {
+    name: 'DatePickerTableHeader',
+  },
+)

--- a/packages/frameworks/vue/src/date-picker/date-picker-table-row.tsx
+++ b/packages/frameworks/vue/src/date-picker/date-picker-table-row.tsx
@@ -5,9 +5,8 @@ import { useDatePickerTableContext } from './date-picker-table-context'
 
 export interface DatePickerTableRowProps extends HTMLArkProps<'tr'> {}
 
-export const DatePickerTableRow = defineComponent({
-  name: 'DatePickerTableRow',
-  setup(_, { attrs, slots }) {
+export const DatePickerTableRow = defineComponent<DatePickerTableRowProps>(
+  (_, { attrs, slots }) => {
     const api = useDatePickerContext()
     const table = useDatePickerTableContext()
 
@@ -17,4 +16,7 @@ export const DatePickerTableRow = defineComponent({
       </ark.tr>
     )
   },
-})
+  {
+    name: 'DatePickerTableRow',
+  },
+)

--- a/packages/frameworks/vue/src/date-picker/date-picker-table.tsx
+++ b/packages/frameworks/vue/src/date-picker/date-picker-table.tsx
@@ -10,14 +10,8 @@ import { useDatePickerViewContext } from './date-picker-view-context'
 export interface DatePickerTableProps
   extends Assign<HTMLArkProps<'table'>, Pick<TableProps, 'columns'>> {}
 
-export const DatePickerTable = defineComponent({
-  name: 'DatePickerTable',
-  props: {
-    columns: {
-      type: Number as PropType<TableProps['columns']>,
-    },
-  },
-  setup(props, { slots, attrs }) {
+export const DatePickerTable = defineComponent<DatePickerTableProps>(
+  (props, { slots, attrs }) => {
     const api = useDatePickerContext()
     const view = useDatePickerViewContext()
     DatePickerTableProvider(reactive({ ...props, id: useId().value, ...view }))
@@ -28,4 +22,12 @@ export const DatePickerTable = defineComponent({
       </ark.table>
     )
   },
-})
+  {
+    name: 'DatePickerTable',
+    props: {
+      columns: {
+        type: Number as PropType<TableProps['columns']>,
+      },
+    },
+  },
+)

--- a/packages/frameworks/vue/src/date-picker/date-picker-trigger.tsx
+++ b/packages/frameworks/vue/src/date-picker/date-picker-trigger.tsx
@@ -4,9 +4,8 @@ import { useDatePickerContext } from './date-picker-context'
 
 export interface DatePickerTriggerProps extends HTMLArkProps<'button'> {}
 
-export const DatePickerTrigger = defineComponent({
-  name: 'DatePickerTrigger',
-  setup(_, { attrs, slots }) {
+export const DatePickerTrigger = defineComponent<DatePickerTriggerProps>(
+  (_, { attrs, slots }) => {
     const api = useDatePickerContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const DatePickerTrigger = defineComponent({
       </ark.button>
     )
   },
-})
+  {
+    name: 'DatePickerTrigger',
+  },
+)

--- a/packages/frameworks/vue/src/date-picker/date-picker-view-control.tsx
+++ b/packages/frameworks/vue/src/date-picker/date-picker-view-control.tsx
@@ -5,9 +5,8 @@ import { useDatePickerViewContext } from './date-picker-view-context'
 
 export interface DatePickerViewControlProps extends HTMLArkProps<'div'> {}
 
-export const DatePickerViewControl = defineComponent({
-  name: 'DatePickerViewControl',
-  setup(_, { attrs, slots }) {
+export const DatePickerViewControl = defineComponent<DatePickerViewControlProps>(
+  (_, { attrs, slots }) => {
     const api = useDatePickerContext()
     const view = useDatePickerViewContext()
 
@@ -17,4 +16,7 @@ export const DatePickerViewControl = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'DatePickerViewControl',
+  },
+)

--- a/packages/frameworks/vue/src/date-picker/date-picker-view-trigger.tsx
+++ b/packages/frameworks/vue/src/date-picker/date-picker-view-trigger.tsx
@@ -5,9 +5,8 @@ import { useDatePickerViewContext } from './date-picker-view-context'
 
 export interface DatePickerViewTriggerProps extends HTMLArkProps<'button'> {}
 
-export const DatePickerViewTrigger = defineComponent({
-  name: 'DatePickerViewTrigger',
-  setup(_, { attrs, slots }) {
+export const DatePickerViewTrigger = defineComponent<DatePickerViewTriggerProps>(
+  (_, { attrs, slots }) => {
     const api = useDatePickerContext()
     const view = useDatePickerViewContext()
 
@@ -17,4 +16,7 @@ export const DatePickerViewTrigger = defineComponent({
       </ark.button>
     )
   },
-})
+  {
+    name: 'DatePickerViewTrigger',
+  },
+)

--- a/packages/frameworks/vue/src/date-picker/date-picker-view.tsx
+++ b/packages/frameworks/vue/src/date-picker/date-picker-view.tsx
@@ -7,15 +7,8 @@ import { DatePickerViewProvider } from './date-picker-view-context'
 
 export interface DatePickerViewProps extends HTMLArkProps<'div'>, Required<ViewProps> {}
 
-export const DatePickerView = defineComponent({
-  name: 'DatePickerView',
-  props: {
-    view: {
-      type: String as PropType<Required<ViewProps>['view']>,
-      required: true,
-    },
-  },
-  setup(props, { slots, attrs }) {
+export const DatePickerView = defineComponent<DatePickerViewProps>(
+  (props, { slots, attrs }) => {
     const api = useDatePickerContext()
     const reactiveProps = reactive(props)
     DatePickerViewProvider(reactiveProps)
@@ -30,4 +23,13 @@ export const DatePickerView = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'DatePickerView',
+    props: {
+      view: {
+        type: String as PropType<Required<ViewProps>['view']>,
+        required: true,
+      },
+    },
+  },
+)

--- a/packages/frameworks/vue/src/date-picker/date-picker-year-select.tsx
+++ b/packages/frameworks/vue/src/date-picker/date-picker-year-select.tsx
@@ -4,9 +4,8 @@ import { useDatePickerContext } from './date-picker-context'
 
 export interface DatePickerYearSelectProps extends HTMLArkProps<'select'> {}
 
-export const DatePickerYearSelect = defineComponent({
-  name: 'DatePickerYearSelect',
-  setup(_, { attrs }) {
+export const DatePickerYearSelect = defineComponent<DatePickerYearSelectProps>(
+  (_, { attrs }) => {
     const api = useDatePickerContext()
 
     return () => (
@@ -19,7 +18,10 @@ export const DatePickerYearSelect = defineComponent({
       </ark.select>
     )
   },
-})
+  {
+    name: 'DatePickerYearSelect',
+  },
+)
 
 interface YearsRange {
   from: number

--- a/packages/frameworks/vue/src/date-picker/date-picker.props.ts
+++ b/packages/frameworks/vue/src/date-picker/date-picker.props.ts
@@ -72,7 +72,7 @@ export const props = {
     type: String as PropType<Context['view']>,
     default: 'day',
   },
-}
+} as const
 export const emits = declareEmits([
   'focus-change',
   'value-change',

--- a/packages/frameworks/vue/src/date-picker/date-picker.tsx
+++ b/packages/frameworks/vue/src/date-picker/date-picker.tsx
@@ -8,11 +8,8 @@ import { useDatePicker, type UseDatePickerProps } from './use-date-picker'
 export interface DatePickerProps extends Assign<HTMLArkProps<'div'>, UseDatePickerProps> {}
 // UsePresenceProps {}
 
-export const DatePicker = defineComponent({
-  name: 'DatePicker',
-  props,
-  emits,
-  setup(props, { slots, attrs, emit }) {
+export const DatePicker = defineComponent<DatePickerProps>(
+  (props, { slots, attrs, emit }) => {
     const api = useDatePicker(props, emit)
     DatePickerProvider(api)
 
@@ -24,4 +21,9 @@ export const DatePicker = defineComponent({
       // </Presence>
     )
   },
-})
+  {
+    name: 'DatePicker',
+    props,
+    emits,
+  },
+)

--- a/packages/frameworks/vue/src/dialog/dialog-backdrop.tsx
+++ b/packages/frameworks/vue/src/dialog/dialog-backdrop.tsx
@@ -6,11 +6,8 @@ import { useDialogContext } from './dialog-context'
 
 export interface DialogBackdropProps extends HTMLArkProps<'div'>, PresenceProps {}
 
-export const DialogBackdrop = defineComponent({
-  name: 'DialogBackdrop',
-  props,
-  emits,
-  setup(props, { slots, attrs }) {
+export const DialogBackdrop = defineComponent<DialogBackdropProps>(
+  (props, { slots, attrs }) => {
     const api = useDialogContext()
 
     return () => (
@@ -21,4 +18,9 @@ export const DialogBackdrop = defineComponent({
       </Presence>
     )
   },
-})
+  {
+    name: 'DialogBackdrop',
+    props,
+    emits,
+  },
+)

--- a/packages/frameworks/vue/src/dialog/dialog-close-trigger.tsx
+++ b/packages/frameworks/vue/src/dialog/dialog-close-trigger.tsx
@@ -4,9 +4,8 @@ import { useDialogContext } from './dialog-context'
 
 export interface DialogCloseTriggerProps extends HTMLArkProps<'button'> {}
 
-export const DialogCloseTrigger = defineComponent({
-  name: 'DialogCloseTrigger',
-  setup(_, { slots, attrs }) {
+export const DialogCloseTrigger = defineComponent<DialogCloseTriggerProps>(
+  (_, { slots, attrs }) => {
     const api = useDialogContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const DialogCloseTrigger = defineComponent({
       </ark.button>
     )
   },
-})
+  {
+    name: 'DialogCloseTrigger',
+  },
+)

--- a/packages/frameworks/vue/src/dialog/dialog-content.tsx
+++ b/packages/frameworks/vue/src/dialog/dialog-content.tsx
@@ -6,11 +6,8 @@ import { useDialogContext } from './dialog-context'
 
 export interface DialogContentProps extends HTMLArkProps<'div'>, PresenceProps {}
 
-export const DialogContent = defineComponent({
-  name: 'DialogContent',
-  props,
-  emits,
-  setup(props, { slots, attrs }) {
+export const DialogContent = defineComponent<DialogContentProps>(
+  (props, { slots, attrs }) => {
     const api = useDialogContext()
 
     return () => (
@@ -21,4 +18,9 @@ export const DialogContent = defineComponent({
       </Presence>
     )
   },
-})
+  {
+    name: 'DialogContent',
+    props,
+    emits,
+  },
+)

--- a/packages/frameworks/vue/src/dialog/dialog-description.tsx
+++ b/packages/frameworks/vue/src/dialog/dialog-description.tsx
@@ -4,9 +4,8 @@ import { useDialogContext } from './dialog-context'
 
 export interface DialogDescriptionProps extends HTMLArkProps<'p'> {}
 
-export const DialogDescription = defineComponent({
-  name: 'DialogDescription',
-  setup(_, { slots, attrs }) {
+export const DialogDescription = defineComponent<DialogDescriptionProps>(
+  (_, { slots, attrs }) => {
     const api = useDialogContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const DialogDescription = defineComponent({
       </ark.p>
     )
   },
-})
+  {
+    name: 'DialogDescription',
+  },
+)

--- a/packages/frameworks/vue/src/dialog/dialog-positioner.tsx
+++ b/packages/frameworks/vue/src/dialog/dialog-positioner.tsx
@@ -4,9 +4,8 @@ import { useDialogContext } from './dialog-context'
 
 export interface DialogPositionerProps extends HTMLArkProps<'div'> {}
 
-export const DialogPositioner = defineComponent({
-  name: 'DialogPositioner',
-  setup(_, { slots, attrs }) {
+export const DialogPositioner = defineComponent<DialogPositionerProps>(
+  (_, { slots, attrs }) => {
     const api = useDialogContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const DialogPositioner = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'DialogPositioner',
+  },
+)

--- a/packages/frameworks/vue/src/dialog/dialog-title.tsx
+++ b/packages/frameworks/vue/src/dialog/dialog-title.tsx
@@ -4,9 +4,8 @@ import { useDialogContext } from './dialog-context'
 
 export interface DialogTitleProps extends HTMLArkProps<'h2'> {}
 
-export const DialogTitle = defineComponent({
-  name: 'DialogTitle',
-  setup(_, { slots, attrs }) {
+export const DialogTitle = defineComponent<DialogTitleProps>(
+  (_, { slots, attrs }) => {
     const api = useDialogContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const DialogTitle = defineComponent({
       </ark.h2>
     )
   },
-})
+  {
+    name: 'DialogTitle',
+  },
+)

--- a/packages/frameworks/vue/src/dialog/dialog-trigger.tsx
+++ b/packages/frameworks/vue/src/dialog/dialog-trigger.tsx
@@ -4,9 +4,8 @@ import { useDialogContext } from './dialog-context'
 
 export interface DialogTriggerProps extends HTMLArkProps<'button'> {}
 
-export const DialogTrigger = defineComponent({
-  name: 'DialogTrigger',
-  setup(_, { slots, attrs }) {
+export const DialogTrigger = defineComponent<DialogTriggerProps>(
+  (_, { slots, attrs }) => {
     const api = useDialogContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const DialogTrigger = defineComponent({
       </ark.button>
     )
   },
-})
+  {
+    name: 'DialogTrigger',
+  },
+)

--- a/packages/frameworks/vue/src/dialog/dialog.tsx
+++ b/packages/frameworks/vue/src/dialog/dialog.tsx
@@ -6,14 +6,16 @@ import { useDialog, type UseDialogProps } from './use-dialog'
 
 export interface DialogProps extends UseDialogProps, UsePresenceProps {}
 
-export const Dialog = defineComponent({
-  name: 'Dialog',
-  props,
-  emits,
-  setup(props, { slots, emit }) {
+export const Dialog = defineComponent<DialogProps>(
+  (props, { slots, emit }) => {
     const api = useDialog(props, emit)
     DialogProvider(api)
 
     return () => slots.default?.(api.value)
   },
-})
+  {
+    name: 'Dialog',
+    props,
+    emits,
+  },
+)

--- a/packages/frameworks/vue/src/editable/editable-area.tsx
+++ b/packages/frameworks/vue/src/editable/editable-area.tsx
@@ -4,9 +4,8 @@ import { useEditableContext } from './editable-context'
 
 export interface EditableAreaProps extends HTMLArkProps<'div'> {}
 
-export const EditableArea = defineComponent({
-  name: 'EditableArea',
-  setup(_, { slots, attrs }) {
+export const EditableArea = defineComponent<EditableAreaProps>(
+  (_, { slots, attrs }) => {
     const api = useEditableContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const EditableArea = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'EditableArea',
+  },
+)

--- a/packages/frameworks/vue/src/editable/editable-cancel-trigger.tsx
+++ b/packages/frameworks/vue/src/editable/editable-cancel-trigger.tsx
@@ -4,9 +4,8 @@ import { useEditableContext } from './editable-context'
 
 export interface EditableCancelTriggerProps extends HTMLArkProps<'button'> {}
 
-export const EditableCancelTrigger = defineComponent({
-  name: 'EditableCancelTrigger',
-  setup(_, { slots, attrs }) {
+export const EditableCancelTrigger = defineComponent<EditableCancelTriggerProps>(
+  (_, { slots, attrs }) => {
     const api = useEditableContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const EditableCancelTrigger = defineComponent({
       </ark.button>
     )
   },
-})
+  {
+    name: 'EditableCancelTrigger',
+  },
+)

--- a/packages/frameworks/vue/src/editable/editable-control.tsx
+++ b/packages/frameworks/vue/src/editable/editable-control.tsx
@@ -4,9 +4,8 @@ import { useEditableContext } from './editable-context'
 
 export interface EditableControlProps extends HTMLArkProps<'div'> {}
 
-export const EditableControl = defineComponent({
-  name: 'EditableControl',
-  setup(_, { slots, attrs }) {
+export const EditableControl = defineComponent<EditableControlProps>(
+  (_, { slots, attrs }) => {
     const api = useEditableContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const EditableControl = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'EditableControl',
+  },
+)

--- a/packages/frameworks/vue/src/editable/editable-edit-trigger.tsx
+++ b/packages/frameworks/vue/src/editable/editable-edit-trigger.tsx
@@ -4,9 +4,8 @@ import { useEditableContext } from './editable-context'
 
 export interface EditableEditTriggerProps extends HTMLArkProps<'button'> {}
 
-export const EditableEditTrigger = defineComponent({
-  name: 'EditableEditTrigger',
-  setup(_, { slots, attrs }) {
+export const EditableEditTrigger = defineComponent<EditableEditTriggerProps>(
+  (_, { slots, attrs }) => {
     const api = useEditableContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const EditableEditTrigger = defineComponent({
       </ark.button>
     )
   },
-})
+  {
+    name: 'EditableEditTrigger',
+  },
+)

--- a/packages/frameworks/vue/src/editable/editable-input.tsx
+++ b/packages/frameworks/vue/src/editable/editable-input.tsx
@@ -4,9 +4,8 @@ import { useEditableContext } from './editable-context'
 
 export interface EditableInputProps extends HTMLArkProps<'input'> {}
 
-export const EditableInput = defineComponent({
-  name: 'EditableInput',
-  setup(_, { slots, attrs }) {
+export const EditableInput = defineComponent<EditableInputProps>(
+  (_, { slots, attrs }) => {
     const api = useEditableContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const EditableInput = defineComponent({
       </ark.input>
     )
   },
-})
+  {
+    name: 'EditableInput',
+  },
+)

--- a/packages/frameworks/vue/src/editable/editable-label.tsx
+++ b/packages/frameworks/vue/src/editable/editable-label.tsx
@@ -4,9 +4,8 @@ import { useEditableContext } from './editable-context'
 
 export interface EditableLabelProps extends HTMLArkProps<'label'> {}
 
-export const EditableLabel = defineComponent({
-  name: 'EditableLabel',
-  setup(_, { slots, attrs }) {
+export const EditableLabel = defineComponent<EditableLabelProps>(
+  (_, { slots, attrs }) => {
     const api = useEditableContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const EditableLabel = defineComponent({
       </ark.label>
     )
   },
-})
+  {
+    name: 'EditableLabel',
+  },
+)

--- a/packages/frameworks/vue/src/editable/editable-preview.tsx
+++ b/packages/frameworks/vue/src/editable/editable-preview.tsx
@@ -4,9 +4,8 @@ import { useEditableContext } from './editable-context'
 
 export interface EditablePreviewProps extends HTMLArkProps<'span'> {}
 
-export const EditablePreview = defineComponent({
-  name: 'EditablePreview',
-  setup(_, { slots, attrs }) {
+export const EditablePreview = defineComponent<EditablePreviewProps>(
+  (_, { slots, attrs }) => {
     const api = useEditableContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const EditablePreview = defineComponent({
       </ark.span>
     )
   },
-})
+  {
+    name: 'EditablePreview',
+  },
+)

--- a/packages/frameworks/vue/src/editable/editable-submit-trigger.tsx
+++ b/packages/frameworks/vue/src/editable/editable-submit-trigger.tsx
@@ -4,9 +4,8 @@ import { useEditableContext } from './editable-context'
 
 export interface EditableSubmitTriggerProps extends HTMLArkProps<'button'> {}
 
-export const EditableSubmitTrigger = defineComponent({
-  name: 'EditableSubmitTrigger',
-  setup(_, { slots, attrs }) {
+export const EditableSubmitTrigger = defineComponent<EditableSubmitTriggerProps>(
+  (_, { slots, attrs }) => {
     const api = useEditableContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const EditableSubmitTrigger = defineComponent({
       </ark.button>
     )
   },
-})
+  {
+    name: 'EditableSubmitTrigger',
+  },
+)

--- a/packages/frameworks/vue/src/editable/editable.tsx
+++ b/packages/frameworks/vue/src/editable/editable.tsx
@@ -7,11 +7,8 @@ import { useEditable, type UseEditableProps } from './use-editable'
 
 export interface EditableProps extends Assign<HTMLArkProps<'div'>, UseEditableProps> {}
 
-export const Editable = defineComponent({
-  name: 'Editable',
-  props,
-  emits,
-  setup(props, { slots, attrs, emit }) {
+export const Editable = defineComponent<EditableProps>(
+  (props, { slots, attrs, emit }) => {
     const api = useEditable(props, emit)
     EditableProvider(api)
 
@@ -21,4 +18,9 @@ export const Editable = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'Editable',
+    props,
+    emits,
+  },
+)

--- a/packages/frameworks/vue/src/environment/environment.tsx
+++ b/packages/frameworks/vue/src/environment/environment.tsx
@@ -1,15 +1,10 @@
 import { computed, defineComponent, ref, type PropType } from 'vue'
-import type { ComponentWithProps } from '../utils'
 import { EnvironmentProvider } from './environment-context'
 
 export type EnvironmentProps = { value?: ShadowRoot | Document | Node }
 
-export const Environment: ComponentWithProps<EnvironmentProps> = defineComponent({
-  name: 'Environment',
-  props: {
-    value: Object as PropType<EnvironmentProps['value']>,
-  },
-  setup(props, { slots }) {
+export const Environment = defineComponent<EnvironmentProps>(
+  (props, { slots }) => {
     const elRef = ref<HTMLSpanElement>()
 
     const currentEnv = computed(() => () => props.value ?? elRef.value?.ownerDocument ?? document)
@@ -25,4 +20,10 @@ export const Environment: ComponentWithProps<EnvironmentProps> = defineComponent
       </>
     )
   },
-})
+  {
+    name: 'Environment',
+    props: {
+      value: Object as PropType<EnvironmentProps['value']>,
+    },
+  },
+)

--- a/packages/frameworks/vue/src/file-upload/file-upload-dropzone.tsx
+++ b/packages/frameworks/vue/src/file-upload/file-upload-dropzone.tsx
@@ -4,9 +4,8 @@ import { useFileUploadContext } from './file-upload-context'
 
 export interface FileUploadDropzoneProps extends HTMLArkProps<'div'> {}
 
-export const FileUploadDropzone = defineComponent({
-  name: 'FileUploadDropzone',
-  setup(_, { attrs, slots }) {
+export const FileUploadDropzone = defineComponent<FileUploadDropzoneProps>(
+  (_, { attrs, slots }) => {
     const api = useFileUploadContext()
 
     return () => (
@@ -18,4 +17,7 @@ export const FileUploadDropzone = defineComponent({
       </>
     )
   },
-})
+  {
+    name: 'FileUploadDropzone',
+  },
+)

--- a/packages/frameworks/vue/src/file-upload/file-upload-item-delete-trigger.tsx
+++ b/packages/frameworks/vue/src/file-upload/file-upload-item-delete-trigger.tsx
@@ -5,9 +5,8 @@ import { useFileUploadItemContext } from './file-upload-item-context'
 
 export interface FileUploadItemDeleteTriggerProps extends HTMLArkProps<'button'> {}
 
-export const FileUploadItemDeleteTrigger = defineComponent({
-  name: 'FileUploadItemDeleteTrigger',
-  setup(_, { slots, attrs }) {
+export const FileUploadItemDeleteTrigger = defineComponent<FileUploadItemDeleteTriggerProps>(
+  (_, { slots, attrs }) => {
     const api = useFileUploadContext()
     const item = useFileUploadItemContext()
 
@@ -17,4 +16,7 @@ export const FileUploadItemDeleteTrigger = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'FileUploadItemDeleteTrigger',
+  },
+)

--- a/packages/frameworks/vue/src/file-upload/file-upload-item-group.tsx
+++ b/packages/frameworks/vue/src/file-upload/file-upload-item-group.tsx
@@ -4,9 +4,8 @@ import { useFileUploadContext } from './file-upload-context'
 
 export interface FileUploadItemGroupProps extends HTMLArkProps<'ul'> {}
 
-export const FileUploadItemGroup = defineComponent({
-  name: 'FileUploadItemGroup',
-  setup(_, { slots, attrs }) {
+export const FileUploadItemGroup = defineComponent<FileUploadItemGroupProps>(
+  (_, { slots, attrs }) => {
     const api = useFileUploadContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const FileUploadItemGroup = defineComponent({
       </ark.ul>
     )
   },
-})
+  {
+    name: 'FileUploadItemGroup',
+  },
+)

--- a/packages/frameworks/vue/src/file-upload/file-upload-item-name.tsx
+++ b/packages/frameworks/vue/src/file-upload/file-upload-item-name.tsx
@@ -5,9 +5,8 @@ import { useFileUploadItemContext } from './file-upload-item-context'
 
 export interface FileUploadItemNameProps extends HTMLArkProps<'div'> {}
 
-export const FileUploadItemName = defineComponent({
-  name: 'FileUploadItemName',
-  setup(_, { slots, attrs }) {
+export const FileUploadItemName = defineComponent<FileUploadItemNameProps>(
+  (_, { slots, attrs }) => {
     const api = useFileUploadContext()
     const item = useFileUploadItemContext()
 
@@ -17,4 +16,7 @@ export const FileUploadItemName = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'FileUploadItemName',
+  },
+)

--- a/packages/frameworks/vue/src/file-upload/file-upload-item-preview-image.tsx
+++ b/packages/frameworks/vue/src/file-upload/file-upload-item-preview-image.tsx
@@ -5,9 +5,8 @@ import { useFileUploadItemContext } from './file-upload-item-context'
 
 export interface FileUploadItemPreviewImageProps extends HTMLArkProps<'img'> {}
 
-export const FileUploadItemPreviewImage = defineComponent({
-  name: 'FileUploadItemPreviewImage',
-  setup(_, { attrs }) {
+export const FileUploadItemPreviewImage = defineComponent<FileUploadItemPreviewImageProps>(
+  (_, { attrs }) => {
     const api = useFileUploadContext()
     const item = useFileUploadItemContext()
     const url = ref<string>('')
@@ -17,4 +16,7 @@ export const FileUploadItemPreviewImage = defineComponent({
     const previewProps = api.value.getItemPreviewImageProps({ ...item, url: url.value })
     return () => <ark.img {...previewProps} {...attrs} />
   },
-})
+  {
+    name: 'FileUploadItemPreviewImage',
+  },
+)

--- a/packages/frameworks/vue/src/file-upload/file-upload-item-preview.tsx
+++ b/packages/frameworks/vue/src/file-upload/file-upload-item-preview.tsx
@@ -11,15 +11,8 @@ export interface FileUploadItemPreviewProps extends HTMLArkProps<'div'> {
   type?: string
 }
 
-export const FileUploadItemPreview = defineComponent({
-  name: 'FileUploadItemPreview',
-  props: {
-    type: {
-      type: String,
-      default: '.*',
-    },
-  },
-  setup(props, { attrs, slots }) {
+export const FileUploadItemPreview = defineComponent<FileUploadItemPreviewProps>(
+  (props, { attrs, slots }) => {
     const api = useFileUploadContext()
     const item = useFileUploadItemContext()
 
@@ -30,4 +23,13 @@ export const FileUploadItemPreview = defineComponent({
         </ark.div>
       )
   },
-})
+  {
+    name: 'FileUploadItemPreview',
+    props: {
+      type: {
+        type: String,
+        default: '.*',
+      },
+    },
+  },
+)

--- a/packages/frameworks/vue/src/file-upload/file-upload-item-size-text.tsx
+++ b/packages/frameworks/vue/src/file-upload/file-upload-item-size-text.tsx
@@ -5,9 +5,8 @@ import { useFileUploadItemContext } from './file-upload-item-context'
 
 export interface FileUploadItemSizeTextProps extends HTMLArkProps<'div'> {}
 
-export const FileUploadItemSizeText = defineComponent({
-  name: 'FileUploadItemSizeText',
-  setup(_, { slots, attrs }) {
+export const FileUploadItemSizeText = defineComponent<FileUploadItemSizeTextProps>(
+  (_, { slots, attrs }) => {
     const api = useFileUploadContext()
     const item = useFileUploadItemContext()
 
@@ -17,4 +16,7 @@ export const FileUploadItemSizeText = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'FileUploadItemSizeText',
+  },
+)

--- a/packages/frameworks/vue/src/file-upload/file-upload-item.tsx
+++ b/packages/frameworks/vue/src/file-upload/file-upload-item.tsx
@@ -6,15 +6,8 @@ import { FileUploadItemProvider, type FileUploadItemContext } from './file-uploa
 
 export interface FileUploadItemProps extends Assign<HTMLArkProps<'li'>, FileUploadItemContext> {}
 
-export const FileUploadItem = defineComponent({
-  name: 'FileUploadItem',
-  props: {
-    file: {
-      type: Object as PropType<FileUploadItemContext['file']>,
-      required: true,
-    },
-  },
-  setup(props, { slots, attrs }) {
+export const FileUploadItem = defineComponent<FileUploadItemProps>(
+  (props, { slots, attrs }) => {
     const api = useFileUploadContext()
     FileUploadItemProvider(props)
 
@@ -24,4 +17,13 @@ export const FileUploadItem = defineComponent({
       </ark.li>
     )
   },
-})
+  {
+    name: 'FileUploadItem',
+    props: {
+      file: {
+        type: Object as PropType<FileUploadItemContext['file']>,
+        required: true,
+      },
+    },
+  },
+)

--- a/packages/frameworks/vue/src/file-upload/file-upload-label.tsx
+++ b/packages/frameworks/vue/src/file-upload/file-upload-label.tsx
@@ -4,9 +4,8 @@ import { useFileUploadContext } from './file-upload-context'
 
 export interface FileUploadLabelProps extends HTMLArkProps<'label'> {}
 
-export const FileUploadLabel = defineComponent({
-  name: 'FileUploadLabel',
-  setup(_, { attrs, slots }) {
+export const FileUploadLabel = defineComponent<FileUploadLabelProps>(
+  (_, { attrs, slots }) => {
     const api = useFileUploadContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const FileUploadLabel = defineComponent({
       </ark.label>
     )
   },
-})
+  {
+    name: 'FileUploadLabel',
+  },
+)

--- a/packages/frameworks/vue/src/file-upload/file-upload-trigger.tsx
+++ b/packages/frameworks/vue/src/file-upload/file-upload-trigger.tsx
@@ -4,9 +4,8 @@ import { useFileUploadContext } from './file-upload-context'
 
 export interface FileUploadTriggerProps extends HTMLArkProps<'button'> {}
 
-export const FileUploadTrigger = defineComponent({
-  name: 'FileUploadTrigger',
-  setup(_, { slots, attrs }) {
+export const FileUploadTrigger = defineComponent<FileUploadTriggerProps>(
+  (_, { slots, attrs }) => {
     const api = useFileUploadContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const FileUploadTrigger = defineComponent({
       </ark.button>
     )
   },
-})
+  {
+    name: 'FileUploadTrigger',
+  },
+)

--- a/packages/frameworks/vue/src/file-upload/file-upload.tsx
+++ b/packages/frameworks/vue/src/file-upload/file-upload.tsx
@@ -7,11 +7,8 @@ import { useFileUpload, type UseFileUploadProps } from './use-file-upload'
 
 export interface FileUploadProps extends Assign<HTMLArkProps<'div'>, UseFileUploadProps> {}
 
-export const FileUpload = defineComponent({
-  name: 'FileUpload',
-  props,
-  emits,
-  setup(props, { slots, attrs, emit }) {
+export const FileUpload = defineComponent<FileUploadProps>(
+  (props, { slots, attrs, emit }) => {
     const api = useFileUpload(props, emit)
     FileUploadProvider(api)
 
@@ -21,4 +18,9 @@ export const FileUpload = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'FileUpload',
+    props,
+    emits,
+  },
+)

--- a/packages/frameworks/vue/src/hover-card/hover-card-arrow-tip.tsx
+++ b/packages/frameworks/vue/src/hover-card/hover-card-arrow-tip.tsx
@@ -4,9 +4,8 @@ import { useHoverCardContext } from './hover-card-context'
 
 export interface HoverCardArrowTipProps extends HTMLArkProps<'div'> {}
 
-export const HoverCardArrowTip = defineComponent({
-  name: 'HoverCardArrowTip',
-  setup(_, { slots, attrs }) {
+export const HoverCardArrowTip = defineComponent<HoverCardArrowTipProps>(
+  (_, { slots, attrs }) => {
     const api = useHoverCardContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const HoverCardArrowTip = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'HoverCardArrowTip',
+  },
+)

--- a/packages/frameworks/vue/src/hover-card/hover-card-arrow.tsx
+++ b/packages/frameworks/vue/src/hover-card/hover-card-arrow.tsx
@@ -4,9 +4,8 @@ import { useHoverCardContext } from './hover-card-context'
 
 export interface HoverCardArrowProps extends HTMLArkProps<'div'> {}
 
-export const HoverCardArrow = defineComponent({
-  name: 'HoverCardArrow',
-  setup(_, { slots, attrs }) {
+export const HoverCardArrow = defineComponent<HoverCardArrowProps>(
+  (_, { slots, attrs }) => {
     const api = useHoverCardContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const HoverCardArrow = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'HoverCardArrow',
+  },
+)

--- a/packages/frameworks/vue/src/hover-card/hover-card-content.tsx
+++ b/packages/frameworks/vue/src/hover-card/hover-card-content.tsx
@@ -6,11 +6,8 @@ import { useHoverCardContext } from './hover-card-context'
 
 export interface HoverCardContentProps extends HTMLArkProps<'div'>, PresenceProps {}
 
-export const HoverCardContent = defineComponent({
-  name: 'HoverCardContent',
-  props,
-  emits,
-  setup(props, { slots, attrs }) {
+export const HoverCardContent = defineComponent<HoverCardContentProps>(
+  (props, { slots, attrs }) => {
     const api = useHoverCardContext()
 
     return () => (
@@ -21,4 +18,9 @@ export const HoverCardContent = defineComponent({
       </Presence>
     )
   },
-})
+  {
+    name: 'HoverCardContent',
+    props,
+    emits,
+  },
+)

--- a/packages/frameworks/vue/src/hover-card/hover-card-positioner.tsx
+++ b/packages/frameworks/vue/src/hover-card/hover-card-positioner.tsx
@@ -4,9 +4,8 @@ import { useHoverCardContext } from './hover-card-context'
 
 export interface HoverCardPositionerProps extends HTMLArkProps<'div'> {}
 
-export const HoverCardPositioner = defineComponent({
-  name: 'HoverCardPositioner',
-  setup(_, { slots, attrs }) {
+export const HoverCardPositioner = defineComponent<HoverCardPositionerProps>(
+  (_, { slots, attrs }) => {
     const api = useHoverCardContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const HoverCardPositioner = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'HoverCardPositioner',
+  },
+)

--- a/packages/frameworks/vue/src/hover-card/hover-card-trigger.tsx
+++ b/packages/frameworks/vue/src/hover-card/hover-card-trigger.tsx
@@ -4,9 +4,8 @@ import { useHoverCardContext } from './hover-card-context'
 
 export interface HoverCardTriggerProps extends HTMLArkProps<'button'> {}
 
-export const HoverCardTrigger = defineComponent({
-  name: 'HoverCardTrigger',
-  setup(_, { slots, attrs }) {
+export const HoverCardTrigger = defineComponent<HoverCardTriggerProps>(
+  (_, { slots, attrs }) => {
     const api = useHoverCardContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const HoverCardTrigger = defineComponent({
       </ark.button>
     )
   },
-})
+  {
+    name: 'HoverCardTrigger',
+  },
+)

--- a/packages/frameworks/vue/src/hover-card/hover-card.tsx
+++ b/packages/frameworks/vue/src/hover-card/hover-card.tsx
@@ -7,14 +7,16 @@ import { useHoverCard, type UseHoverCardProps } from './use-hover-card'
 
 export interface HoverCardProps extends Assign<HTMLArkProps<'div'>, UseHoverCardProps> {}
 
-export const HoverCard = defineComponent({
-  name: 'HoverCard',
-  props,
-  emits,
-  setup(props, { slots, emit }) {
+export const HoverCard = defineComponent<HoverCardProps>(
+  (props, { slots, emit }) => {
     const api = useHoverCard(props, emit)
     HoverCardProvider(api)
 
     return () => slots.default?.(api.value)
   },
-})
+  {
+    name: 'HoverCard',
+    props,
+    emits,
+  },
+)

--- a/packages/frameworks/vue/src/menu/menu-arrow-tip.tsx
+++ b/packages/frameworks/vue/src/menu/menu-arrow-tip.tsx
@@ -4,9 +4,8 @@ import { useMenuContext } from './menu-context'
 
 export interface MenuArrowTipProps extends HTMLArkProps<'div'> {}
 
-export const MenuArrowTip = defineComponent({
-  name: 'MenuArrowTip',
-  setup(_, { slots, attrs }) {
+export const MenuArrowTip = defineComponent<MenuArrowTipProps>(
+  (_, { slots, attrs }) => {
     const api = useMenuContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const MenuArrowTip = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'MenuArrowTip',
+  },
+)

--- a/packages/frameworks/vue/src/menu/menu-arrow.tsx
+++ b/packages/frameworks/vue/src/menu/menu-arrow.tsx
@@ -4,9 +4,8 @@ import { useMenuContext } from './menu-context'
 
 export interface MenuArrowProps extends HTMLArkProps<'div'> {}
 
-export const MenuArrow = defineComponent({
-  name: 'MenuArrow',
-  setup(_, { slots, attrs }) {
+export const MenuArrow = defineComponent<MenuArrowProps>(
+  (_, { slots, attrs }) => {
     const api = useMenuContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const MenuArrow = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'MenuArrow',
+  },
+)

--- a/packages/frameworks/vue/src/menu/menu-content.tsx
+++ b/packages/frameworks/vue/src/menu/menu-content.tsx
@@ -7,11 +7,8 @@ import { useMenuContext } from './menu-context'
 
 export interface MenuContentProps extends Assign<HTMLArkProps<'div'>, PresenceProps> {}
 
-export const MenuContent = defineComponent({
-  name: 'MenuContent',
-  props,
-  emits,
-  setup(props, { slots, attrs }) {
+export const MenuContent = defineComponent<MenuContentProps>(
+  (props, { slots, attrs }) => {
     const api = useMenuContext()
 
     return () => (
@@ -22,4 +19,9 @@ export const MenuContent = defineComponent({
       </Presence>
     )
   },
-})
+  {
+    name: 'MenuContent',
+    props,
+    emits,
+  },
+)

--- a/packages/frameworks/vue/src/menu/menu-context-trigger.tsx
+++ b/packages/frameworks/vue/src/menu/menu-context-trigger.tsx
@@ -4,9 +4,8 @@ import { useMenuContext } from './menu-context'
 
 export interface MenuContextTriggerProps extends HTMLArkProps<'button'> {}
 
-export const MenuContextTrigger = defineComponent({
-  name: 'MenuContextTrigger',
-  setup(_, { slots, attrs }) {
+export const MenuContextTrigger = defineComponent<MenuContextTriggerProps>(
+  (_, { slots, attrs }) => {
     const api = useMenuContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const MenuContextTrigger = defineComponent({
       </ark.button>
     )
   },
-})
+  {
+    name: 'MenuContextTrigger',
+  },
+)

--- a/packages/frameworks/vue/src/menu/menu-item-group-label.tsx
+++ b/packages/frameworks/vue/src/menu/menu-item-group-label.tsx
@@ -8,15 +8,8 @@ interface ItemGroupLabelProps {
 
 export interface MenuItemGroupLabelProps extends HTMLArkProps<'div'>, ItemGroupLabelProps {}
 
-export const MenuItemGroupLabel = defineComponent({
-  name: 'MenuItemGroupLabel',
-  props: {
-    htmlFor: {
-      type: String as PropType<MenuItemGroupLabelProps['htmlFor']>,
-      required: true,
-    },
-  },
-  setup(props, { slots, attrs }) {
+export const MenuItemGroupLabel = defineComponent<MenuItemGroupLabelProps>(
+  (props, { slots, attrs }) => {
     const api = useMenuContext()
 
     return () => (
@@ -25,4 +18,13 @@ export const MenuItemGroupLabel = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'MenuItemGroupLabel',
+    props: {
+      htmlFor: {
+        type: String as PropType<MenuItemGroupLabelProps['htmlFor']>,
+        required: true,
+      },
+    },
+  },
+)

--- a/packages/frameworks/vue/src/menu/menu-item-group.tsx
+++ b/packages/frameworks/vue/src/menu/menu-item-group.tsx
@@ -6,15 +6,8 @@ import { useMenuContext } from './menu-context'
 
 export interface MenuItemGroupProps extends Assign<HTMLArkProps<'div'>, GroupProps> {}
 
-export const MenuItemGroup = defineComponent({
-  name: 'MenuItemGroup',
-  props: {
-    id: {
-      type: String as PropType<MenuItemGroupProps['id']>,
-      required: true,
-    },
-  },
-  setup(props, { slots, attrs }) {
+export const MenuItemGroup = defineComponent<MenuItemGroupProps>(
+  (props, { slots, attrs }) => {
     const api = useMenuContext()
 
     return () => (
@@ -23,4 +16,13 @@ export const MenuItemGroup = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'MenuItemGroup',
+    props: {
+      id: {
+        type: String as PropType<MenuItemGroupProps['id']>,
+        required: true,
+      },
+    },
+  },
+)

--- a/packages/frameworks/vue/src/menu/menu-item.tsx
+++ b/packages/frameworks/vue/src/menu/menu-item.tsx
@@ -6,27 +6,8 @@ import { useMenuContext } from './menu-context'
 
 export interface MenuItemProps extends Assign<HTMLArkProps<'div'>, ItemProps> {}
 
-export const MenuItem = defineComponent({
-  name: 'MenuItem',
-  props: {
-    id: {
-      type: String as PropType<MenuItemProps['id']>,
-      required: true,
-    },
-    disabled: {
-      type: Boolean as PropType<MenuItemProps['disabled']>,
-      default: undefined,
-    },
-    valueText: {
-      type: String as PropType<MenuItemProps['valueText']>,
-      default: undefined,
-    },
-    closeOnSelect: {
-      type: Boolean as PropType<MenuItemProps['closeOnSelect']>,
-      default: undefined,
-    },
-  },
-  setup(props, { slots, attrs }) {
+export const MenuItem = defineComponent<MenuItemProps>(
+  (props, { slots, attrs }) => {
     const api = useMenuContext()
 
     return () => (
@@ -35,4 +16,25 @@ export const MenuItem = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'MenuItem',
+    props: {
+      id: {
+        type: String as PropType<MenuItemProps['id']>,
+        required: true,
+      },
+      disabled: {
+        type: Boolean as PropType<MenuItemProps['disabled']>,
+        default: undefined,
+      },
+      valueText: {
+        type: String as PropType<MenuItemProps['valueText']>,
+        default: undefined,
+      },
+      closeOnSelect: {
+        type: Boolean as PropType<MenuItemProps['closeOnSelect']>,
+        default: undefined,
+      },
+    },
+  },
+)

--- a/packages/frameworks/vue/src/menu/menu-option-item.tsx
+++ b/packages/frameworks/vue/src/menu/menu-option-item.tsx
@@ -6,39 +6,8 @@ import { useMenuContext } from './menu-context'
 
 export interface MenuOptionItemProps extends Assign<HTMLArkProps<'div'>, OptionItemProps> {}
 
-export const MenuOptionItem = defineComponent({
-  name: 'MenuOptionItem',
-  props: {
-    id: {
-      type: String as PropType<MenuOptionItemProps['id']>,
-    },
-    disabled: {
-      type: Boolean as PropType<MenuOptionItemProps['disabled']>,
-      default: undefined,
-    },
-    valueText: {
-      type: String as PropType<MenuOptionItemProps['valueText']>,
-      default: undefined,
-    },
-    closeOnSelect: {
-      type: Boolean as PropType<MenuOptionItemProps['closeOnSelect']>,
-      default: undefined,
-    },
-    name: {
-      type: String as PropType<MenuOptionItemProps['name']>,
-      required: true,
-    },
-    type: {
-      type: String as PropType<MenuOptionItemProps['type']>,
-      required: true,
-    },
-    value: {
-      type: String as PropType<MenuOptionItemProps['value']>,
-      required: true,
-    },
-  },
-  emits: ['checked-change'],
-  setup(props, { slots, attrs, emit }) {
+export const MenuOptionItem = defineComponent<MenuOptionItemProps>(
+  (props, { slots, attrs, emit }) => {
     const menuOptionItemProps = computed<OptionItemProps>(() => ({
       ...props,
       onCheckedChange(checked) {
@@ -54,4 +23,37 @@ export const MenuOptionItem = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'MenuOptionItem',
+    props: {
+      id: {
+        type: String as PropType<MenuOptionItemProps['id']>,
+      },
+      disabled: {
+        type: Boolean as PropType<MenuOptionItemProps['disabled']>,
+        default: undefined,
+      },
+      valueText: {
+        type: String as PropType<MenuOptionItemProps['valueText']>,
+        default: undefined,
+      },
+      closeOnSelect: {
+        type: Boolean as PropType<MenuOptionItemProps['closeOnSelect']>,
+        default: undefined,
+      },
+      name: {
+        type: String as PropType<MenuOptionItemProps['name']>,
+        required: true,
+      },
+      type: {
+        type: String as PropType<MenuOptionItemProps['type']>,
+        required: true,
+      },
+      value: {
+        type: String as PropType<MenuOptionItemProps['value']>,
+        required: true,
+      },
+    },
+    emits: ['checked-change'],
+  },
+)

--- a/packages/frameworks/vue/src/menu/menu-positioner.tsx
+++ b/packages/frameworks/vue/src/menu/menu-positioner.tsx
@@ -4,9 +4,8 @@ import { useMenuContext } from './menu-context'
 
 export interface MenuPositionerProps extends HTMLArkProps<'div'> {}
 
-export const MenuPositioner = defineComponent({
-  name: 'MenuPositioner',
-  setup(_, { slots, attrs }) {
+export const MenuPositioner = defineComponent<MenuPositionerProps>(
+  (_, { slots, attrs }) => {
     const api = useMenuContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const MenuPositioner = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'MenuPositioner',
+  },
+)

--- a/packages/frameworks/vue/src/menu/menu-separator.tsx
+++ b/packages/frameworks/vue/src/menu/menu-separator.tsx
@@ -4,11 +4,13 @@ import { useMenuContext } from './menu-context'
 
 export interface MenuSeparatorProps extends HTMLArkProps<'hr'> {}
 
-export const MenuSeparator = defineComponent({
-  name: 'MenuSeparator',
-  setup(_, { attrs }) {
+export const MenuSeparator = defineComponent<MenuSeparatorProps>(
+  (_, { attrs }) => {
     const api = useMenuContext()
 
     return () => <ark.hr {...api.value.separatorProps} {...attrs} />
   },
-})
+  {
+    name: 'MenuSeparator',
+  },
+)

--- a/packages/frameworks/vue/src/menu/menu-trigger-item.tsx
+++ b/packages/frameworks/vue/src/menu/menu-trigger-item.tsx
@@ -4,9 +4,8 @@ import { useMenuTriggerItemContext } from './menu-context'
 
 export interface MenuTriggerItemProps extends HTMLArkProps<'div'> {}
 
-export const MenuTriggerItem = defineComponent({
-  name: 'MenuTriggerItem',
-  setup(_, { slots, attrs }) {
+export const MenuTriggerItem = defineComponent<MenuTriggerItemProps>(
+  (_, { slots, attrs }) => {
     const triggerItemProps = useMenuTriggerItemContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const MenuTriggerItem = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'MenuTriggerItem',
+  },
+)

--- a/packages/frameworks/vue/src/menu/menu-trigger.tsx
+++ b/packages/frameworks/vue/src/menu/menu-trigger.tsx
@@ -4,9 +4,8 @@ import { useMenuContext } from './menu-context'
 
 export interface MenuTriggerProps extends HTMLArkProps<'button'> {}
 
-export const MenuTrigger = defineComponent({
-  name: 'MenuTrigger',
-  setup(_, { slots, attrs }) {
+export const MenuTrigger = defineComponent<MenuTriggerProps>(
+  (_, { slots, attrs }) => {
     const api = useMenuContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const MenuTrigger = defineComponent({
       </ark.button>
     )
   },
-})
+  {
+    name: 'MenuTrigger',
+  },
+)

--- a/packages/frameworks/vue/src/menu/menu.tsx
+++ b/packages/frameworks/vue/src/menu/menu.tsx
@@ -11,11 +11,8 @@ import { useMenu, type UseMenuProps } from './use-menu'
 
 export interface MenuProps extends UseMenuProps {}
 
-export const Menu = defineComponent({
-  name: 'Menu',
-  props,
-  emits,
-  setup(props, { slots, emit }) {
+export const Menu = defineComponent<MenuProps>(
+  (props, { slots, emit }) => {
     const { api, machine } = useMenu(props, emit)
 
     const parentApi = useMenuContext()
@@ -37,4 +34,9 @@ export const Menu = defineComponent({
       return slots.default?.(api.value)
     }
   },
-})
+  {
+    name: 'Menu',
+    props,
+    emits,
+  },
+)

--- a/packages/frameworks/vue/src/menu/tests/menu.test.tsx
+++ b/packages/frameworks/vue/src/menu/tests/menu.test.tsx
@@ -1,8 +1,8 @@
 import { menuAnatomy } from '@ark-ui/anatomy'
 import user from '@testing-library/user-event'
 import { fireEvent, render, screen, waitFor } from '@testing-library/vue'
-import { Menu } from '../'
-import { getExports, getParts } from '../../setup-test'
+// import { Menu } from '../'
+import { getParts } from '../../setup-test'
 import ContextMenuComponentUnderTest from './context-menu.test.vue'
 import MenuItemGroupComponentUnderTest from './menu-item-group.test.vue'
 import ComponentUnderTest from './menu.test.vue'
@@ -16,9 +16,9 @@ describe('Menu', () => {
     expect(document.querySelector(part)).toBeInTheDocument()
   })
 
-  it.skip.each(getExports(menuAnatomy))('should export %s', async (part) => {
-    expect(Menu[part]).toBeDefined()
-  })
+  // it.skip.each(getExports(menuAnatomy))('should export %s', async (part) => {
+  //   expect(Menu[part]).toBeDefined()
+  // })
 
   it('should set correct aria attributes on disabled MenuItems', () => {
     render(ComponentUnderTest)

--- a/packages/frameworks/vue/src/number-input/number-input-control.tsx
+++ b/packages/frameworks/vue/src/number-input/number-input-control.tsx
@@ -4,9 +4,8 @@ import { useNumberInputContext } from './number-input-context'
 
 export interface NumberInputControlProps extends HTMLArkProps<'div'> {}
 
-export const NumberInputControl = defineComponent({
-  name: 'NumberInputControl',
-  setup(_, { slots, attrs }) {
+export const NumberInputControl = defineComponent<NumberInputControlProps>(
+  (_, { slots, attrs }) => {
     const api = useNumberInputContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const NumberInputControl = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'NumberInputControl',
+  },
+)

--- a/packages/frameworks/vue/src/number-input/number-input-decrement-trigger.tsx
+++ b/packages/frameworks/vue/src/number-input/number-input-decrement-trigger.tsx
@@ -4,9 +4,8 @@ import { useNumberInputContext } from './number-input-context'
 
 export interface NumberInputDecrementTriggerProps extends HTMLArkProps<'button'> {}
 
-export const NumberInputDecrementTrigger = defineComponent({
-  name: 'NumberInputDecrementTrigger',
-  setup(_, { slots, attrs }) {
+export const NumberInputDecrementTrigger = defineComponent<NumberInputDecrementTriggerProps>(
+  (_, { slots, attrs }) => {
     const api = useNumberInputContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const NumberInputDecrementTrigger = defineComponent({
       </ark.button>
     )
   },
-})
+  {
+    name: 'NumberInputDecrementTrigger',
+  },
+)

--- a/packages/frameworks/vue/src/number-input/number-input-increment-trigger.tsx
+++ b/packages/frameworks/vue/src/number-input/number-input-increment-trigger.tsx
@@ -4,9 +4,8 @@ import { useNumberInputContext } from './number-input-context'
 
 export interface NumberInputIncrementTriggerProps extends HTMLArkProps<'button'> {}
 
-export const NumberInputIncrementTrigger = defineComponent({
-  name: 'NumberInputIncrementTrigger',
-  setup(_, { slots, attrs }) {
+export const NumberInputIncrementTrigger = defineComponent<NumberInputIncrementTriggerProps>(
+  (_, { slots, attrs }) => {
     const api = useNumberInputContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const NumberInputIncrementTrigger = defineComponent({
       </ark.button>
     )
   },
-})
+  {
+    name: 'NumberInputIncrementTrigger',
+  },
+)

--- a/packages/frameworks/vue/src/number-input/number-input-input.tsx
+++ b/packages/frameworks/vue/src/number-input/number-input-input.tsx
@@ -4,11 +4,13 @@ import { useNumberInputContext } from './number-input-context'
 
 export interface NumberInputInputProps extends HTMLArkProps<'input'> {}
 
-export const NumberInputInput = defineComponent({
-  name: 'NumberInputInput',
-  setup(_, { attrs }) {
+export const NumberInputInput = defineComponent<NumberInputInputProps>(
+  (_, { attrs }) => {
     const api = useNumberInputContext()
 
     return () => <ark.input {...api.value.inputProps} {...attrs} />
   },
-})
+  {
+    name: 'NumberInputInput',
+  },
+)

--- a/packages/frameworks/vue/src/number-input/number-input-label.tsx
+++ b/packages/frameworks/vue/src/number-input/number-input-label.tsx
@@ -4,9 +4,8 @@ import { useNumberInputContext } from './number-input-context'
 
 export interface NumberInputLabelProps extends HTMLArkProps<'label'> {}
 
-export const NumberInputLabel = defineComponent({
-  name: 'NumberInputLabel',
-  setup(_, { slots, attrs }) {
+export const NumberInputLabel = defineComponent<NumberInputLabelProps>(
+  (_, { slots, attrs }) => {
     const api = useNumberInputContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const NumberInputLabel = defineComponent({
       </ark.label>
     )
   },
-})
+  {
+    name: 'NumberInputLabel',
+  },
+)

--- a/packages/frameworks/vue/src/number-input/number-input-scrubber.tsx
+++ b/packages/frameworks/vue/src/number-input/number-input-scrubber.tsx
@@ -4,9 +4,8 @@ import { useNumberInputContext } from './number-input-context'
 
 export interface NumberInputScrubberProps extends HTMLArkProps<'div'> {}
 
-export const NumberInputScrubber = defineComponent({
-  name: 'NumberInputScrubber',
-  setup(_, { slots, attrs }) {
+export const NumberInputScrubber = defineComponent<NumberInputScrubberProps>(
+  (_, { slots, attrs }) => {
     const api = useNumberInputContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const NumberInputScrubber = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'NumberInputScrubber',
+  },
+)

--- a/packages/frameworks/vue/src/number-input/number-input.tsx
+++ b/packages/frameworks/vue/src/number-input/number-input.tsx
@@ -7,11 +7,8 @@ import { useNumberInput, type UseNumberInputProps } from './use-number-input'
 
 export interface NumberInputProps extends Assign<HTMLArkProps<'div'>, UseNumberInputProps> {}
 
-export const NumberInput = defineComponent({
-  name: 'NumberInput',
-  props,
-  emits,
-  setup(props, { slots, attrs, emit }) {
+export const NumberInput = defineComponent<NumberInputProps>(
+  (props, { slots, attrs, emit }) => {
     const api = useNumberInput(props, emit)
     NumberInputProvider(api)
 
@@ -21,4 +18,9 @@ export const NumberInput = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'NumberInput',
+    props,
+    emits,
+  },
+)

--- a/packages/frameworks/vue/src/pagination/pagination-ellipsis.tsx
+++ b/packages/frameworks/vue/src/pagination/pagination-ellipsis.tsx
@@ -6,15 +6,8 @@ import { usePaginationContext } from './pagination-context'
 
 export interface PaginationEllipsisProps extends Assign<HTMLArkProps<'div'>, EllipsisProps> {}
 
-export const PaginationEllipsis = defineComponent({
-  name: 'PaginationEllipsis',
-  props: {
-    index: {
-      type: Number as PropType<EllipsisProps['index']>,
-      required: true,
-    },
-  },
-  setup(props, { slots, attrs }) {
+export const PaginationEllipsis = defineComponent<PaginationEllipsisProps>(
+  (props, { slots, attrs }) => {
     const api = usePaginationContext()
 
     return () => (
@@ -23,4 +16,13 @@ export const PaginationEllipsis = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'PaginationEllipsis',
+    props: {
+      index: {
+        type: Number as PropType<EllipsisProps['index']>,
+        required: true,
+      },
+    },
+  },
+)

--- a/packages/frameworks/vue/src/pagination/pagination-item.tsx
+++ b/packages/frameworks/vue/src/pagination/pagination-item.tsx
@@ -6,15 +6,8 @@ import { usePaginationContext } from './pagination-context'
 
 export interface PaginationItemProps extends Assign<HTMLArkProps<'button'>, ItemProps> {}
 
-export const PaginationItem = defineComponent({
-  name: 'PaginationItem',
-  props: {
-    value: {
-      type: Number as PropType<ItemProps['value']>,
-      required: true,
-    },
-  },
-  setup(props, { slots, attrs }) {
+export const PaginationItem = defineComponent<PaginationItemProps>(
+  (props, { slots, attrs }) => {
     const api = usePaginationContext()
 
     return () => (
@@ -23,4 +16,17 @@ export const PaginationItem = defineComponent({
       </ark.button>
     )
   },
-})
+  {
+    name: 'PaginationItem',
+    props: {
+      type: {
+        type: String as PropType<ItemProps['type']>,
+        default: 'page',
+      },
+      value: {
+        type: Number as PropType<ItemProps['value']>,
+        required: true,
+      },
+    },
+  },
+)

--- a/packages/frameworks/vue/src/pagination/pagination-next-trigger.tsx
+++ b/packages/frameworks/vue/src/pagination/pagination-next-trigger.tsx
@@ -4,9 +4,8 @@ import { usePaginationContext } from './pagination-context'
 
 export interface PaginationNextTriggerProps extends HTMLArkProps<'button'> {}
 
-export const PaginationNextTrigger = defineComponent({
-  name: 'PaginationNextTrigger',
-  setup(_, { slots, attrs }) {
+export const PaginationNextTrigger = defineComponent<PaginationNextTriggerProps>(
+  (_, { slots, attrs }) => {
     const api = usePaginationContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const PaginationNextTrigger = defineComponent({
       </ark.button>
     )
   },
-})
+  {
+    name: 'PaginationNextTrigger',
+  },
+)

--- a/packages/frameworks/vue/src/pagination/pagination-prev-trigger.tsx
+++ b/packages/frameworks/vue/src/pagination/pagination-prev-trigger.tsx
@@ -4,9 +4,8 @@ import { usePaginationContext } from './pagination-context'
 
 export interface PaginationPrevTriggerProps extends HTMLArkProps<'button'> {}
 
-export const PaginationPrevTrigger = defineComponent({
-  name: 'PaginationPrevTrigger',
-  setup(_, { slots, attrs }) {
+export const PaginationPrevTrigger = defineComponent<PaginationPrevTriggerProps>(
+  (_, { slots, attrs }) => {
     const api = usePaginationContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const PaginationPrevTrigger = defineComponent({
       </ark.button>
     )
   },
-})
+  {
+    name: 'PaginationPrevTrigger',
+  },
+)

--- a/packages/frameworks/vue/src/pagination/pagination.tsx
+++ b/packages/frameworks/vue/src/pagination/pagination.tsx
@@ -7,11 +7,8 @@ import { usePagination, type UsePaginationProps } from './use-pagination'
 
 export interface PaginationProps extends Assign<HTMLArkProps<'nav'>, UsePaginationProps> {}
 
-export const Pagination = defineComponent({
-  name: 'Pagination',
-  props,
-  emits,
-  setup(props, { slots, attrs, emit }) {
+export const Pagination = defineComponent<PaginationProps>(
+  (props, { slots, attrs, emit }) => {
     const api = usePagination(props, emit)
     PaginationProvider(api)
 
@@ -21,4 +18,9 @@ export const Pagination = defineComponent({
       </ark.nav>
     )
   },
-})
+  {
+    name: 'Pagination',
+    props,
+    emits,
+  },
+)

--- a/packages/frameworks/vue/src/pin-input/pin-input-control.tsx
+++ b/packages/frameworks/vue/src/pin-input/pin-input-control.tsx
@@ -4,9 +4,8 @@ import { usePinInputContext } from './pin-input-context'
 
 export interface PinInputControlProps extends HTMLArkProps<'div'> {}
 
-export const PinInputControl = defineComponent({
-  name: 'PinInputControl',
-  setup(_, { slots, attrs }) {
+export const PinInputControl = defineComponent<PinInputControlProps>(
+  (_, { slots, attrs }) => {
     const api = usePinInputContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const PinInputControl = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'PinInputControl',
+  },
+)

--- a/packages/frameworks/vue/src/pin-input/pin-input-input.tsx
+++ b/packages/frameworks/vue/src/pin-input/pin-input-input.tsx
@@ -5,17 +5,19 @@ import { usePinInputContext } from './pin-input-context'
 
 export interface PinInputInputProps extends Assign<HTMLArkProps<'input'>, { index: number }> {}
 
-export const PinInputInput = defineComponent({
-  name: 'PinInputInput',
-  props: {
-    index: {
-      type: Number as PropType<PinInputInputProps['index']>,
-      required: true,
-    },
-  },
-  setup(props, { attrs }) {
+export const PinInputInput = defineComponent<PinInputInputProps>(
+  (props, { attrs }) => {
     const api = usePinInputContext()
 
     return () => <ark.input {...api.value.getInputProps({ index: props.index })} {...attrs} />
   },
-})
+  {
+    name: 'PinInputInput',
+    props: {
+      index: {
+        type: Number as PropType<PinInputInputProps['index']>,
+        required: true,
+      },
+    },
+  },
+)

--- a/packages/frameworks/vue/src/pin-input/pin-input-label.tsx
+++ b/packages/frameworks/vue/src/pin-input/pin-input-label.tsx
@@ -4,9 +4,8 @@ import { usePinInputContext } from './pin-input-context'
 
 export interface PinInputLabelProps extends HTMLArkProps<'label'> {}
 
-export const PinInputLabel = defineComponent({
-  name: 'PinInputLabel',
-  setup(_, { slots, attrs }) {
+export const PinInputLabel = defineComponent<PinInputLabelProps>(
+  (_, { slots, attrs }) => {
     const api = usePinInputContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const PinInputLabel = defineComponent({
       </ark.label>
     )
   },
-})
+  {
+    name: 'PinInputLabel',
+  },
+)

--- a/packages/frameworks/vue/src/pin-input/pin-input.tsx
+++ b/packages/frameworks/vue/src/pin-input/pin-input.tsx
@@ -7,11 +7,8 @@ import { usePinInput, type UsePinInputProps } from './use-pin-input'
 
 export interface PinInputProps extends Assign<HTMLArkProps<'div'>, UsePinInputProps> {}
 
-export const PinInput = defineComponent({
-  name: 'PinInput',
-  props,
-  emits,
-  setup(props, { slots, attrs, emit }) {
+export const PinInput = defineComponent<PinInputProps>(
+  (props, { slots, attrs, emit }) => {
     const api = usePinInput(props, emit)
     PinInputProvider(api)
 
@@ -24,4 +21,9 @@ export const PinInput = defineComponent({
       </>
     )
   },
-})
+  {
+    name: 'PinInput',
+    props,
+    emits,
+  },
+)

--- a/packages/frameworks/vue/src/popover/popover-anchor.tsx
+++ b/packages/frameworks/vue/src/popover/popover-anchor.tsx
@@ -4,9 +4,8 @@ import { usePopoverContext } from './popover-context'
 
 export interface PopoverAnchorProps extends HTMLArkProps<'div'> {}
 
-export const PopoverAnchor = defineComponent({
-  name: 'PopoverAnchor',
-  setup(_, { slots, attrs }) {
+export const PopoverAnchor = defineComponent<PopoverAnchorProps>(
+  (_, { slots, attrs }) => {
     const api = usePopoverContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const PopoverAnchor = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'PopoverAnchor',
+  },
+)

--- a/packages/frameworks/vue/src/popover/popover-arrow-tip.tsx
+++ b/packages/frameworks/vue/src/popover/popover-arrow-tip.tsx
@@ -4,9 +4,8 @@ import { usePopoverContext } from './popover-context'
 
 export interface PopoverArrowTipProps extends HTMLArkProps<'div'> {}
 
-export const PopoverArrowTip = defineComponent({
-  name: 'PopoverArrowTip',
-  setup(_, { slots, attrs }) {
+export const PopoverArrowTip = defineComponent<PopoverArrowTipProps>(
+  (_, { slots, attrs }) => {
     const api = usePopoverContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const PopoverArrowTip = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'PopoverArrowTip',
+  },
+)

--- a/packages/frameworks/vue/src/popover/popover-arrow.tsx
+++ b/packages/frameworks/vue/src/popover/popover-arrow.tsx
@@ -4,9 +4,8 @@ import { usePopoverContext } from './popover-context'
 
 export interface PopoverArrowProps extends HTMLArkProps<'div'> {}
 
-export const PopoverArrow = defineComponent({
-  name: 'PopoverArrow',
-  setup(_, { slots, attrs }) {
+export const PopoverArrow = defineComponent<PopoverArrowProps>(
+  (_, { slots, attrs }) => {
     const api = usePopoverContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const PopoverArrow = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'PopoverArrow',
+  },
+)

--- a/packages/frameworks/vue/src/popover/popover-close-trigger.tsx
+++ b/packages/frameworks/vue/src/popover/popover-close-trigger.tsx
@@ -4,9 +4,8 @@ import { usePopoverContext } from './popover-context'
 
 export interface PopoverCloseTriggerProps extends HTMLArkProps<'button'> {}
 
-export const PopoverCloseTrigger = defineComponent({
-  name: 'PopoverCloseTrigger',
-  setup(_, { slots, attrs }) {
+export const PopoverCloseTrigger = defineComponent<PopoverCloseTriggerProps>(
+  (_, { slots, attrs }) => {
     const api = usePopoverContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const PopoverCloseTrigger = defineComponent({
       </ark.button>
     )
   },
-})
+  {
+    name: 'PopoverCloseTrigger',
+  },
+)

--- a/packages/frameworks/vue/src/popover/popover-content.tsx
+++ b/packages/frameworks/vue/src/popover/popover-content.tsx
@@ -6,11 +6,8 @@ import { usePopoverContext } from './popover-context'
 
 export interface PopoverContentProps extends HTMLArkProps<'div'>, PresenceProps {}
 
-export const PopoverContent = defineComponent({
-  name: 'PopoverContent',
-  props,
-  emits,
-  setup(props, { slots, attrs }) {
+export const PopoverContent = defineComponent<PopoverContentProps>(
+  (props, { slots, attrs }) => {
     const api = usePopoverContext()
 
     return () => (
@@ -21,4 +18,9 @@ export const PopoverContent = defineComponent({
       </Presence>
     )
   },
-})
+  {
+    name: 'PopoverContent',
+    props,
+    emits,
+  },
+)

--- a/packages/frameworks/vue/src/popover/popover-description.tsx
+++ b/packages/frameworks/vue/src/popover/popover-description.tsx
@@ -4,9 +4,8 @@ import { usePopoverContext } from './popover-context'
 
 export interface PopoverDescriptionProps extends HTMLArkProps<'p'> {}
 
-export const PopoverDescription = defineComponent({
-  name: 'PopoverDescription',
-  setup(_, { slots, attrs }) {
+export const PopoverDescription = defineComponent<PopoverDescriptionProps>(
+  (_, { slots, attrs }) => {
     const api = usePopoverContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const PopoverDescription = defineComponent({
       </ark.p>
     )
   },
-})
+  {
+    name: 'PopoverDescription',
+  },
+)

--- a/packages/frameworks/vue/src/popover/popover-indicator.tsx
+++ b/packages/frameworks/vue/src/popover/popover-indicator.tsx
@@ -4,9 +4,8 @@ import { usePopoverContext } from './popover-context'
 
 export interface PopoverIndicatorProps extends HTMLArkProps<'div'> {}
 
-export const PopoverIndicator = defineComponent({
-  name: 'PopoverIndicator',
-  setup(_, { slots, attrs }) {
+export const PopoverIndicator = defineComponent<PopoverIndicatorProps>(
+  (_, { slots, attrs }) => {
     const api = usePopoverContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const PopoverIndicator = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'PopoverIndicator',
+  },
+)

--- a/packages/frameworks/vue/src/popover/popover-positioner.tsx
+++ b/packages/frameworks/vue/src/popover/popover-positioner.tsx
@@ -4,9 +4,8 @@ import { usePopoverContext } from './popover-context'
 
 export interface PopoverPositionerProps extends HTMLArkProps<'div'> {}
 
-export const PopoverPositioner = defineComponent({
-  name: 'PopoverPositioner',
-  setup(_, { slots, attrs }) {
+export const PopoverPositioner = defineComponent<PopoverPositionerProps>(
+  (_, { slots, attrs }) => {
     const api = usePopoverContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const PopoverPositioner = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'PopoverPositioner',
+  },
+)

--- a/packages/frameworks/vue/src/popover/popover-title.tsx
+++ b/packages/frameworks/vue/src/popover/popover-title.tsx
@@ -4,9 +4,8 @@ import { usePopoverContext } from './popover-context'
 
 export interface PopoverTitleProps extends HTMLArkProps<'div'> {}
 
-export const PopoverTitle = defineComponent({
-  name: 'PopoverTitle',
-  setup(_, { slots, attrs }) {
+export const PopoverTitle = defineComponent<PopoverTitleProps>(
+  (_, { slots, attrs }) => {
     const api = usePopoverContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const PopoverTitle = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'PopoverTitle',
+  },
+)

--- a/packages/frameworks/vue/src/popover/popover-trigger.tsx
+++ b/packages/frameworks/vue/src/popover/popover-trigger.tsx
@@ -4,9 +4,8 @@ import { usePopoverContext } from './popover-context'
 
 export interface PopoverTriggerProps extends HTMLArkProps<'button'> {}
 
-export const PopoverTrigger = defineComponent({
-  name: 'PopoverTrigger',
-  setup(_, { slots, attrs }) {
+export const PopoverTrigger = defineComponent<PopoverTriggerProps>(
+  (_, { slots, attrs }) => {
     const api = usePopoverContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const PopoverTrigger = defineComponent({
       </ark.button>
     )
   },
-})
+  {
+    name: 'PopoverTrigger',
+  },
+)

--- a/packages/frameworks/vue/src/popover/popover.tsx
+++ b/packages/frameworks/vue/src/popover/popover.tsx
@@ -5,14 +5,16 @@ import { usePopover, type UsePopoverProps } from './use-popover'
 
 export interface PopoverProps extends UsePopoverProps {}
 
-export const Popover = defineComponent({
-  name: 'Popover',
-  props,
-  emits,
-  setup(props, { slots, emit }) {
+export const Popover = defineComponent<PopoverProps>(
+  (props, { slots, emit }) => {
     const api = usePopover(props, emit)
     PopoverProvider(api)
 
     return () => slots.default?.(api.value)
   },
-})
+  {
+    name: 'Popover',
+    props,
+    emits,
+  },
+)

--- a/packages/frameworks/vue/src/presence/presence.tsx
+++ b/packages/frameworks/vue/src/presence/presence.tsx
@@ -6,24 +6,8 @@ import { usePresence, type UsePresenceProps } from './use-presence'
 
 export interface PresenceProps extends Assign<HTMLArkProps<'div'>, UsePresenceProps> {}
 
-export const Presence = defineComponent({
-  name: 'Presence',
-  props: {
-    present: {
-      type: Boolean as PropType<UsePresenceProps['present']>,
-      default: undefined,
-    },
-    lazyMount: {
-      type: Boolean as PropType<UsePresenceProps['lazyMount']>,
-      default: undefined,
-    },
-    unmountOnExit: {
-      type: Boolean as PropType<UsePresenceProps['unmountOnExit']>,
-      default: undefined,
-    },
-  },
-  emits,
-  setup(props, { slots, attrs, emit }) {
+export const Presence = defineComponent<PresenceProps>(
+  (props, { slots, attrs, emit }) => {
     const api = usePresence(props, emit)
 
     return () =>
@@ -33,4 +17,22 @@ export const Presence = defineComponent({
         </ark.div>
       )
   },
-})
+  {
+    name: 'Presence',
+    props: {
+      present: {
+        type: Boolean as PropType<UsePresenceProps['present']>,
+        default: undefined,
+      },
+      lazyMount: {
+        type: Boolean as PropType<UsePresenceProps['lazyMount']>,
+        default: undefined,
+      },
+      unmountOnExit: {
+        type: Boolean as PropType<UsePresenceProps['unmountOnExit']>,
+        default: undefined,
+      },
+    },
+    emits,
+  },
+)

--- a/packages/frameworks/vue/src/radio-group/radio-group-indicator.tsx
+++ b/packages/frameworks/vue/src/radio-group/radio-group-indicator.tsx
@@ -4,9 +4,8 @@ import { useRadioGroupContext } from './radio-group-context'
 
 export interface RadioGroupIndicatorProps extends HTMLArkProps<'div'> {}
 
-export const RadioGroupIndicator = defineComponent({
-  name: 'RadioGroupIndicator',
-  setup(_, { slots, attrs }) {
+export const RadioGroupIndicator = defineComponent<RadioGroupIndicatorProps>(
+  (_, { slots, attrs }) => {
     const api = useRadioGroupContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const RadioGroupIndicator = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'RadioGroupIndicator',
+  },
+)

--- a/packages/frameworks/vue/src/radio-group/radio-group-item-control.tsx
+++ b/packages/frameworks/vue/src/radio-group/radio-group-item-control.tsx
@@ -5,9 +5,8 @@ import { useRadioGroupItemContext } from './radio-group-item-context'
 
 export interface RadioGroupItemControlProps extends HTMLArkProps<'div'> {}
 
-export const RadioGroupItemControl = defineComponent({
-  name: 'RadioGroupItemControl',
-  setup(_, { slots, attrs }) {
+export const RadioGroupItemControl = defineComponent<RadioGroupItemControlProps>(
+  (_, { slots, attrs }) => {
     const api = useRadioGroupContext()
     const itemProps = useRadioGroupItemContext()
 
@@ -20,4 +19,7 @@ export const RadioGroupItemControl = defineComponent({
       </>
     )
   },
-})
+  {
+    name: 'RadioGroupItemControl',
+  },
+)

--- a/packages/frameworks/vue/src/radio-group/radio-group-item-text.tsx
+++ b/packages/frameworks/vue/src/radio-group/radio-group-item-text.tsx
@@ -5,9 +5,8 @@ import { useRadioGroupItemContext } from './radio-group-item-context'
 
 export interface RadioGroupItemTextProps extends HTMLArkProps<'span'> {}
 
-export const RadioGroupItemText = defineComponent({
-  name: 'RadioGroupItemText',
-  setup(_, { slots, attrs }) {
+export const RadioGroupItemText = defineComponent<RadioGroupItemTextProps>(
+  (_, { slots, attrs }) => {
     const api = useRadioGroupContext()
     const itemProps = useRadioGroupItemContext()
 
@@ -17,4 +16,7 @@ export const RadioGroupItemText = defineComponent({
       </ark.span>
     )
   },
-})
+  {
+    name: 'RadioGroupItemText',
+  },
+)

--- a/packages/frameworks/vue/src/radio-group/radio-group-item.tsx
+++ b/packages/frameworks/vue/src/radio-group/radio-group-item.tsx
@@ -7,24 +7,8 @@ import { RadioGroupItemProvider } from './radio-group-item-context'
 
 export interface RadioGroupItemProps extends Assign<HTMLArkProps<'label'>, ItemProps> {}
 
-export const RadioGroupItem = defineComponent({
-  name: 'RadioGroupItem',
-  props: {
-    value: {
-      type: String as PropType<ItemProps['value']>,
-      required: true,
-    },
-    disabled: {
-      type: Boolean as PropType<ItemProps['disabled']>,
-      default: undefined,
-    },
-    invalid: {
-      type: Boolean as PropType<ItemProps['invalid']>,
-      default: undefined,
-    },
-  },
-
-  setup(props, { slots, attrs }) {
+export const RadioGroupItem = defineComponent<RadioGroupItemProps>(
+  (props, { slots, attrs }) => {
     const api = useRadioGroupContext()
     RadioGroupItemProvider(computed(() => props))
 
@@ -34,4 +18,21 @@ export const RadioGroupItem = defineComponent({
       </ark.label>
     )
   },
-})
+  {
+    name: 'RadioGroupItem',
+    props: {
+      value: {
+        type: String as PropType<ItemProps['value']>,
+        required: true,
+      },
+      disabled: {
+        type: Boolean as PropType<ItemProps['disabled']>,
+        default: undefined,
+      },
+      invalid: {
+        type: Boolean as PropType<ItemProps['invalid']>,
+        default: undefined,
+      },
+    },
+  },
+)

--- a/packages/frameworks/vue/src/radio-group/radio-group-label.tsx
+++ b/packages/frameworks/vue/src/radio-group/radio-group-label.tsx
@@ -4,9 +4,8 @@ import { useRadioGroupContext } from './radio-group-context'
 
 export interface RadioGroupLabelProps extends HTMLArkProps<'label'> {}
 
-export const RadioGroupLabel = defineComponent({
-  name: 'RadioGroupLabel',
-  setup(_, { slots, attrs }) {
+export const RadioGroupLabel = defineComponent<RadioGroupLabelProps>(
+  (_, { slots, attrs }) => {
     const api = useRadioGroupContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const RadioGroupLabel = defineComponent({
       </ark.label>
     )
   },
-})
+  {
+    name: 'RadioGroupLabel',
+  },
+)

--- a/packages/frameworks/vue/src/radio-group/radio-group.tsx
+++ b/packages/frameworks/vue/src/radio-group/radio-group.tsx
@@ -7,11 +7,8 @@ import { useRadioGroup, type UseRadioGroupProps } from './use-radio-group'
 
 export interface RadioGroupProps extends Assign<HTMLArkProps<'div'>, UseRadioGroupProps> {}
 
-export const RadioGroup = defineComponent({
-  name: 'RadioGroup',
-  props,
-  emits,
-  setup(props, { slots, attrs, emit }) {
+export const RadioGroup = defineComponent<RadioGroupProps>(
+  (props, { slots, attrs, emit }) => {
     const api = useRadioGroup(props, emit)
     RadioGroupProvider(api)
 
@@ -21,4 +18,9 @@ export const RadioGroup = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'RadioGroup',
+    props,
+    emits,
+  },
+)

--- a/packages/frameworks/vue/src/rating-group/rating-group-control.tsx
+++ b/packages/frameworks/vue/src/rating-group/rating-group-control.tsx
@@ -4,9 +4,8 @@ import { useRatingGroupContext } from './rating-group-context'
 
 export interface RatingGroupControlProps extends HTMLArkProps<'div'> {}
 
-export const RatingGroupControl = defineComponent({
-  name: 'RatingGroupControl',
-  setup(_, { slots, attrs }) {
+export const RatingGroupControl = defineComponent<RatingGroupControlProps>(
+  (_, { slots, attrs }) => {
     const api = useRatingGroupContext()
 
     return () => (
@@ -18,4 +17,7 @@ export const RatingGroupControl = defineComponent({
       </>
     )
   },
-})
+  {
+    name: 'RatingGroupControl',
+  },
+)

--- a/packages/frameworks/vue/src/rating-group/rating-group-item.tsx
+++ b/packages/frameworks/vue/src/rating-group/rating-group-item.tsx
@@ -7,15 +7,8 @@ import { RatingGroupItemProvider } from './rating-group-item-context'
 
 export interface RatingGroupItemProps extends Assign<HTMLArkProps<'span'>, ItemProps> {}
 
-export const RatingGroupItem = defineComponent({
-  name: 'RatingGroupItem',
-  props: {
-    index: {
-      type: Number as PropType<ItemProps['index']>,
-      required: true,
-    },
-  },
-  setup(props, { slots, attrs }) {
+export const RatingGroupItem = defineComponent<RatingGroupItemProps>(
+  (props, { slots, attrs }) => {
     const api = useRatingGroupContext()
     const itemState = computed(() => api.value.getItemState(props))
     RatingGroupItemProvider(computed(() => props))
@@ -26,4 +19,13 @@ export const RatingGroupItem = defineComponent({
       </ark.span>
     )
   },
-})
+  {
+    name: 'RatingGroupItem',
+    props: {
+      index: {
+        type: Number as PropType<ItemProps['index']>,
+        required: true,
+      },
+    },
+  },
+)

--- a/packages/frameworks/vue/src/rating-group/rating-group-label.tsx
+++ b/packages/frameworks/vue/src/rating-group/rating-group-label.tsx
@@ -4,9 +4,8 @@ import { useRatingGroupContext } from './rating-group-context'
 
 export interface RatingGroupLabelProps extends HTMLArkProps<'label'> {}
 
-export const RatingGroupLabel = defineComponent({
-  name: 'RatingGroupLabel',
-  setup(_, { slots, attrs }) {
+export const RatingGroupLabel = defineComponent<RatingGroupLabelProps>(
+  (_, { slots, attrs }) => {
     const api = useRatingGroupContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const RatingGroupLabel = defineComponent({
       </ark.label>
     )
   },
-})
+  {
+    name: 'RatingGroupLabel',
+  },
+)

--- a/packages/frameworks/vue/src/rating-group/rating-group.tsx
+++ b/packages/frameworks/vue/src/rating-group/rating-group.tsx
@@ -7,11 +7,8 @@ import { useRatingGroup, type UseRatingGroupProps } from './use-rating-group'
 
 export interface RatingGroupProps extends Assign<HTMLArkProps<'div'>, UseRatingGroupProps> {}
 
-export const RatingGroup = defineComponent({
-  name: 'RatingGroup',
-  props,
-  emits,
-  setup(props, { slots, attrs, emit }) {
+export const RatingGroup = defineComponent<RatingGroupProps>(
+  (props, { slots, attrs, emit }) => {
     const api = useRatingGroup(props, emit)
     RatingGroupProvider(api)
 
@@ -21,4 +18,9 @@ export const RatingGroup = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'RatingGroup',
+    props,
+    emits,
+  },
+)

--- a/packages/frameworks/vue/src/segment-group/segment-group-indicator.tsx
+++ b/packages/frameworks/vue/src/segment-group/segment-group-indicator.tsx
@@ -5,9 +5,8 @@ import { useSegmentGroupContext } from './segment-group-context'
 
 export interface SegmentGroupIndicatorProps extends HTMLArkProps<'div'> {}
 
-export const SegmentGroupIndicator = defineComponent({
-  name: 'SegmentGroupIndicator',
-  setup(_, { slots, attrs }) {
+export const SegmentGroupIndicator = defineComponent<SegmentGroupIndicatorProps>(
+  (_, { slots, attrs }) => {
     const api = useSegmentGroupContext()
 
     return () => (
@@ -20,4 +19,7 @@ export const SegmentGroupIndicator = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'SegmentGroupIndicator',
+  },
+)

--- a/packages/frameworks/vue/src/segment-group/segment-group-item-control.tsx
+++ b/packages/frameworks/vue/src/segment-group/segment-group-item-control.tsx
@@ -6,9 +6,8 @@ import { useSegmentGroupItemContext } from './segment-group-item-context'
 
 export interface SegmentGroupItemControlProps extends HTMLArkProps<'div'> {}
 
-export const SegmentGroupItemControl = defineComponent({
-  name: 'SegmentGroupItemControl',
-  setup(_, { slots, attrs }) {
+export const SegmentGroupItemControl = defineComponent<SegmentGroupItemControlProps>(
+  (_, { slots, attrs }) => {
     const api = useSegmentGroupContext()
     const itemProps = useSegmentGroupItemContext()
 
@@ -25,4 +24,7 @@ export const SegmentGroupItemControl = defineComponent({
       </>
     )
   },
-})
+  {
+    name: 'SegmentGroupItemControl',
+  },
+)

--- a/packages/frameworks/vue/src/segment-group/segment-group-item-text.tsx
+++ b/packages/frameworks/vue/src/segment-group/segment-group-item-text.tsx
@@ -6,9 +6,8 @@ import { useSegmentGroupItemContext } from './segment-group-item-context'
 
 export interface SegmentGroupItemTextProps extends HTMLArkProps<'span'> {}
 
-export const SegmentGroupItemText = defineComponent({
-  name: 'SegmentGroupItemText',
-  setup(_, { slots, attrs }) {
+export const SegmentGroupItemText = defineComponent<SegmentGroupItemTextProps>(
+  (_, { slots, attrs }) => {
     const api = useSegmentGroupContext()
     const itemProps = useSegmentGroupItemContext()
 
@@ -22,4 +21,7 @@ export const SegmentGroupItemText = defineComponent({
       </ark.span>
     )
   },
-})
+  {
+    name: 'SegmentGroupItemText',
+  },
+)

--- a/packages/frameworks/vue/src/segment-group/segment-group-item.tsx
+++ b/packages/frameworks/vue/src/segment-group/segment-group-item.tsx
@@ -8,24 +8,8 @@ import { SegmentGroupItemProvider } from './segment-group-item-context'
 
 export interface SegmentGroupItemProps extends Assign<HTMLArkProps<'label'>, ItemProps> {}
 
-export const SegmentGroupItem = defineComponent({
-  name: 'SegmentGroupItem',
-  props: {
-    value: {
-      type: String as PropType<ItemProps['value']>,
-      required: true,
-    },
-    disabled: {
-      type: Boolean as PropType<ItemProps['disabled']>,
-      default: undefined,
-    },
-    invalid: {
-      type: Boolean as PropType<ItemProps['invalid']>,
-      default: undefined,
-    },
-  },
-
-  setup(props, { slots, attrs }) {
+export const SegmentGroupItem = defineComponent<SegmentGroupItemProps>(
+  (props, { slots, attrs }) => {
     const api = useSegmentGroupContext()
     SegmentGroupItemProvider(computed(() => props))
 
@@ -39,4 +23,21 @@ export const SegmentGroupItem = defineComponent({
       </ark.label>
     )
   },
-})
+  {
+    name: 'SegmentGroupItem',
+    props: {
+      value: {
+        type: String as PropType<ItemProps['value']>,
+        required: true,
+      },
+      disabled: {
+        type: Boolean as PropType<ItemProps['disabled']>,
+        default: undefined,
+      },
+      invalid: {
+        type: Boolean as PropType<ItemProps['invalid']>,
+        default: undefined,
+      },
+    },
+  },
+)

--- a/packages/frameworks/vue/src/segment-group/segment-group-label.tsx
+++ b/packages/frameworks/vue/src/segment-group/segment-group-label.tsx
@@ -5,9 +5,8 @@ import { useSegmentGroupContext } from './segment-group-context'
 
 export interface SegmentGroupLabelProps extends HTMLArkProps<'label'> {}
 
-export const SegmentGroupLabel = defineComponent({
-  name: 'SegmentGroupLabel',
-  setup(_, { slots, attrs }) {
+export const SegmentGroupLabel = defineComponent<SegmentGroupLabelProps>(
+  (_, { slots, attrs }) => {
     const api = useSegmentGroupContext()
 
     return () => (
@@ -16,4 +15,7 @@ export const SegmentGroupLabel = defineComponent({
       </ark.label>
     )
   },
-})
+  {
+    name: 'SegmentGroupLabel',
+  },
+)

--- a/packages/frameworks/vue/src/segment-group/segment-group.tsx
+++ b/packages/frameworks/vue/src/segment-group/segment-group.tsx
@@ -8,11 +8,8 @@ import { useSegmentGroup, type UseSegmentGroupProps } from './use-segment-group'
 
 export interface SegmentGroupProps extends Assign<HTMLArkProps<'div'>, UseSegmentGroupProps> {}
 
-export const SegmentGroup = defineComponent({
-  name: 'SegmentGroup',
-  props,
-  emits,
-  setup(props, { slots, attrs, emit }) {
+export const SegmentGroup = defineComponent<SegmentGroupProps>(
+  (props, { slots, attrs, emit }) => {
     const api = useSegmentGroup(props, emit)
     SegmentGroupProvider(api)
 
@@ -22,4 +19,9 @@ export const SegmentGroup = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'SegmentGroup',
+    props,
+    emits,
+  },
+)

--- a/packages/frameworks/vue/src/slider/slider-control.tsx
+++ b/packages/frameworks/vue/src/slider/slider-control.tsx
@@ -4,9 +4,8 @@ import { useSliderContext } from './slider-context'
 
 export interface SliderControlProps extends HTMLArkProps<'div'> {}
 
-export const SliderControl = defineComponent({
-  name: 'SliderControl',
-  setup(_, { slots, attrs }) {
+export const SliderControl = defineComponent<SliderControlProps>(
+  (_, { slots, attrs }) => {
     const api = useSliderContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const SliderControl = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'SliderControl',
+  },
+)

--- a/packages/frameworks/vue/src/slider/slider-label.tsx
+++ b/packages/frameworks/vue/src/slider/slider-label.tsx
@@ -4,9 +4,8 @@ import { useSliderContext } from './slider-context'
 
 export interface SliderLabelProps extends HTMLArkProps<'label'> {}
 
-export const SliderLabel = defineComponent({
-  name: 'SliderLabel',
-  setup(_, { slots, attrs }) {
+export const SliderLabel = defineComponent<SliderLabelProps>(
+  (_, { slots, attrs }) => {
     const api = useSliderContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const SliderLabel = defineComponent({
       </ark.label>
     )
   },
-})
+  {
+    name: 'SliderLabel',
+  },
+)

--- a/packages/frameworks/vue/src/slider/slider-marker-group.tsx
+++ b/packages/frameworks/vue/src/slider/slider-marker-group.tsx
@@ -4,9 +4,8 @@ import { useSliderContext } from './slider-context'
 
 export interface SliderMarkerGroupProps extends HTMLArkProps<'div'> {}
 
-export const SliderMarkerGroup = defineComponent({
-  name: 'SliderMarkerGroup',
-  setup(_, { slots, attrs }) {
+export const SliderMarkerGroup = defineComponent<SliderMarkerGroupProps>(
+  (_, { slots, attrs }) => {
     const api = useSliderContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const SliderMarkerGroup = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'SliderMarkerGroup',
+  },
+)

--- a/packages/frameworks/vue/src/slider/slider-marker.tsx
+++ b/packages/frameworks/vue/src/slider/slider-marker.tsx
@@ -6,15 +6,8 @@ import { useSliderContext } from './slider-context'
 
 export interface SliderMarkerProps extends Assign<HTMLArkProps<'span'>, MarkerProps> {}
 
-export const SliderMarker = defineComponent({
-  name: 'SliderMarker',
-  props: {
-    value: {
-      type: Number as PropType<MarkerProps['value']>,
-      required: true,
-    },
-  },
-  setup(props, { slots, attrs }) {
+export const SliderMarker = defineComponent<SliderMarkerProps>(
+  (props, { slots, attrs }) => {
     const api = useSliderContext()
 
     return () => (
@@ -23,4 +16,13 @@ export const SliderMarker = defineComponent({
       </ark.span>
     )
   },
-})
+  {
+    name: 'SliderMarker',
+    props: {
+      value: {
+        type: Number as PropType<MarkerProps['value']>,
+        required: true,
+      },
+    },
+  },
+)

--- a/packages/frameworks/vue/src/slider/slider-range.tsx
+++ b/packages/frameworks/vue/src/slider/slider-range.tsx
@@ -4,9 +4,8 @@ import { useSliderContext } from './slider-context'
 
 export interface SliderRangeProps extends HTMLArkProps<'div'> {}
 
-export const SliderRange = defineComponent({
-  name: 'SliderRange',
-  setup(_, { slots, attrs }) {
+export const SliderRange = defineComponent<SliderRangeProps>(
+  (_, { slots, attrs }) => {
     const api = useSliderContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const SliderRange = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'SliderRange',
+  },
+)

--- a/packages/frameworks/vue/src/slider/slider-thumb.tsx
+++ b/packages/frameworks/vue/src/slider/slider-thumb.tsx
@@ -6,15 +6,8 @@ import { useSliderContext } from './slider-context'
 
 export interface SliderThumbProps extends Assign<HTMLArkProps<'div'>, ThumbProps> {}
 
-export const SliderThumb = defineComponent({
-  name: 'SliderThumb',
-  props: {
-    index: {
-      type: Number as PropType<ThumbProps['index']>,
-      required: true,
-    },
-  },
-  setup(props, { slots, attrs }) {
+export const SliderThumb = defineComponent<SliderThumbProps>(
+  (props, { slots, attrs }) => {
     const api = useSliderContext()
 
     return () => (
@@ -26,4 +19,13 @@ export const SliderThumb = defineComponent({
       </>
     )
   },
-})
+  {
+    name: 'SliderThumb',
+    props: {
+      index: {
+        type: Number as PropType<ThumbProps['index']>,
+        required: true,
+      },
+    },
+  },
+)

--- a/packages/frameworks/vue/src/slider/slider-track.tsx
+++ b/packages/frameworks/vue/src/slider/slider-track.tsx
@@ -4,9 +4,8 @@ import { useSliderContext } from './slider-context'
 
 export interface SliderTrackProps extends HTMLArkProps<'div'> {}
 
-export const SliderTrack = defineComponent({
-  name: 'SliderTrack',
-  setup(_, { slots, attrs }) {
+export const SliderTrack = defineComponent<SliderTrackProps>(
+  (_, { slots, attrs }) => {
     const api = useSliderContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const SliderTrack = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'SliderTrack',
+  },
+)

--- a/packages/frameworks/vue/src/slider/slider-value-text.tsx
+++ b/packages/frameworks/vue/src/slider/slider-value-text.tsx
@@ -4,9 +4,8 @@ import { useSliderContext } from './slider-context'
 
 export interface SliderValueTextProps extends HTMLArkProps<'span'> {}
 
-export const SliderValueText = defineComponent({
-  name: 'SliderValueText',
-  setup(_, { slots, attrs }) {
+export const SliderValueText = defineComponent<SliderValueTextProps>(
+  (_, { slots, attrs }) => {
     const api = useSliderContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const SliderValueText = defineComponent({
       </ark.span>
     )
   },
-})
+  {
+    name: 'SliderValueText',
+  },
+)

--- a/packages/frameworks/vue/src/slider/slider.tsx
+++ b/packages/frameworks/vue/src/slider/slider.tsx
@@ -7,11 +7,8 @@ import { useSlider, type UseSliderProps } from './use-slider'
 
 export interface SliderProps extends Assign<HTMLArkProps<'div'>, UseSliderProps> {}
 
-export const Slider = defineComponent({
-  name: 'Slider',
-  props,
-  emits,
-  setup(props, { slots, attrs, emit }) {
+export const Slider = defineComponent<SliderProps>(
+  (props, { slots, attrs, emit }) => {
     const api = useSlider(props, emit)
     SliderProvider(api)
 
@@ -21,4 +18,9 @@ export const Slider = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'Slider',
+    props,
+    emits,
+  },
+)

--- a/packages/frameworks/vue/src/splitter/splitter-panel.tsx
+++ b/packages/frameworks/vue/src/splitter/splitter-panel.tsx
@@ -6,16 +6,8 @@ import { useSplitterContext } from './splitter-context'
 
 export interface SplitterPanelProps extends Assign<HTMLArkProps<'div'>, PanelProps> {}
 
-export const SplitterPanel = defineComponent({
-  name: 'SplitterPanel',
-  props: {
-    id: {
-      type: [String, Number] as PropType<SplitterPanelProps['id']>,
-      required: true,
-    },
-    snapSize: Number as PropType<SplitterPanelProps['snapSize']>,
-  },
-  setup(props, { slots, attrs }) {
+export const SplitterPanel = defineComponent<SplitterPanelProps>(
+  (props, { slots, attrs }) => {
     const api = useSplitterContext()
 
     return () => (
@@ -24,4 +16,14 @@ export const SplitterPanel = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'SplitterPanel',
+    props: {
+      id: {
+        type: [String, Number] as PropType<SplitterPanelProps['id']>,
+        required: true,
+      },
+      snapSize: Number as PropType<SplitterPanelProps['snapSize']>,
+    },
+  },
+)

--- a/packages/frameworks/vue/src/splitter/splitter-resize-trigger.tsx
+++ b/packages/frameworks/vue/src/splitter/splitter-resize-trigger.tsx
@@ -7,21 +7,8 @@ import { useSplitterContext } from './splitter-context'
 export interface SplitterResizeTriggerProps
   extends Assign<HTMLArkProps<'button'>, ResizeTriggerProps> {}
 
-export const SplitterResizeTrigger = defineComponent({
-  name: 'SplitterResizeTrigger',
-  props: {
-    id: {
-      type: String as PropType<SplitterResizeTriggerProps['id']>,
-      required: true,
-    },
-    step: {
-      type: Number as PropType<SplitterResizeTriggerProps['step']>,
-    },
-    disabled: {
-      type: Boolean as PropType<SplitterResizeTriggerProps['disabled']>,
-    },
-  },
-  setup(props, { slots, attrs }) {
+export const SplitterResizeTrigger = defineComponent<SplitterResizeTriggerProps>(
+  (props, { slots, attrs }) => {
     const api = useSplitterContext()
 
     return () => (
@@ -30,4 +17,19 @@ export const SplitterResizeTrigger = defineComponent({
       </ark.button>
     )
   },
-})
+  {
+    name: 'SplitterResizeTrigger',
+    props: {
+      id: {
+        type: String as PropType<SplitterResizeTriggerProps['id']>,
+        required: true,
+      },
+      step: {
+        type: Number as PropType<SplitterResizeTriggerProps['step']>,
+      },
+      disabled: {
+        type: Boolean as PropType<SplitterResizeTriggerProps['disabled']>,
+      },
+    },
+  },
+)

--- a/packages/frameworks/vue/src/splitter/splitter.tsx
+++ b/packages/frameworks/vue/src/splitter/splitter.tsx
@@ -7,11 +7,8 @@ import { useSplitter, type UseSplitterProps } from './use-splitter'
 
 export interface SplitterProps extends Assign<HTMLArkProps<'div'>, UseSplitterProps> {}
 
-export const Splitter = defineComponent({
-  name: 'Splitter',
-  props,
-  emits,
-  setup(props, { slots, attrs, emit }) {
+export const Splitter = defineComponent<SplitterProps>(
+  (props, { slots, attrs, emit }) => {
     const api = useSplitter(props, emit)
     SplitterProvider(api)
 
@@ -21,4 +18,9 @@ export const Splitter = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'Splitter',
+    props,
+    emits,
+  },
+)

--- a/packages/frameworks/vue/src/switch/switch-control.tsx
+++ b/packages/frameworks/vue/src/switch/switch-control.tsx
@@ -4,9 +4,8 @@ import { useSwitchContext } from './switch-context'
 
 export interface SwitchControlProps extends HTMLArkProps<'span'> {}
 
-export const SwitchControl = defineComponent({
-  name: 'SwitchControl',
-  setup(_, { slots, attrs }) {
+export const SwitchControl = defineComponent<SwitchControlProps>(
+  (_, { slots, attrs }) => {
     const api = useSwitchContext()
 
     return () => (
@@ -18,4 +17,7 @@ export const SwitchControl = defineComponent({
       </>
     )
   },
-})
+  {
+    name: 'SwitchControl',
+  },
+)

--- a/packages/frameworks/vue/src/switch/switch-label.tsx
+++ b/packages/frameworks/vue/src/switch/switch-label.tsx
@@ -4,9 +4,8 @@ import { useSwitchContext } from './switch-context'
 
 export interface SwitchLabelProps extends HTMLArkProps<'span'> {}
 
-export const SwitchLabel = defineComponent({
-  name: 'SwitchLabel',
-  setup(_, { slots, attrs }) {
+export const SwitchLabel = defineComponent<SwitchLabelProps>(
+  (_, { slots, attrs }) => {
     const api = useSwitchContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const SwitchLabel = defineComponent({
       </ark.span>
     )
   },
-})
+  {
+    name: 'SwitchLabel',
+  },
+)

--- a/packages/frameworks/vue/src/switch/switch-thumb.tsx
+++ b/packages/frameworks/vue/src/switch/switch-thumb.tsx
@@ -4,9 +4,8 @@ import { useSwitchContext } from './switch-context'
 
 export interface SwitchThumbProps extends HTMLArkProps<'span'> {}
 
-export const SwitchThumb = defineComponent({
-  name: 'SwitchThumb',
-  setup(_, { slots, attrs }) {
+export const SwitchThumb = defineComponent<SwitchThumbProps>(
+  (_, { slots, attrs }) => {
     const api = useSwitchContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const SwitchThumb = defineComponent({
       </ark.span>
     )
   },
-})
+  {
+    name: 'SwitchThumb',
+  },
+)

--- a/packages/frameworks/vue/src/switch/switch.tsx
+++ b/packages/frameworks/vue/src/switch/switch.tsx
@@ -7,11 +7,8 @@ import { useSwitch, type UseSwitchProps } from './use-switch'
 
 export interface SwitchProps extends Assign<HTMLArkProps<'div'>, UseSwitchProps> {}
 
-export const Switch = defineComponent({
-  name: 'Switch',
-  props,
-  emits,
-  setup(props, { slots, attrs, emit }) {
+export const Switch = defineComponent<SwitchProps>(
+  (props, { slots, attrs, emit }) => {
     const api = useSwitch(props, emit)
     SwitchProvider(api)
 
@@ -21,4 +18,9 @@ export const Switch = defineComponent({
       </ark.label>
     )
   },
-})
+  {
+    name: 'Switch',
+    props,
+    emits,
+  },
+)

--- a/packages/frameworks/vue/src/tabs/tab-content.tsx
+++ b/packages/frameworks/vue/src/tabs/tab-content.tsx
@@ -6,15 +6,8 @@ import { useTabsContext } from './tabs-context'
 
 export interface TabContentProps extends Assign<HTMLArkProps<'div'>, ContentProps> {}
 
-export const TabContent = defineComponent({
-  name: 'TabContent',
-  props: {
-    value: {
-      type: String as PropType<TabContentProps['value']>,
-      required: true,
-    },
-  },
-  setup(props, { slots, attrs }) {
+export const TabContent = defineComponent<TabContentProps>(
+  (props, { slots, attrs }) => {
     const api = useTabsContext()
 
     return () => (
@@ -23,4 +16,13 @@ export const TabContent = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'TabContent',
+    props: {
+      value: {
+        type: String as PropType<TabContentProps['value']>,
+        required: true,
+      },
+    },
+  },
+)

--- a/packages/frameworks/vue/src/tabs/tab-indicator.tsx
+++ b/packages/frameworks/vue/src/tabs/tab-indicator.tsx
@@ -4,9 +4,8 @@ import { useTabsContext } from './tabs-context'
 
 export interface TabIndicatorProps extends HTMLArkProps<'div'> {}
 
-export const TabIndicator = defineComponent({
-  name: 'TabIndicator',
-  setup(_, { slots, attrs }) {
+export const TabIndicator = defineComponent<TabIndicatorProps>(
+  (_, { slots, attrs }) => {
     const api = useTabsContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const TabIndicator = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'TabIndicator',
+  },
+)

--- a/packages/frameworks/vue/src/tabs/tab-list.tsx
+++ b/packages/frameworks/vue/src/tabs/tab-list.tsx
@@ -4,9 +4,8 @@ import { useTabsContext } from './tabs-context'
 
 export interface TabListProps extends HTMLArkProps<'div'> {}
 
-export const TabList = defineComponent({
-  name: 'TabList',
-  setup(_, { slots, attrs }) {
+export const TabList = defineComponent<TabListProps>(
+  (_, { slots, attrs }) => {
     const api = useTabsContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const TabList = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'TabList',
+  },
+)

--- a/packages/frameworks/vue/src/tabs/tab-trigger.tsx
+++ b/packages/frameworks/vue/src/tabs/tab-trigger.tsx
@@ -6,18 +6,8 @@ import { useTabsContext } from './tabs-context'
 
 export interface TabTriggerProps extends Assign<HTMLArkProps<'button'>, TriggerProps> {}
 
-export const TabTrigger = defineComponent({
-  name: 'TabTrigger',
-  props: {
-    value: {
-      type: String as PropType<TabTriggerProps['value']>,
-      required: true,
-    },
-    disabled: {
-      type: Boolean as PropType<TabTriggerProps['disabled']>,
-    },
-  },
-  setup(props, { slots, attrs }) {
+export const TabTrigger = defineComponent<TabTriggerProps>(
+  (props, { slots, attrs }) => {
     const api = useTabsContext()
 
     return () => (
@@ -26,4 +16,16 @@ export const TabTrigger = defineComponent({
       </ark.button>
     )
   },
-})
+  {
+    name: 'TabTrigger',
+    props: {
+      value: {
+        type: String as PropType<TabTriggerProps['value']>,
+        required: true,
+      },
+      disabled: {
+        type: Boolean as PropType<TabTriggerProps['disabled']>,
+      },
+    },
+  },
+)

--- a/packages/frameworks/vue/src/tabs/tabs.tsx
+++ b/packages/frameworks/vue/src/tabs/tabs.tsx
@@ -8,11 +8,8 @@ import { useTabs, type UseTabsProps } from './use-tabs'
 
 export interface TabsProps extends Assign<HTMLArkProps<'div'>, UseTabsProps>, UsePresenceProps {}
 
-export const Tabs = defineComponent({
-  name: 'Tabs',
-  props,
-  emits,
-  setup(props, { slots, attrs, emit }) {
+export const Tabs = defineComponent<TabsProps>(
+  (props, { slots, attrs, emit }) => {
     const api = useTabs(props, emit)
     TabsProvider(api)
 
@@ -22,4 +19,9 @@ export const Tabs = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'Tabs',
+    props,
+    emits,
+  },
+)

--- a/packages/frameworks/vue/src/tags-input/tags-input-clear-trigger.tsx
+++ b/packages/frameworks/vue/src/tags-input/tags-input-clear-trigger.tsx
@@ -4,9 +4,8 @@ import { useTagsInputContext } from './tags-input-context'
 
 export interface TagsInputClearTriggerProps extends HTMLArkProps<'button'> {}
 
-export const TagsInputClearTrigger = defineComponent({
-  name: 'TagsInputClearTrigger',
-  setup(_, { attrs, slots }) {
+export const TagsInputClearTrigger = defineComponent<TagsInputClearTriggerProps>(
+  (_, { attrs, slots }) => {
     const api = useTagsInputContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const TagsInputClearTrigger = defineComponent({
       </ark.button>
     )
   },
-})
+  {
+    name: 'TagsInputClearTrigger',
+  },
+)

--- a/packages/frameworks/vue/src/tags-input/tags-input-control.tsx
+++ b/packages/frameworks/vue/src/tags-input/tags-input-control.tsx
@@ -4,9 +4,8 @@ import { useTagsInputContext } from './tags-input-context'
 
 export interface TagsInputControlProps extends HTMLArkProps<'div'> {}
 
-export const TagsInputControl = defineComponent({
-  name: 'TagsInputControl',
-  setup(_, { slots, attrs }) {
+export const TagsInputControl = defineComponent<TagsInputControlProps>(
+  (_, { slots, attrs }) => {
     const api = useTagsInputContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const TagsInputControl = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'TagsInputControl',
+  },
+)

--- a/packages/frameworks/vue/src/tags-input/tags-input-input.tsx
+++ b/packages/frameworks/vue/src/tags-input/tags-input-input.tsx
@@ -4,9 +4,8 @@ import { useTagsInputContext } from './tags-input-context'
 
 export interface TagsInputInputProps extends HTMLArkProps<'input'> {}
 
-export const TagsInputInput = defineComponent({
-  name: 'TagsInputInput',
-  setup(_, { attrs }) {
+export const TagsInputInput = defineComponent<TagsInputInputProps>(
+  (_, { attrs }) => {
     const api = useTagsInputContext()
 
     const inputProps = computed(() => ({
@@ -16,4 +15,7 @@ export const TagsInputInput = defineComponent({
 
     return () => <ark.input {...inputProps.value} {...attrs} />
   },
-})
+  {
+    name: 'TagsInputInput',
+  },
+)

--- a/packages/frameworks/vue/src/tags-input/tags-input-item-delete-trigger.tsx
+++ b/packages/frameworks/vue/src/tags-input/tags-input-item-delete-trigger.tsx
@@ -5,9 +5,8 @@ import { useTagsInputItemContext } from './tags-input-item-context'
 
 export interface TagsInputItemDeleteTriggerProps extends HTMLArkProps<'button'> {}
 
-export const TagsInputItemDeleteTrigger = defineComponent({
-  name: 'TagsInputItemDeleteTrigger',
-  setup(_, { slots, attrs }) {
+export const TagsInputItemDeleteTrigger = defineComponent<TagsInputItemDeleteTriggerProps>(
+  (_, { slots, attrs }) => {
     const api = useTagsInputContext()
     const itemProps = useTagsInputItemContext()
 
@@ -17,4 +16,7 @@ export const TagsInputItemDeleteTrigger = defineComponent({
       </ark.button>
     )
   },
-})
+  {
+    name: 'TagsInputItemDeleteTrigger',
+  },
+)

--- a/packages/frameworks/vue/src/tags-input/tags-input-item-input.tsx
+++ b/packages/frameworks/vue/src/tags-input/tags-input-item-input.tsx
@@ -5,10 +5,8 @@ import { useTagsInputItemContext } from './tags-input-item-context'
 
 export interface TagsInputItemInputProps extends HTMLArkProps<'input'> {}
 
-export const TagsInputItemInput = defineComponent({
-  name: 'TagsInputItemInput',
-
-  setup(_, { slots, attrs }) {
+export const TagsInputItemInput = defineComponent<TagsInputItemInputProps>(
+  (_, { slots, attrs }) => {
     const api = useTagsInputContext()
     const itemProps = useTagsInputItemContext()
 
@@ -18,4 +16,7 @@ export const TagsInputItemInput = defineComponent({
       </ark.input>
     )
   },
-})
+  {
+    name: 'TagsInputItemInput',
+  },
+)

--- a/packages/frameworks/vue/src/tags-input/tags-input-item-text.tsx
+++ b/packages/frameworks/vue/src/tags-input/tags-input-item-text.tsx
@@ -5,9 +5,8 @@ import { useTagsInputItemContext } from './tags-input-item-context'
 
 export interface TagsInputItemTextProps extends HTMLArkProps<'span'> {}
 
-export const TagsInputItemText = defineComponent({
-  name: 'TagsInputItemText',
-  setup(_, { slots, attrs }) {
+export const TagsInputItemText = defineComponent<TagsInputItemTextProps>(
+  (_, { slots, attrs }) => {
     const api = useTagsInputContext()
     const itemProps = useTagsInputItemContext()
 
@@ -17,4 +16,7 @@ export const TagsInputItemText = defineComponent({
       </ark.span>
     )
   },
-})
+  {
+    name: 'TagsInputItemText',
+  },
+)

--- a/packages/frameworks/vue/src/tags-input/tags-input-item.tsx
+++ b/packages/frameworks/vue/src/tags-input/tags-input-item.tsx
@@ -7,22 +7,8 @@ import { TagsInputItemProvider } from './tags-input-item-context'
 
 export interface TagsInputItemProps extends Assign<HTMLArkProps<'div'>, ItemProps> {}
 
-export const TagsInputItem = defineComponent({
-  name: 'TagsInputItem',
-  props: {
-    index: {
-      type: [String, Number] as PropType<ItemProps['index']>,
-      required: true,
-    },
-    value: {
-      type: String as PropType<ItemProps['value']>,
-      required: true,
-    },
-    disabled: {
-      type: Boolean as PropType<ItemProps['disabled']>,
-    },
-  },
-  setup(props, { slots, attrs }) {
+export const TagsInputItem = defineComponent<TagsInputItemProps>(
+  (props, { slots, attrs }) => {
     const api = useTagsInputContext()
     TagsInputItemProvider(computed(() => props))
 
@@ -32,4 +18,20 @@ export const TagsInputItem = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'TagsInputItem',
+    props: {
+      index: {
+        type: [String, Number] as PropType<ItemProps['index']>,
+        required: true,
+      },
+      value: {
+        type: String as PropType<ItemProps['value']>,
+        required: true,
+      },
+      disabled: {
+        type: Boolean as PropType<ItemProps['disabled']>,
+      },
+    },
+  },
+)

--- a/packages/frameworks/vue/src/tags-input/tags-input-label.tsx
+++ b/packages/frameworks/vue/src/tags-input/tags-input-label.tsx
@@ -4,9 +4,8 @@ import { useTagsInputContext } from './tags-input-context'
 
 export interface TagsInputLabelProps extends HTMLArkProps<'label'> {}
 
-export const TagsInputLabel = defineComponent({
-  name: 'TagsInputLabel',
-  setup(_, { slots, attrs }) {
+export const TagsInputLabel = defineComponent<TagsInputLabelProps>(
+  (_, { slots, attrs }) => {
     const api = useTagsInputContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const TagsInputLabel = defineComponent({
       </ark.label>
     )
   },
-})
+  {
+    name: 'TagsInputLabel',
+  },
+)

--- a/packages/frameworks/vue/src/tags-input/tags-input.tsx
+++ b/packages/frameworks/vue/src/tags-input/tags-input.tsx
@@ -7,11 +7,8 @@ import { useTagsInput, type UseTagsInputProps } from './use-tags-input'
 
 export interface TagsInputProps extends Assign<HTMLArkProps<'div'>, UseTagsInputProps> {}
 
-export const TagsInput = defineComponent({
-  name: 'TagsInput',
-  props,
-  emits,
-  setup(props, { slots, attrs, emit }) {
+export const TagsInput = defineComponent<TagsInputProps>(
+  (props, { slots, attrs, emit }) => {
     const api = useTagsInput(props, emit)
     TagsInputProvider(api)
 
@@ -24,4 +21,9 @@ export const TagsInput = defineComponent({
       </>
     )
   },
-})
+  {
+    name: 'TagsInput',
+    props,
+    emits,
+  },
+)

--- a/packages/frameworks/vue/src/toast/create-toaster.tsx
+++ b/packages/frameworks/vue/src/toast/create-toaster.tsx
@@ -12,6 +12,7 @@ import {
   type VNode,
 } from 'vue'
 import { useEnvironmentContext } from '../environment'
+import type { HTMLArkProps } from '../factory'
 import type { Optional } from '../types'
 import { ToastProvider } from './toast-context'
 import { ToastGroup } from './toast-group'
@@ -30,9 +31,8 @@ export const createToaster = (props: CreateToasterProps): CreateToasterReturn =>
   const service = toast.group.machine({ id: '1', placement, ...rest }).start()
   let api = computed(() => toast.group.connect(service.getState(), service.send, normalizeProps))
 
-  const Toaster = defineComponent({
-    name: 'Toaster',
-    setup(_, { attrs }) {
+  const Toaster = defineComponent<HTMLArkProps<'ol'>>(
+    (_, { attrs }) => {
       const getRootNode = useEnvironmentContext()
       const [state, send] = useActor(service)
       api = computed(() => toast.group.connect(state.value, send, normalizeProps))
@@ -52,7 +52,10 @@ export const createToaster = (props: CreateToasterProps): CreateToasterReturn =>
         </ToastGroup>
       )
     },
-  })
+    {
+      name: 'Toaster',
+    },
+  )
 
   return [Toaster, api]
 }

--- a/packages/frameworks/vue/src/toast/toast-close-trigger.tsx
+++ b/packages/frameworks/vue/src/toast/toast-close-trigger.tsx
@@ -4,9 +4,8 @@ import { useToastContext } from './toast-context'
 
 export interface ToastCloseTriggerProps extends HTMLArkProps<'button'> {}
 
-export const ToastCloseTrigger = defineComponent({
-  name: 'ToastCloseTrigger',
-  setup(_, { attrs, slots }) {
+export const ToastCloseTrigger = defineComponent<ToastCloseTriggerProps>(
+  (_, { attrs, slots }) => {
     const api = useToastContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const ToastCloseTrigger = defineComponent({
       </ark.button>
     )
   },
-})
+  {
+    name: 'ToastCloseTrigger',
+  },
+)

--- a/packages/frameworks/vue/src/toast/toast-description.tsx
+++ b/packages/frameworks/vue/src/toast/toast-description.tsx
@@ -4,9 +4,8 @@ import { useToastContext } from './toast-context'
 
 export interface ToastDescriptionProps extends HTMLArkProps<'div'> {}
 
-export const ToastDescription = defineComponent({
-  name: 'ToastDescription',
-  setup(_, { attrs, slots }) {
+export const ToastDescription = defineComponent<ToastDescriptionProps>(
+  (_, { attrs, slots }) => {
     const api = useToastContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const ToastDescription = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'ToastDescription',
+  },
+)

--- a/packages/frameworks/vue/src/toast/toast-group.tsx
+++ b/packages/frameworks/vue/src/toast/toast-group.tsx
@@ -3,9 +3,11 @@ import { ark, type HTMLArkProps } from '../factory'
 
 export interface ToastGroupProps extends HTMLArkProps<'ol'> {}
 
-export const ToastGroup = defineComponent({
-  name: 'ToastGroup',
-  setup(_, { attrs, slots }) {
+export const ToastGroup = defineComponent<ToastGroupProps>(
+  (_, { attrs, slots }) => {
     return () => <ark.ol {...attrs}>{slots.default?.()}</ark.ol>
   },
-})
+  {
+    name: 'ToastGroup',
+  },
+)

--- a/packages/frameworks/vue/src/toast/toast-title.tsx
+++ b/packages/frameworks/vue/src/toast/toast-title.tsx
@@ -4,9 +4,8 @@ import { useToastContext } from './toast-context'
 
 export interface ToastTitleProps extends HTMLArkProps<'div'> {}
 
-export const ToastTitle = defineComponent({
-  name: 'ToastTitle',
-  setup(_, { attrs, slots }) {
+export const ToastTitle = defineComponent<ToastTitleProps>(
+  (_, { attrs, slots }) => {
     const api = useToastContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const ToastTitle = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'ToastTitle',
+  },
+)

--- a/packages/frameworks/vue/src/toast/toast.tsx
+++ b/packages/frameworks/vue/src/toast/toast.tsx
@@ -4,9 +4,8 @@ import { useToastContext } from './toast-context'
 
 export interface ToastProps extends HTMLArkProps<'li'> {}
 
-export const Toast = defineComponent({
-  name: 'Toast',
-  setup(_, { attrs, slots }) {
+export const Toast = defineComponent<ToastProps>(
+  (_, { attrs, slots }) => {
     const api = useToastContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const Toast = defineComponent({
       </ark.li>
     )
   },
-})
+  {
+    name: 'Toast',
+  },
+)

--- a/packages/frameworks/vue/src/toggle-group/toggle-group-item.tsx
+++ b/packages/frameworks/vue/src/toggle-group/toggle-group-item.tsx
@@ -6,18 +6,8 @@ import { useToggleGroupContext } from './toggle-group-context'
 
 export interface ToggleGroupItemProps extends Assign<HTMLArkProps<'button'>, ItemProps> {}
 
-export const ToggleGroupItem = defineComponent({
-  name: 'ToggleGroupItem',
-  props: {
-    value: {
-      type: String as PropType<ItemProps['value']>,
-      required: true,
-    },
-    disabled: {
-      type: Boolean as PropType<ItemProps['disabled']>,
-    },
-  },
-  setup(props, { slots, attrs }) {
+export const ToggleGroupItem = defineComponent<ToggleGroupItemProps>(
+  (props, { slots, attrs }) => {
     const api = useToggleGroupContext()
 
     return () => (
@@ -26,4 +16,16 @@ export const ToggleGroupItem = defineComponent({
       </ark.button>
     )
   },
-})
+  {
+    name: 'ToggleGroupItem',
+    props: {
+      value: {
+        type: String as PropType<ItemProps['value']>,
+        required: true,
+      },
+      disabled: {
+        type: Boolean as PropType<ItemProps['disabled']>,
+      },
+    },
+  },
+)

--- a/packages/frameworks/vue/src/toggle-group/toggle-group.tsx
+++ b/packages/frameworks/vue/src/toggle-group/toggle-group.tsx
@@ -7,11 +7,8 @@ import { useToggleGroup, type UseToggleGroupProps } from './use-toggle-group'
 
 export interface ToggleGroupProps extends Assign<HTMLArkProps<'div'>, UseToggleGroupProps> {}
 
-export const ToggleGroup = defineComponent({
-  name: 'ToggleGroup',
-  props,
-  emits,
-  setup(props, { slots, attrs, emit }) {
+export const ToggleGroup = defineComponent<ToggleGroupProps>(
+  (props, { slots, attrs, emit }) => {
     const api = useToggleGroup(props, emit)
     ToggleGroupProvider(api)
 
@@ -21,4 +18,9 @@ export const ToggleGroup = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'ToggleGroup',
+    props,
+    emits,
+  },
+)

--- a/packages/frameworks/vue/src/tooltip/tooltip-arrow-tip.tsx
+++ b/packages/frameworks/vue/src/tooltip/tooltip-arrow-tip.tsx
@@ -4,9 +4,8 @@ import { useTooltipContext } from './tooltip-context'
 
 export interface TooltipArrowTipProps extends HTMLArkProps<'div'> {}
 
-export const TooltipArrowTip = defineComponent({
-  name: 'TooltipArrowTip',
-  setup(_, { slots, attrs }) {
+export const TooltipArrowTip = defineComponent<TooltipArrowTipProps>(
+  (_, { slots, attrs }) => {
     const api = useTooltipContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const TooltipArrowTip = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'TooltipArrowTip',
+  },
+)

--- a/packages/frameworks/vue/src/tooltip/tooltip-arrow.tsx
+++ b/packages/frameworks/vue/src/tooltip/tooltip-arrow.tsx
@@ -4,9 +4,8 @@ import { useTooltipContext } from './tooltip-context'
 
 export interface TooltipArrowProps extends HTMLArkProps<'div'> {}
 
-export const TooltipArrow = defineComponent({
-  name: 'TooltipArrow',
-  setup(_, { slots, attrs }) {
+export const TooltipArrow = defineComponent<TooltipArrowProps>(
+  (_, { slots, attrs }) => {
     const api = useTooltipContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const TooltipArrow = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'TooltipArrow',
+  },
+)

--- a/packages/frameworks/vue/src/tooltip/tooltip-content.tsx
+++ b/packages/frameworks/vue/src/tooltip/tooltip-content.tsx
@@ -6,11 +6,8 @@ import { useTooltipContext } from './tooltip-context'
 
 export interface TooltipContentProps extends HTMLArkProps<'div'>, PresenceProps {}
 
-export const TooltipContent = defineComponent({
-  name: 'TooltipContent',
-  props,
-  emits,
-  setup(props, { slots, attrs }) {
+export const TooltipContent = defineComponent<TooltipContentProps>(
+  (props, { slots, attrs }) => {
     const api = useTooltipContext()
 
     return () => (
@@ -21,4 +18,9 @@ export const TooltipContent = defineComponent({
       </Presence>
     )
   },
-})
+  {
+    name: 'TooltipContent',
+    props,
+    emits,
+  },
+)

--- a/packages/frameworks/vue/src/tooltip/tooltip-positioner.tsx
+++ b/packages/frameworks/vue/src/tooltip/tooltip-positioner.tsx
@@ -4,9 +4,8 @@ import { useTooltipContext } from './tooltip-context'
 
 export interface TooltipPositionerProps extends HTMLArkProps<'div'> {}
 
-export const TooltipPositioner = defineComponent({
-  name: 'TooltipPositioner',
-  setup(_, { slots, attrs }) {
+export const TooltipPositioner = defineComponent<TooltipPositionerProps>(
+  (_, { slots, attrs }) => {
     const api = useTooltipContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const TooltipPositioner = defineComponent({
       </ark.div>
     )
   },
-})
+  {
+    name: 'TooltipPositioner',
+  },
+)

--- a/packages/frameworks/vue/src/tooltip/tooltip-trigger.tsx
+++ b/packages/frameworks/vue/src/tooltip/tooltip-trigger.tsx
@@ -4,9 +4,8 @@ import { useTooltipContext } from './tooltip-context'
 
 export interface TooltipTriggerProps extends HTMLArkProps<'button'> {}
 
-export const TooltipTrigger = defineComponent({
-  name: 'TooltipTrigger',
-  setup(_, { slots, attrs }) {
+export const TooltipTrigger = defineComponent<TooltipTriggerProps>(
+  (_, { slots, attrs }) => {
     const api = useTooltipContext()
 
     return () => (
@@ -15,4 +14,7 @@ export const TooltipTrigger = defineComponent({
       </ark.button>
     )
   },
-})
+  {
+    name: 'TooltipTrigger',
+  },
+)

--- a/packages/frameworks/vue/src/tooltip/tooltip.tsx
+++ b/packages/frameworks/vue/src/tooltip/tooltip.tsx
@@ -5,14 +5,16 @@ import { useTooltip, type UseTooltipProps } from './use-tooltip'
 
 export interface TooltipProps extends UseTooltipProps {}
 
-export const Tooltip = defineComponent({
-  name: 'Tooltip',
-  props,
-  emits,
-  setup(props, { slots, emit }) {
+export const Tooltip = defineComponent<TooltipProps>(
+  (props, { slots, emit }) => {
     const api = useTooltip(props, emit)
     TooltipProvider(api)
 
     return () => slots.default?.(api.value)
   },
-})
+  {
+    name: 'Tooltip',
+    props,
+    emits,
+  },
+)


### PR DESCRIPTION
Without `as const` some props are incorrect (for example orientation in carousel)