### PR TITLE
chore: fix "husky install is deprecated" message on install

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 bun run lint-staged

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "website"
   ],
   "scripts": {
-    "prepare": "husky install",
+    "prepare": "husky",
     "build": "turbo run build --filter='!./templates/**'",
     "exports:check": "bun scripts exports:check",
     "exports:sync": "bun scripts exports:sync",


### PR DESCRIPTION
I have followed the 8 to 9 migration steps on the Husky release notes: https://github.com/typicode/husky/releases/tag/v9.0.1
Husky seemed to run fine when I have made the current commit.