### PR TITLE
fix(docs): add missing theme switcher label

### DIFF
--- a/website/src/components/color-mode-button.astro
+++ b/website/src/components/color-mode-button.astro
@@ -3,7 +3,7 @@ import { css, cx } from 'styled-system/css'
 import { button } from 'styled-system/recipes'
 ---
 
-<button id="themeToggle" class={cx(css({ px: '0' }), button({ variant: 'ghost', size: 'md' }))}>
+<button id="themeToggle" class={cx(css({ px: '0' }), button({ variant: 'ghost', size: 'md' }))} aria-label="Toggle color scheme">
   <svg
     width="24"
     height="24"


### PR DESCRIPTION
Fix missing readable label on the theme switcher.