### PR TITLE
feat(*): allow to configure machine externally

### DIFF
--- a/frameworks/react/src/components/avatar/avatar-root.tsx
+++ b/frameworks/react/src/components/avatar/avatar-root.tsx
@@ -3,10 +3,12 @@ import { forwardRef } from 'react'
 import type { Assign } from '../../types'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLArkProps, ark } from '../factory'
-import { type UseAvatarProps, useAvatar } from './use-avatar'
+import { type UseAvatarProps, type UseAvatarReturn, useAvatar } from './use-avatar'
 import { AvatarProvider } from './use-avatar-context'
 
-export interface AvatarRootProps extends Assign<HTMLArkProps<'div'>, UseAvatarProps> {}
+export interface AvatarRootProps extends Assign<HTMLArkProps<'div'>, UseAvatarProps> {
+  api?: UseAvatarReturn
+}
 
 export const AvatarRoot = forwardRef<HTMLDivElement, AvatarRootProps>((props, ref) => {
   const [useAvatarProps, localProps] = createSplitProps<UseAvatarProps>()(props, [
@@ -14,7 +16,7 @@ export const AvatarRoot = forwardRef<HTMLDivElement, AvatarRootProps>((props, re
     'ids',
     'onStatusChange',
   ])
-  const avatar = useAvatar(useAvatarProps)
+  const avatar = props.api || useAvatar(useAvatarProps)
   const mergedProps = mergeProps(avatar.rootProps, localProps)
 
   return (

--- a/frameworks/react/src/components/avatar/avatar.stories.tsx
+++ b/frameworks/react/src/components/avatar/avatar.stories.tsx
@@ -7,5 +7,6 @@ const meta: Meta = {
 export default meta
 
 export { Basic } from './examples/basic'
-export { Events } from './examples/events'
 export { Context } from './examples/context'
+export { Events } from './examples/events'
+export { External } from './examples/external'

--- a/frameworks/react/src/components/avatar/examples/external.tsx
+++ b/frameworks/react/src/components/avatar/examples/external.tsx
@@ -1,0 +1,12 @@
+import { Avatar, useAvatar } from '..'
+
+export const External = () => {
+  const api = useAvatar({ onStatusChange: (e) => console.log('status changed', e) })
+
+  return (
+    <Avatar.Root api={api}>
+      <Avatar.Fallback>PA</Avatar.Fallback>
+      <Avatar.Image src="https://i.pravatar.cc/300" alt="avatar" />
+    </Avatar.Root>
+  )
+}

--- a/frameworks/react/src/components/avatar/index.ts
+++ b/frameworks/react/src/components/avatar/index.ts
@@ -3,6 +3,7 @@ export { AvatarContext, type AvatarContextProps } from './avatar-context'
 export { AvatarFallback, type AvatarFallbackProps } from './avatar-fallback'
 export { AvatarImage, type AvatarImageProps } from './avatar-image'
 export { AvatarRoot, type AvatarRootProps } from './avatar-root'
-export { type UseAvatarContext, useAvatarContext } from './use-avatar-context'
+export { useAvatar, type UseAvatarProps, type UseAvatarReturn } from './use-avatar'
+export { useAvatarContext, type UseAvatarContext } from './use-avatar-context'
 
 export * as Avatar from './avatar'


### PR DESCRIPTION
```tsx
import { Avatar, useAvatar } from '@ark-ui/react'

export const External = () => {
  const api = useAvatar({ onStatusChange: (e) => console.log('status changed', e) })

  return (
    <Avatar.RootProvider value={api}>
      <Avatar.Fallback>PA</Avatar.Fallback>
      <Avatar.Image src="https://i.pravatar.cc/300" alt="avatar" />
    </Avatar.RootProvider>
  )
}
