### PR TITLE
docs(website): add typescript caveat disclaimer in select component page

### DIFF
--- a/packages/website/src/content/components/select.mdx
+++ b/packages/website/src/content/components/select.mdx
@@ -52,6 +52,11 @@ See how to use the Select component with popular form libraries:
 
 <Story id="FormLibrary" />
 
+## TypeScript Caveats in Vue
+Under the hood for React and Solid frameworks, we supply a complex prop type with a generic so that the type of the `items` prop matches the param type in the function signatures for props such as the `isItemDisabled` prop, say. (See the api reference table below) Unfortunately, generic typing is not supported in Vue for components that contain props with slots and/or emits. Therefore, you will not expect updated typing in this way.
+
+If you have a solution or a workaround to this problem, we would love the contribution and request that you [open a Github idea discussion](https://github.com/chakra-ui/ark/discussions/new?category=ideas) to let us know a PoC you have to share!
+
 ## API Reference
 
 <ComponentTypes />


### PR DESCRIPTION
Adds a section in the `Select` component docs page for TypeScript describing the caveat in having a Generic prop type in Vue.