### PR TITLE
fix: Add missing `group` role to Checkbox Group

### DIFF
--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -6,6 +6,10 @@ description: All notable changes will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Checkbox:** Added missing `group` role for Checkbox group component.
+
 ## [3.3.0] - 2024-06-12
 
 ### Added

--- a/packages/react/src/components/checkbox/checkbox-group.tsx
+++ b/packages/react/src/components/checkbox/checkbox-group.tsx
@@ -21,7 +21,7 @@ export const CheckboxGroup = forwardRef<HTMLDivElement, CheckboxGroupProps>((pro
 
   return (
     <CheckboxGroupContextProvider value={checkboxGroup}>
-      <ark.div ref={ref} {...localProps} {...checkboxAnatomy.build().group.attrs} />
+      <ark.div ref={ref} role="group" {...localProps} {...checkboxAnatomy.build().group.attrs} />
     </CheckboxGroupContextProvider>
   )
 })

--- a/packages/solid/CHANGELOG.md
+++ b/packages/solid/CHANGELOG.md
@@ -6,6 +6,10 @@ description: All notable changes will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Checkbox:** Added missing `group` role for Checkbox group component.
+
 ## [3.3.0] - 2024-06-12
 
 ### Added

--- a/packages/solid/src/components/checkbox/checkbox-group.tsx
+++ b/packages/solid/src/components/checkbox/checkbox-group.tsx
@@ -19,7 +19,7 @@ export const CheckboxGroup = (props: CheckboxGroupProps) => {
 
   return (
     <CheckboxGroupContextProvider value={checkboxGroup}>
-      <ark.div {...localProps} {...checkboxAnatomy.build().group.attrs} />
+      <ark.div role="group" {...localProps} {...checkboxAnatomy.build().group.attrs} />
     </CheckboxGroupContextProvider>
   )
 }

--- a/packages/vue/CHANGELOG.md
+++ b/packages/vue/CHANGELOG.md
@@ -6,6 +6,10 @@ description: All notable changes will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Checkbox:** Added missing `group` role for Checkbox group component.
+
 ## [3.4.0] - 2024-06-12
 
 ### Added

--- a/packages/vue/src/components/checkbox/checkbox-group.vue
+++ b/packages/vue/src/components/checkbox/checkbox-group.vue
@@ -32,7 +32,7 @@ CheckboxGroupProvider(checkboxGroup)
 </script>
 
 <template>
-  <ark.div v-bind="{ ...checkboxAnatomy.build().group.attrs }" :as-child="asChild">
+  <ark.div role="group" v-bind="{ ...checkboxAnatomy.build().group.attrs }" :as-child="asChild">
     <slot />
   </ark.div>
 </template>


### PR DESCRIPTION
Checkbox groups should have a `group` role.
https://www.w3.org/WAI/ARIA/apg/patterns/checkbox/examples/checkbox/