### PR TITLE
docs: fix typo carousel example

### DIFF
--- a/website/src/content/components/carousel.mdx
+++ b/website/src/content/components/carousel.mdx
@@ -23,7 +23,7 @@ we name its parts.
 
 ## Examples
 
-Learn how to use the `Caorusel` component in your project. Let's take a look at
+Learn how to use the `Carousel` component in your project. Let's take a look at
 the most basic example:
 
 <Story id="Basic" />

--- a/website/src/content/components/date-picker.mdx
+++ b/website/src/content/components/date-picker.mdx
@@ -37,7 +37,7 @@ prop to `range`.
 
 ### Standalone Date Picker
 
-In some cases, you might want to display a non-dismissable date picker. This can
+In some cases, you might want to display a non-dismissible date picker. This can
 be achieved by setting the `open` prop to `true` and `closeOnSelect` prop to
 `false`.
 

--- a/website/src/content/components/number-input.mdx
+++ b/website/src/content/components/number-input.mdx
@@ -53,7 +53,7 @@ real cursor's pointer.
 
 <Story id="Scrubber" />
 
-### Using the mousewheel to change value
+### Using the mouse wheel to change value
 
 The NumberInput exposes a way to increment/decrement the value using the mouse
 wheel event. To activate this, set the `allowMouseWheel` prop to `true`.


### PR DESCRIPTION
fixes: #2421
and 2 other typo's