### PR TITLE
fix(react): do not overwrite `open` context

### DIFF
--- a/packages/react/src/components/hover-card/tests/hover-card.test.tsx
+++ b/packages/react/src/components/hover-card/tests/hover-card.test.tsx
@@ -70,4 +70,11 @@ describe('HoverCard', () => {
     await user.unhover(screen.getByText('Hover me'))
     await waitFor(() => expect(screen.queryByTestId('positioner')).not.toBeInTheDocument())
   })
+
+  it('should open by default', async () => {
+    render(<ComponentUnderTest defaultOpen />)
+
+    const hoverContent = screen.getByText('Content')
+    await waitFor(() => expect(hoverContent).toBeVisible())
+  })
 })

--- a/packages/react/src/components/hover-card/use-hover-card.ts
+++ b/packages/react/src/components/hover-card/use-hover-card.ts
@@ -24,14 +24,13 @@ export const useHoverCard = (props: UseHoverCardProps = {}): UseHoverCardReturn 
     id: useId(),
     dir,
     getRootNode,
-    open: props.defaultOpen,
+    open: props.open ?? props.defaultOpen,
     'open.controlled': props.open !== undefined,
     ...props,
   }
 
   const context: hoverCard.Context = {
     ...initialContext,
-    open: props.open,
     onOpenChange: useEvent(props.onOpenChange, { sync: true }),
   }
 

--- a/packages/react/src/components/popover/tests/popover.test.tsx
+++ b/packages/react/src/components/popover/tests/popover.test.tsx
@@ -87,4 +87,9 @@ describe('Popover', () => {
     await user.click(screen.getByRole('button', { name: 'close' }))
     await waitFor(() => expect(screen.queryByTestId('positioner')).not.toBeInTheDocument())
   })
+
+  it('should open by default', async () => {
+    render(<ComponentUnderTest defaultOpen />)
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
 })

--- a/packages/react/src/components/popover/use-popover.ts
+++ b/packages/react/src/components/popover/use-popover.ts
@@ -24,14 +24,13 @@ export const usePopover = (props: UsePopoverProps = {}): UsePopoverReturn => {
     id: useId(),
     dir,
     getRootNode,
-    open: props.defaultOpen,
+    open: props.open ?? props.defaultOpen,
     'open.controlled': props.open !== undefined,
     ...props,
   }
 
   const context: popover.Context = {
     ...initialContext,
-    open: props.open,
     onOpenChange: useEvent(props.onOpenChange, { sync: true }),
   }
 


### PR DESCRIPTION
`defaultOpen` prop of `Popover` and `HoverCard` doesn't work (I don't know why but `Dialog` works fine🤔 )