### PR TITLE
refactor(react): simplify ensureKeys type definition

### DIFF
--- a/packages/frameworks/react/src/create-split-props.ts
+++ b/packages/frameworks/react/src/create-split-props.ts
@@ -1,11 +1,7 @@
-type EnsureKeys<
-  ExpectedKeys extends (keyof Target)[],
-  Target,
-> = ExpectedKeys extends (keyof Target)[]
-  ? [keyof Target] extends [ExpectedKeys[number]]
+type EnsureKeys<ExpectedKeys extends (keyof Target)[], Target> =
+  Exclude<ExpectedKeys[number], keyof Target> extends never
     ? unknown
-    : `Missing required keys: ${Exclude<keyof Target, ExpectedKeys[number]>}`
-  : never
+    : `Missing required keys: ${Exclude<ExpectedKeys[number], keyof Target>}`
 
 export const createSplitProps =
   <Target>() =>

--- a/packages/frameworks/solid/src/create-split-props.ts
+++ b/packages/frameworks/solid/src/create-split-props.ts
@@ -1,13 +1,9 @@
 import { splitProps } from 'solid-js'
 
-type EnsureKeys<
-  ExpectedKeys extends (keyof Target)[],
-  Target,
-> = ExpectedKeys extends (keyof Target)[]
-  ? [keyof Target] extends [ExpectedKeys[number]]
+type EnsureKeys<ExpectedKeys extends (keyof Target)[], Target> =
+  Exclude<ExpectedKeys[number], keyof Target> extends never
     ? unknown
-    : `Missing required keys: ${Exclude<keyof Target, ExpectedKeys[number]>}`
-  : never
+    : `Missing required keys: ${Exclude<ExpectedKeys[number], keyof Target>}`
 
 export const createSplitProps =
   <Target extends Record<never, never>>() =>


### PR DESCRIPTION
Just a small suggestion. 💙

EnsureKeys previously used a nested ternary operator. I refactored the code because I thought it was difficult to understand and poor readability due to the use of nested ternary operators.

I modified my code using the Exclude utility type.