### PR TITLE
feat(factory): add `as` prop

### DIFF
--- a/packages/frameworks/react/src/factory.test.tsx
+++ b/packages/frameworks/react/src/factory.test.tsx
@@ -82,4 +82,9 @@ describe('Ark Factory', () => {
     )
     expect(screen.getByText('Ark UI')).not.toHaveAttribute('data-testid', 'parent')
   })
+
+  it('should use as', async () => {
+    render(<ark.div as="h1">Ark UI</ark.div>)
+    expect(screen.getByText('Ark UI').tagName).toBe('H1')
+  })
 })

--- a/packages/frameworks/solid/src/factory.test.tsx
+++ b/packages/frameworks/solid/src/factory.test.tsx
@@ -105,4 +105,9 @@ describe('Ark Factory', () => {
     const child = screen.getByTestId('child')
     expect(child).toHaveClass('child parent')
   })
+
+  it('should use as', async () => {
+    render(() => <ark.div as="h1">Ark UI</ark.div>)
+    expect(screen.getByText('Ark UI').tagName).toBe('H1')
+  })
 })

--- a/packages/frameworks/vue/src/factory.test.tsx
+++ b/packages/frameworks/vue/src/factory.test.tsx
@@ -80,4 +80,9 @@ describe('Factory', () => {
     )
     expect(screen.getByText('Ark UI')).not.toHaveAttribute('data-testid', 'parent')
   })
+
+  it('should use as', async () => {
+    render(<ark.div as="h1">Ark UI</ark.div>)
+    expect(screen.getByText('Ark UI').tagName).toBe('H1')
+  })
 })


### PR DESCRIPTION
Add the ability to use `as` prop with ark factory, this will allow creating reusable components like `<Heading />` when you're not sure which tag to use