### PR TITLE
fix(menu): expose context types

### DIFF
--- a/packages/frameworks/react/src/menu/menu-context.ts
+++ b/packages/frameworks/react/src/menu/menu-context.ts
@@ -1,19 +1,17 @@
 import { createContext } from '../create-context'
 import { type UseMenuReturn } from './use-menu'
 
-type MenuContext = unknown // type `UseMenuReturn['api']` can't be named
-
-export const [MenuProvider, useMenuContext] = createContext<MenuContext | undefined>({
+export const [MenuProvider, useMenuContext] = createContext<
+  UseMenuReturn['api'] | undefined
+>({
   name: 'MenuContext',
   hookName: 'useMenuContext',
   providerName: '<MenuProvider />',
   strict: false,
 })
 
-type MenuMachineContext = unknown // type `UseMenuReturn['machine']` can't be named
-
 export const [MenuMachineProvider, useMenuMachineContext] = createContext<
-  MenuMachineContext | undefined
+  UseMenuReturn['machine'] | undefined
 >({
   name: 'MenuMachineContext',
   hookName: 'useMenuMachineContext',


### PR DESCRIPTION
Some types of menu contexts are currently set to `unknown`, and I don't really know why.

I've updated these types :
- `UseMenuReturn['api'] | undefined` for the `MenuContext`.
- `UseMenuReturn['machine'] | undefined` for the `MenuMachineContext`.

