### PR TITLE
fix(solid): added reactivity to collection and context of use-select (#2029)

### DIFF
--- a/packages/frameworks/solid/src/select/use-select.ts
+++ b/packages/frameworks/solid/src/select/use-select.ts
@@ -22,11 +22,13 @@ export const useSelect = <T extends CollectionItem>(
     'itemToString',
     'items',
   ])
-  const collection = select.collection(collectionOptions)
+  const collection = createMemo(() => select.collection(collectionOptions))
   const getRootNode = useEnvironmentContext()
-  const context = mergeProps({ id: createUniqueId(), getRootNode, collection }, rest)
+  const context = createMemo(() =>
+    mergeProps({ id: createUniqueId(), getRootNode, collection: collection() }, rest),
+  )
 
-  const [state, send] = useMachine(select.machine(context), {
+  const [state, send] = useMachine(select.machine(context()), {
     context,
   })
 

--- a/packages/frameworks/solid/src/select/use-select.ts
+++ b/packages/frameworks/solid/src/select/use-select.ts
@@ -1,7 +1,7 @@
 import type { CollectionOptions } from '@zag-js/select'
 import * as select from '@zag-js/select'
 import { mergeProps, normalizeProps, useMachine, type PropTypes } from '@zag-js/solid'
-import { createMemo, createUniqueId, type Accessor, createEffect } from 'solid-js'
+import { createMemo, createUniqueId, type Accessor } from 'solid-js'
 import { createSplitProps } from '../create-split-props'
 import { useEnvironmentContext } from '../environment'
 import { type CollectionItem, type Optional } from '../types'
@@ -26,12 +26,6 @@ export const useSelect = <T extends CollectionItem>(
   const getRootNode = useEnvironmentContext()
   const context = () =>
     mergeProps({ id: createUniqueId(), getRootNode, collection: collection() }, rest)
-
-  createEffect(() => {
-    console.log('collectionOptions', collectionOptions.items)
-    console.log('collection', collection().nodes)
-    console.log('context', context().collection.nodes)
-  })
   const [state, send] = useMachine(select.machine(context), {
     context,
   })

--- a/packages/frameworks/solid/src/select/use-select.ts
+++ b/packages/frameworks/solid/src/select/use-select.ts
@@ -1,7 +1,7 @@
 import type { CollectionOptions } from '@zag-js/select'
 import * as select from '@zag-js/select'
 import { mergeProps, normalizeProps, useMachine, type PropTypes } from '@zag-js/solid'
-import { createMemo, createUniqueId, type Accessor } from 'solid-js'
+import { createMemo, createUniqueId, type Accessor, createEffect } from 'solid-js'
 import { createSplitProps } from '../create-split-props'
 import { useEnvironmentContext } from '../environment'
 import { type CollectionItem, type Optional } from '../types'
@@ -22,13 +22,17 @@ export const useSelect = <T extends CollectionItem>(
     'itemToString',
     'items',
   ])
-  const collection = createMemo(() => select.collection(collectionOptions))
+  const collection = () => select.collection(collectionOptions)
   const getRootNode = useEnvironmentContext()
-  const context = createMemo(() =>
-    mergeProps({ id: createUniqueId(), getRootNode, collection: collection() }, rest),
-  )
+  const context = () =>
+    mergeProps({ id: createUniqueId(), getRootNode, collection: collection() }, rest)
 
-  const [state, send] = useMachine(select.machine(context()), {
+  createEffect(() => {
+    console.log('collectionOptions', collectionOptions.items)
+    console.log('collection', collection().nodes)
+    console.log('context', context().collection.nodes)
+  })
+  const [state, send] = useMachine(select.machine(context), {
     context,
   })
 

--- a/packages/frameworks/solid/src/select/use-select.ts
+++ b/packages/frameworks/solid/src/select/use-select.ts
@@ -26,7 +26,7 @@ export const useSelect = <T extends CollectionItem>(
   const getRootNode = useEnvironmentContext()
   const context = () =>
     mergeProps({ id: createUniqueId(), getRootNode, collection: collection() }, rest)
-  const [state, send] = useMachine(select.machine(context), {
+  const [state, send] = useMachine(select.machine(context()), {
     context,
   })
 


### PR DESCRIPTION
This PR fixed #2029 
- The `use-select` hook currently doesn't update the state machine of `zag-js` when `collectionOptions`'s props change.
- This PR make that hook register change in `collectionOptions`'s props including `items` props.
- Which in turn solve #2029