### PR TITLE
refactor(react): simplify ensureKeys type definition

### DIFF
--- a/packages/frameworks/react/src/create-split-props.ts
+++ b/packages/frameworks/react/src/create-split-props.ts
@@ -1,11 +1,9 @@
 type EnsureKeys<
   ExpectedKeys extends (keyof Target)[],
   Target,
-> = ExpectedKeys extends (keyof Target)[]
-  ? [keyof Target] extends [ExpectedKeys[number]]
-    ? unknown
-    : `Missing required keys: ${Exclude<keyof Target, ExpectedKeys[number]>}`
-  : never
+> = keyof Target extends ExpectedKeys[number]
+  ? unknown
+  : `Missing required keys: ${Exclude<keyof Target, ExpectedKeys[number]> & string}`
 
 export const createSplitProps =
   <Target>() =>

--- a/packages/frameworks/solid/src/create-split-props.ts
+++ b/packages/frameworks/solid/src/create-split-props.ts
@@ -3,11 +3,9 @@ import { splitProps } from 'solid-js'
 type EnsureKeys<
   ExpectedKeys extends (keyof Target)[],
   Target,
-> = ExpectedKeys extends (keyof Target)[]
-  ? [keyof Target] extends [ExpectedKeys[number]]
-    ? unknown
-    : `Missing required keys: ${Exclude<keyof Target, ExpectedKeys[number]>}`
-  : never
+> = keyof Target extends ExpectedKeys[number]
+  ? unknown
+  : `Missing required keys: ${Exclude<keyof Target, ExpectedKeys[number]> & string}`
 
 export const createSplitProps =
   <Target extends Record<never, never>>() =>


### PR DESCRIPTION
Just a small suggestion. 💙 

refactor EnsureKeys type for improved readability by removing nested ternary and unnecessary never type, which was not required for type safety.

If you encounter any issues, please leave a message. Thank you.