### PR TITLE
Fixed collapsible component animation documentation

### DIFF
--- a/website/src/content/pages/components/collapsible.mdx
+++ b/website/src/content/pages/components/collapsible.mdx
@@ -23,11 +23,11 @@ animate the open and closed states.
   to { height: 0; }
 }
 
-[data-scope='accordion'][data-part='item-content'][data-state='open'] {
+[data-scope='collapsible'][data-part='content'][data-state='open'] {
   animation: slideDown 250ms;
 }
 
-[data-scope='accordion'][data-part='item-content'][data-state='closed'] {
+[data-scope='collapsible'][data-part='content'][data-state='closed'] {
   animation: slideUp 200ms;
 }
 ```


### PR DESCRIPTION
Docs showed animation for the accordion component :

```scss
@keyframes slideDown {
  from { height: 0; }
  to { height: var(--height); }
}

@keyframes slideUp {
  from { height: var(--height); }
  to { height: 0; }
}

[data-scope='accordion'][data-part='item-content'][data-state='open'] {
  animation: slideDown 250ms;
}

[data-scope='accordion'][data-part='item-content'][data-state='closed'] {
  animation: slideUp 200ms;
}
```

Instead of the accurate animation code :
```scss
@keyframes slideDown {
  from { height: 0; }
  to { height: var(--height); }
}

@keyframes slideUp {
  from { height: var(--height); }
  to { height: 0; }
}

[data-scope='collapsible'][data-part='content'][data-state='open'] {
  animation: slideDown 250ms;
}

[data-scope='collapsible'][data-part='content'][data-state='closed'] {
  animation: slideUp 200ms;
}

```
