### PR TITLE
fix(react): updates `Portal` to have backward compatibility

### DIFF
--- a/packages/frameworks/react/src/portal.test.tsx
+++ b/packages/frameworks/react/src/portal.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen } from '@testing-library/react'
+import { useRef } from 'react'
+import { Portal } from './portal'
+
+const PortalWithContainerTest = (props: { disabled?: boolean }) => {
+  const container = useRef<HTMLDivElement>(null)
+  return (
+    <div>
+      <Portal container={container} disabled={props.disabled}>
+        <p>Anything must be visible</p>
+      </Portal>
+      <div data-testid="container" ref={container}></div>
+    </div>
+  )
+}
+
+describe('Portal', () => {
+  it('should render portal without element children', () => {
+    render(<Portal>Anything must be visible</Portal>)
+    expect(screen.getByText('Anything must be visible')).toBeVisible()
+  })
+
+  it('should render portal with element children', () => {
+    render(
+      <Portal>
+        <p>Anything must be visible</p>
+      </Portal>,
+    )
+    expect(screen.getByText('Anything must be visible')).toBeVisible()
+  })
+
+  it('should render portal with multiple element children', () => {
+    render(
+      <Portal>
+        <p>Anything must be visible</p>
+        <p>Another visible item</p>
+      </Portal>,
+    )
+    expect(screen.getByText('Anything must be visible')).toBeVisible()
+    expect(screen.getByText('Another visible item')).toBeVisible()
+  })
+
+  it('should render portal children next to the body', () => {
+    const view = render(
+      <div>
+        <Portal>
+          <p>Anything must be visible</p>
+        </Portal>
+      </div>,
+    )
+
+    expect(view.baseElement).toMatchInlineSnapshot(`
+      <body>
+        <div>
+          <div />
+        </div>
+        <p>
+          Anything must be visible
+        </p>
+      </body>
+    `)
+  })
+
+  it('should not render portal children next to the body if marked as `disabled`', () => {
+    const view = render(
+      <div>
+        <Portal disabled>
+          <p>Anything must be visible</p>
+        </Portal>
+      </div>,
+    )
+
+    expect(view.baseElement).toMatchInlineSnapshot(`
+      <body>
+        <div>
+          <div>
+            <p>
+              Anything must be visible
+            </p>
+          </div>
+        </div>
+      </body>
+    `)
+  })
+
+  it('should render portal children inside a custom element', () => {
+    render(<PortalWithContainerTest />)
+
+    const container = screen.getByTestId('container')
+    expect(container).toBeInTheDocument()
+    expect(container).not.toBeEmptyDOMElement()
+    expect(screen.getByText('Anything must be visible')).toBeVisible()
+  })
+
+  it('should not render portal children inside a custom element if marked as `disabled`', () => {
+    render(<PortalWithContainerTest disabled />)
+
+    const container = screen.getByTestId('container')
+    expect(container).toBeInTheDocument()
+    expect(container).toBeEmptyDOMElement()
+    expect(screen.getByText('Anything must be visible')).toBeVisible()
+  })
+})

--- a/packages/frameworks/react/src/portal.tsx
+++ b/packages/frameworks/react/src/portal.tsx
@@ -1,10 +1,4 @@
-import {
-  Children,
-  type PropsWithChildren,
-  type ReactNode,
-  type ReactPortal,
-  type RefObject,
-} from 'react'
+import { Children, type PropsWithChildren, type RefObject } from 'react'
 import { createPortal } from 'react-dom'
 import { useEnvironmentContext } from './environment'
 import { useIsServer } from './use-is-server'
@@ -14,17 +8,15 @@ export interface PortalProps {
   container?: RefObject<HTMLElement>
 }
 
-export const Portal = (
-  props: PropsWithChildren<PortalProps>,
-): ReactPortal[] | ReactNode | null | undefined => {
+export const Portal = (props: PropsWithChildren<PortalProps>) => {
   const { children, container, disabled } = props
   const isServer = useIsServer()
   const getRootNode = useEnvironmentContext()
 
-  if (isServer || disabled) return children
+  if (isServer || disabled) return <>{children}</>
 
   const doc = getRootNode?.().ownerDocument ?? document
   const mountNode = container?.current ?? doc.body
 
-  return Children.map(children, (child) => createPortal(child, mountNode))
+  return <>{Children.map(children, (child) => createPortal(child, mountNode))}</>
 }


### PR DESCRIPTION
Fixes #2154 and #1787

There were a lot of ways this could be solved, most of them are by working around `typescript`. I decided to push the most type-safe solution since `Portal`'s return type now gets inferred as `JSX.Element`, so the code will work on all versions of `@types/react@18`. The only downside is adding a `Fragment` without actually needing it. 

I also added some tests for the `Portal` component since there weren't any :)