### PR TITLE
fix(vue): add missing presenceProps for certain Vue components

### DIFF
--- a/packages/frameworks/vue/src/color-picker/color-picker-content.tsx
+++ b/packages/frameworks/vue/src/color-picker/color-picker-content.tsx
@@ -15,7 +15,7 @@ export const ColorPickerContent = defineComponent<ColorPickerContentProps>(
     return () => (
       <>
         {presenceApi.value.isUnmounted ? null : (
-          <ark.div {...api.value.contentProps} {...attrs}>
+          <ark.div {...api.value.contentProps} {...presenceApi.value.presenceProps} {...attrs}>
             {slots.default?.()}
           </ark.div>
         )}

--- a/packages/frameworks/vue/src/combobox/combobox-content.tsx
+++ b/packages/frameworks/vue/src/combobox/combobox-content.tsx
@@ -14,7 +14,7 @@ export const ComboboxContent = defineComponent<ComboboxContentProps>(
     return () => (
       <>
         {presenceApi.value.isUnmounted ? null : (
-          <ark.div {...api.value.contentProps} {...attrs}>
+          <ark.div {...api.value.contentProps} {...presenceApi.value.presenceProps} {...attrs}>
             {slots.default?.()}
           </ark.div>
         )}

--- a/packages/frameworks/vue/src/date-picker/date-picker-content.tsx
+++ b/packages/frameworks/vue/src/date-picker/date-picker-content.tsx
@@ -13,7 +13,7 @@ export const DatePickerContent = defineComponent<DatePickerContentProps>(
     return () => (
       <>
         {presenceApi.value.isUnmounted ? null : (
-          <ark.div {...api.value.contentProps} {...attrs}>
+          <ark.div {...api.value.contentProps} {...presenceApi.value.presenceProps} {...attrs}>
             {slots.default?.()}
           </ark.div>
         )}

--- a/packages/frameworks/vue/src/dialog/dialog-backdrop.tsx
+++ b/packages/frameworks/vue/src/dialog/dialog-backdrop.tsx
@@ -14,7 +14,7 @@ export const DialogBackdrop = defineComponent<DialogBackdropProps>(
     return () => (
       <>
         {presenceApi.value.isUnmounted ? null : (
-          <ark.div {...api.value.backdropProps} {...attrs}>
+          <ark.div {...api.value.backdropProps} {...presenceApi.value.presenceProps} {...attrs}>
             {slots.default?.()}
           </ark.div>
         )}

--- a/packages/frameworks/vue/src/dialog/dialog-content.tsx
+++ b/packages/frameworks/vue/src/dialog/dialog-content.tsx
@@ -14,7 +14,7 @@ export const DialogContent = defineComponent<DialogContentProps>(
     return () => (
       <>
         {presenceApi.value.isUnmounted ? null : (
-          <ark.div {...api.value.contentProps} {...attrs}>
+          <ark.div {...api.value.contentProps} {...presenceApi.value.presenceProps} {...attrs}>
             {slots.default?.()}
           </ark.div>
         )}

--- a/packages/frameworks/vue/src/hover-card/hover-card-content.tsx
+++ b/packages/frameworks/vue/src/hover-card/hover-card-content.tsx
@@ -14,7 +14,7 @@ export const HoverCardContent = defineComponent<HoverCardContentProps>(
     return () => (
       <>
         {presenceApi.value.isUnmounted ? null : (
-          <ark.div {...api.value.contentProps} {...attrs}>
+          <ark.div {...api.value.contentProps} {...presenceApi.value.presenceProps} {...attrs}>
             {slots.default?.()}
           </ark.div>
         )}

--- a/packages/frameworks/vue/src/menu/menu-content.tsx
+++ b/packages/frameworks/vue/src/menu/menu-content.tsx
@@ -15,7 +15,7 @@ export const MenuContent = defineComponent<MenuContentProps>(
     return () => (
       <>
         {presenceApi.value.isUnmounted ? null : (
-          <ark.div {...api.value.contentProps} {...attrs}>
+          <ark.div {...api.value.contentProps} {...presenceApi.value.presenceProps} {...attrs}>
             {slots.default?.()}
           </ark.div>
         )}

--- a/packages/frameworks/vue/src/popover/popover-content.tsx
+++ b/packages/frameworks/vue/src/popover/popover-content.tsx
@@ -14,7 +14,7 @@ export const PopoverContent = defineComponent<PopoverContentProps>(
     return () => (
       <>
         {presenceApi.value.isUnmounted ? null : (
-          <ark.div {...api.value.contentProps} {...attrs}>
+          <ark.div {...api.value.contentProps} {...presenceApi.value.presenceProps} {...attrs}>
             {slots.default?.()}
           </ark.div>
         )}

--- a/packages/frameworks/vue/src/select/select-content.tsx
+++ b/packages/frameworks/vue/src/select/select-content.tsx
@@ -15,7 +15,7 @@ export const SelectContent = defineComponent<SelectContentProps>(
     return () => (
       <>
         {presenceApi.value.isUnmounted ? null : (
-          <ark.div {...api.value.contentProps} {...attrs}>
+          <ark.div {...api.value.contentProps} {...presenceApi.value.presenceProps} {...attrs}>
             {slots.default?.()}
           </ark.div>
         )}

--- a/packages/frameworks/vue/src/tabs/tab-content.tsx
+++ b/packages/frameworks/vue/src/tabs/tab-content.tsx
@@ -25,7 +25,11 @@ export const TabContent = defineComponent<TabContentProps>(
     return () => (
       <>
         {presenceApi.value.isUnmounted ? null : (
-          <ark.div {...api.value.getContentProps(props)} {...attrs}>
+          <ark.div
+            {...api.value.getContentProps(props)}
+            {...presenceApi.value.presenceProps}
+            {...attrs}
+          >
             {slots.default?.()}
           </ark.div>
         )}

--- a/packages/frameworks/vue/src/tooltip/tooltip-content.tsx
+++ b/packages/frameworks/vue/src/tooltip/tooltip-content.tsx
@@ -14,7 +14,7 @@ export const TooltipContent = defineComponent<TooltipContentProps>(
     return () => (
       <>
         {presenceApi.value.isUnmounted ? null : (
-          <ark.div {...api.value.contentProps} {...attrs}>
+          <ark.div {...api.value.contentProps} {...presenceApi.value.presenceProps} {...attrs}>
             {slots.default?.()}
           </ark.div>
         )}

--- a/packages/website/src/content/types/vue/byte-format.types.json
+++ b/packages/website/src/content/types/vue/byte-format.types.json
@@ -7,7 +7,7 @@
       "description": "The unit granularity to display"
     },
     "unitDisplay": {
-      "type": "'short' | 'long' | 'narrow'",
+      "type": "'long' | 'short' | 'narrow'",
       "isRequired": false,
       "description": "The unit display"
     }


### PR DESCRIPTION
This PR fixes: #2329
Also add missing `presenceProps` on other Vue components compared to the React components.

This fixes the close animations for those components:
- Color picker
- Combobox
- Date picker
- Dialog & Dialog backdrop
- Hover card
- Menu
- Popover
- Select
- Tabs
- Tooltip

Note: Not sure if it's correct that the close animations in Histoire are a bit different for some components then in the Ark docs.