### PR TITLE
docs: fix broken links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,43 +13,43 @@ dedicated packages for each supported framework.
 
 ## Components
 
-|                                                                             | React | Solid | Svelte | Vue |
-| --------------------------------------------------------------------------- | ----- | ----- | ------ | --- |
-| [Accordion](https://ark-ui.com/docs/components/accordion)                   | ✓     | ✓     |        | ✓   |
-| [Avatar](https://ark-ui.com/docs/components/avatar)                         | ✓     | ✓     |        | ✓   |
-| [Carousel](https://ark-ui.com/docs/components/carousel)                     | ✓     | ✓     |        | ✓   |
-| [Checkbox](https://ark-ui.com/docs/components/checkbox)                     | ✓     | ✓     |        | ✓   |
-| [Clipboard](https://ark-ui.com/docs/components/clipboard)                   | ✓     | ✓     |        | ✓   |
-| [Collapsible](https://ark-ui.com/docs/components/collapsible)               | ✓     | ✓     |        | ✓   |
-| [Color Picker](https://ark-ui.com/docs/components/color-picker)             | ✓     | ✓     |        | ✓   |
-| [Combobox](https://ark-ui.com/docs/components/combobox)                     | ✓     | ✓     |        | ✓   |
-| [Date Picker](https://ark-ui.com/docs/components/date-picker)               | ✓     | ✓     |        | ✓   |
-| [Dialog](https://ark-ui.com/docs/components/dialog)                         | ✓     | ✓     |        | ✓   |
-| [Editable](https://ark-ui.com/docs/components/editable)                     | ✓     | ✓     |        | ✓   |
-| [File Upload](https://ark-ui.com/docs/components/file-upload)               | ✓     | ✓     |        | ✓   |
-| [Format](https://ark-ui.com/docs/components/format)                         | ✓     | ✓     |        | ✓   |
-| [Hover Card](https://ark-ui.com/docs/components/hover-card)                 | ✓     | ✓     |        | ✓   |
-| [Menu](https://ark-ui.com/docs/components/menu)                             | ✓     | ✓     |        | ✓   |
-| [Number Input](https://ark-ui.com/docs/components/number-input)             | ✓     | ✓     |        | ✓   |
-| [Pagination](https://ark-ui.com/docs/components/pagination)                 | ✓     | ✓     |        | ✓   |
-| [Pin Input](https://ark-ui.com/docs/components/pin-input)                   | ✓     | ✓     |        | ✓   |
-| [Popover](https://ark-ui.com/docs/components/popover)                       | ✓     | ✓     |        | ✓   |
-| [Presence](https://ark-ui.com/docs/components/presence)                     | ✓     | ✓     |        | ✓   |
-| [Progress - Circular](https://ark-ui.com/docs/components/circular-progress) | ✓     | ✓     |        | ✓   |
-| [Progress - Linear](https://ark-ui.com/docs/components/linear-progress)     | ✓     | ✓     |        | ✓   |
-| [Radio Group](https://ark-ui.com/docs/components/radio-group)               | ✓     | ✓     |        | ✓   |
-| [Rating Group](https://ark-ui.com/docs/components/rating-group)             | ✓     | ✓     |        | ✓   |
-| [Segment Group](https://ark-ui.com/docs/components/segment-group)           | ✓     | ✓     |        | ✓   |
-| [Select](https://ark-ui.com/docs/components/select)                         | ✓     | ✓     |        | ✓   |
-| [Slider](https://ark-ui.com/docs/components/slider)                         | ✓     | ✓     |        | ✓   |
-| [Splitter](https://ark-ui.com/docs/components/splitter)                     | ✓     | ✓     |        | ✓   |
-| [Switch](https://ark-ui.com/docs/components/switch)                         | ✓     | ✓     |        | ✓   |
-| [Tabs](https://ark-ui.com/docs/components/tabs)                             | ✓     | ✓     |        | ✓   |
-| [Tags Input](https://ark-ui.com/docs/components/tags-input)                 | ✓     | ✓     |        | ✓   |
-| [Toast](https://ark-ui.com/docs/components/toast)                           | ✓     | ✓     |        | ✓   |
-| [Toggle Group](https://ark-ui.com/docs/components/toggle-group)             | ✓     | ✓     |        | ✓   |
-| [Tooltip](https://ark-ui.com/docs/components/tooltip)                       | ✓     | ✓     |        | ✓   |
-| [Tree View](https://ark-ui.com/docs/components/tree-view)                   | ✓     | ✓     |        | ✓   |
+|                                                                                   | React | Solid | Svelte | Vue |
+| --------------------------------------------------------------------------------- | ----- | ----- | ------ | --- |
+| [Accordion](https://ark-ui.com/docs/react/components/accordion)                   | ✓     | ✓     |        | ✓   |
+| [Avatar](https://ark-ui.com/docs/react/components/avatar)                         | ✓     | ✓     |        | ✓   |
+| [Carousel](https://ark-ui.com/docs/react/components/carousel)                     | ✓     | ✓     |        | ✓   |
+| [Checkbox](https://ark-ui.com/docs/react/components/checkbox)                     | ✓     | ✓     |        | ✓   |
+| [Clipboard](https://ark-ui.com/docs/react/components/clipboard)                   | ✓     | ✓     |        | ✓   |
+| [Collapsible](https://ark-ui.com/docs/react/components/collapsible)               | ✓     | ✓     |        | ✓   |
+| [Color Picker](https://ark-ui.com/docs/react/components/color-picker)             | ✓     | ✓     |        | ✓   |
+| [Combobox](https://ark-ui.com/docs/react/components/combobox)                     | ✓     | ✓     |        | ✓   |
+| [Date Picker](https://ark-ui.com/docs/react/components/date-picker)               | ✓     | ✓     |        | ✓   |
+| [Dialog](https://ark-ui.com/docs/react/components/dialog)                         | ✓     | ✓     |        | ✓   |
+| [Editable](https://ark-ui.com/docs/react/components/editable)                     | ✓     | ✓     |        | ✓   |
+| [File Upload](https://ark-ui.com/docs/react/components/file-upload)               | ✓     | ✓     |        | ✓   |
+| [Format](https://ark-ui.com/docs/react/components/format)                         | ✓     | ✓     |        | ✓   |
+| [Hover Card](https://ark-ui.com/docs/react/components/hover-card)                 | ✓     | ✓     |        | ✓   |
+| [Menu](https://ark-ui.com/docs/react/components/menu)                             | ✓     | ✓     |        | ✓   |
+| [Number Input](https://ark-ui.com/docs/react/components/number-input)             | ✓     | ✓     |        | ✓   |
+| [Pagination](https://ark-ui.com/docs/react/components/pagination)                 | ✓     | ✓     |        | ✓   |
+| [Pin Input](https://ark-ui.com/docs/react/components/pin-input)                   | ✓     | ✓     |        | ✓   |
+| [Popover](https://ark-ui.com/docs/react/components/popover)                       | ✓     | ✓     |        | ✓   |
+| [Presence](https://ark-ui.com/docs/react/components/presence)                     | ✓     | ✓     |        | ✓   |
+| [Progress - Circular](https://ark-ui.com/docs/react/components/circular-progress) | ✓     | ✓     |        | ✓   |
+| [Progress - Linear](https://ark-ui.com/docs/react/components/linear-progress)     | ✓     | ✓     |        | ✓   |
+| [Radio Group](https://ark-ui.com/docs/react/components/radio-group)               | ✓     | ✓     |        | ✓   |
+| [Rating Group](https://ark-ui.com/docs/react/components/rating-group)             | ✓     | ✓     |        | ✓   |
+| [Segment Group](https://ark-ui.com/docs/react/components/segment-group)           | ✓     | ✓     |        | ✓   |
+| [Select](https://ark-ui.com/docs/react/components/select)                         | ✓     | ✓     |        | ✓   |
+| [Slider](https://ark-ui.com/docs/react/components/slider)                         | ✓     | ✓     |        | ✓   |
+| [Splitter](https://ark-ui.com/docs/react/components/splitter)                     | ✓     | ✓     |        | ✓   |
+| [Switch](https://ark-ui.com/docs/react/components/switch)                         | ✓     | ✓     |        | ✓   |
+| [Tabs](https://ark-ui.com/docs/react/components/tabs)                             | ✓     | ✓     |        | ✓   |
+| [Tags Input](https://ark-ui.com/docs/react/components/tags-input)                 | ✓     | ✓     |        | ✓   |
+| [Toast](https://ark-ui.com/docs/react/components/toast)                           | ✓     | ✓     |        | ✓   |
+| [Toggle Group](https://ark-ui.com/docs/react/components/toggle-group)             | ✓     | ✓     |        | ✓   |
+| [Tooltip](https://ark-ui.com/docs/react/components/tooltip)                       | ✓     | ✓     |        | ✓   |
+| [Tree View](https://ark-ui.com/docs/react/components/tree-view)                   | ✓     | ✓     |        | ✓   |
 
 ## Documentation
 


### PR DESCRIPTION
This PR fixes broken links to components documentation in the README file.

I believe it's okay to fix it like this because the documentation seems to be identical for all supported frameworks and also it's easy to switch between frameworks on the website.