### PR TITLE
feat: Add a name prop to CheckboxGroup

### DIFF
--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -6,6 +6,9 @@ description: All notable changes will be documented in this file.
 
 ## [Unreleased]
 
+- **CheckboxGroup**: Introduced the `name` prop on CheckboxGroup to set the names of the checkboxes
+  inside it.
+
 ## [3.4.0] - 2024-06-25
 
 ### Added

--- a/packages/react/src/components/checkbox/checkbox-group.tsx
+++ b/packages/react/src/components/checkbox/checkbox-group.tsx
@@ -16,6 +16,7 @@ export const CheckboxGroup = forwardRef<HTMLDivElement, CheckboxGroupProps>((pro
     'onValueChange',
     'disabled',
     'readOnly',
+    'name',
   ])
 
   const checkboxGroup = useCheckboxGroup(checkboxGroupProps)

--- a/packages/react/src/components/checkbox/checkbox.stories.tsx
+++ b/packages/react/src/components/checkbox/checkbox.stories.tsx
@@ -9,6 +9,7 @@ export default meta
 export { Basic } from './examples/basic'
 export { Controlled } from './examples/controlled'
 export { Group } from './examples/group'
+export { GroupWithForm } from './examples/group-with-form'
 export { Indeterminate } from './examples/indeterminate'
 export { RenderProp } from './examples/render-prop'
 export { WithField } from './examples/with-field'

--- a/packages/react/src/components/checkbox/examples/group-with-form.tsx
+++ b/packages/react/src/components/checkbox/examples/group-with-form.tsx
@@ -1,0 +1,32 @@
+import { CheckIcon } from 'lucide-react'
+import { Checkbox } from '../..'
+
+const items = [
+  { label: 'React', value: 'react' },
+  { label: 'Solid', value: 'solid' },
+  { label: 'Vue', value: 'vue' },
+]
+
+export const GroupWithForm = () => (
+  <form
+    onSubmit={(e) => {
+      e.preventDefault()
+      console.log(new FormData(e.currentTarget).getAll('framework'))
+    }}
+  >
+    <Checkbox.Group defaultValue={['react']} name="framework">
+      {items.map((item) => (
+        <Checkbox.Root value={item.value} key={item.value}>
+          <Checkbox.Label>{item.label}</Checkbox.Label>
+          <Checkbox.Control>
+            <Checkbox.Indicator>
+              <CheckIcon />
+            </Checkbox.Indicator>
+          </Checkbox.Control>
+          <Checkbox.HiddenInput />
+        </Checkbox.Root>
+      ))}
+    </Checkbox.Group>
+    <button type="submit">Submit</button>
+  </form>
+)

--- a/packages/react/src/components/checkbox/examples/group.tsx
+++ b/packages/react/src/components/checkbox/examples/group.tsx
@@ -8,7 +8,7 @@ const items = [
 ]
 
 export const Group = () => (
-  <Checkbox.Group defaultValue={['react']} onValueChange={console.log}>
+  <Checkbox.Group defaultValue={['react']} name="framework" onValueChange={console.log}>
     {items.map((item) => (
       <Checkbox.Root value={item.value} key={item.value}>
         <Checkbox.Label>{item.label}</Checkbox.Label>

--- a/packages/react/src/components/checkbox/use-checkbox-group.ts
+++ b/packages/react/src/components/checkbox/use-checkbox-group.ts
@@ -11,6 +11,11 @@ export interface UseCheckboxGroupProps {
    */
   value?: string[]
   /**
+   * The name of the input fields in the checkbox group
+   * (Useful for form submission).
+   */
+  name?: string
+  /**
    * The callback to call when the value changes
    */
   onValueChange?: (value: string[]) => void
@@ -29,7 +34,7 @@ export interface CheckboxGroupItemProps {
 }
 
 export function useCheckboxGroup(props: UseCheckboxGroupProps = {}) {
-  const { defaultValue, value: controlledValue, onValueChange, disabled, readOnly } = props
+  const { defaultValue, value: controlledValue, onValueChange, disabled, readOnly, name } = props
   const interative = !(disabled || readOnly)
 
   const onChangeProp = useEvent(onValueChange, { sync: true })
@@ -67,6 +72,7 @@ export function useCheckboxGroup(props: UseCheckboxGroupProps = {}) {
           toggleValue(props.value)
         }
       },
+      name,
       disabled,
       readOnly,
     }
@@ -75,6 +81,7 @@ export function useCheckboxGroup(props: UseCheckboxGroupProps = {}) {
   return {
     isChecked,
     value,
+    name,
     disabled,
     readOnly,
     setValue,

--- a/packages/solid/CHANGELOG.md
+++ b/packages/solid/CHANGELOG.md
@@ -6,6 +6,9 @@ description: All notable changes will be documented in this file.
 
 ## [Unreleased]
 
+- **CheckboxGroup**: Introduced the `name` prop on CheckboxGroup to set the names of the checkboxes
+  inside it.
+
 ## [3.4.0] - 2024-06-25
 
 ### Added

--- a/packages/solid/src/components/checkbox/checkbox-group.tsx
+++ b/packages/solid/src/components/checkbox/checkbox-group.tsx
@@ -14,6 +14,7 @@ export const CheckboxGroup = (props: CheckboxGroupProps) => {
     'onValueChange',
     'disabled',
     'readOnly',
+    'name',
   ])
   const checkboxGroup = useCheckboxGroup(checkboxGroupProps)
 

--- a/packages/solid/src/components/checkbox/examples/group.tsx
+++ b/packages/solid/src/components/checkbox/examples/group.tsx
@@ -9,7 +9,7 @@ const items = [
 ]
 
 export const Group = () => (
-  <CheckboxGroup defaultValue={['react']} onValueChange={console.log}>
+  <CheckboxGroup defaultValue={['react']} name="framework" onValueChange={console.log}>
     <For each={items}>
       {(item) => (
         <Checkbox.Root value={item.value}>

--- a/packages/solid/src/components/checkbox/use-checkbox-group.ts
+++ b/packages/solid/src/components/checkbox/use-checkbox-group.ts
@@ -11,6 +11,11 @@ export interface UseCheckboxGroupProps {
    */
   value?: Accessor<string[]>
   /**
+   * The name of the input fields in the checkbox group
+   * (Useful for form submission).
+   */
+  name?: string
+  /**
    * The callback to call when the value changes
    */
   onValueChange?: (value: string[]) => void
@@ -65,6 +70,7 @@ export function useCheckboxGroup(props: UseCheckboxGroupProps = {}) {
             toggleValue(itemProps.value)
           }
         },
+        name: props.name,
         disabled: props.disabled,
         readOnly: props.readOnly,
       }
@@ -73,6 +79,7 @@ export function useCheckboxGroup(props: UseCheckboxGroupProps = {}) {
     return {
       isChecked,
       value,
+      name: props.name,
       disabled: props.disabled,
       readOnly: props.readOnly,
       setValue,

--- a/packages/vue/CHANGELOG.md
+++ b/packages/vue/CHANGELOG.md
@@ -6,6 +6,9 @@ description: All notable changes will be documented in this file.
 
 ## [Unreleased]
 
+- **CheckboxGroup**: Introduced the `name` prop on CheckboxGroup to set the names of the checkboxes
+  inside it.
+
 ## [3.5.0] - 2024-06-25
 
 ### Added

--- a/packages/vue/src/components/checkbox/checkbox-group.types.ts
+++ b/packages/vue/src/components/checkbox/checkbox-group.types.ts
@@ -15,6 +15,11 @@ export interface GroupProps {
    * If `true`, the checkbox group is read-only
    */
   readOnly?: boolean
+  /**
+   * The name of the input fields in the checkbox group
+   * (Useful for form submission).
+   */
+  name?: string
 }
 
 export type GroupEmits = {

--- a/packages/vue/src/components/checkbox/examples/group.vue
+++ b/packages/vue/src/components/checkbox/examples/group.vue
@@ -10,7 +10,7 @@ const items = [
 </script>
 
 <template>
-  <Checkbox.Group :defaultValue="['react']" @valueChange="console.log">
+  <Checkbox.Group :defaultValue="['react']" name="framework" @valueChange="console.log">
     <Checkbox.Root v-for="item in items" :value="item.value" :key="item.value">
       <Checkbox.Label>{{ item.label }}</Checkbox.Label>
       <Checkbox.Control>

--- a/packages/vue/src/components/checkbox/use-checkbox-group.ts
+++ b/packages/vue/src/components/checkbox/use-checkbox-group.ts
@@ -48,6 +48,7 @@ export function useCheckboxGroup(props: GroupProps, emit?: EmitFn<GroupEmits>) {
           toggleValue(itemProps.value)
         }
       },
+      name: props.name,
       disabled: props.disabled,
       readOnly: props.readOnly,
     }
@@ -59,6 +60,7 @@ export function useCheckboxGroup(props: GroupProps, emit?: EmitFn<GroupEmits>) {
   return computed(() => ({
     isChecked,
     value: valueRef.value,
+    name: props.name,
     disabled: props.disabled,
     readOnly: props.readOnly,
     addValue,

--- a/website/src/content/types/react/checkbox.types.json
+++ b/website/src/content/types/react/checkbox.types.json
@@ -27,6 +27,11 @@
         "isRequired": false,
         "description": "If `true`, the checkbox group is disabled"
       },
+      "name": {
+        "type": "string",
+        "isRequired": false,
+        "description": "The name of all input field in a checkbox group.\nUseful for form submission."
+      },
       "onValueChange": {
         "type": "(value: string[]) => void",
         "isRequired": false,

--- a/website/src/content/types/solid/checkbox.types.json
+++ b/website/src/content/types/solid/checkbox.types.json
@@ -25,6 +25,11 @@
         "isRequired": false,
         "description": "If `true`, the checkbox group is disabled"
       },
+      "name": {
+        "type": "string",
+        "isRequired": false,
+        "description": "The name of all input field in a checkbox group.\nUseful for form submission."
+      },
       "onValueChange": {
         "type": "(value: string[]) => void",
         "isRequired": false,

--- a/website/src/content/types/vue/checkbox.types.json
+++ b/website/src/content/types/vue/checkbox.types.json
@@ -30,6 +30,11 @@
         "isRequired": false,
         "description": "The controlled value of the checkbox group"
       },
+      "name": {
+        "type": "string",
+        "isRequired": false,
+        "description": "The name of all input field in a checkbox group.\nUseful for form submission."
+      },
       "readOnly": {
         "type": "boolean",
         "isRequired": false,


### PR DESCRIPTION
Hi! I added a `name` prop to CheckboxGroup to set the name of all the checkboxes it holds to improve form submission usage. I'm not really sure if there are any tests to add. I updated the story examples to show that the input names are updated if the prop is set.

I'm not too well versed in vue nor solid, so please scrutinize my code heavily!

Also, I noticed that CheckboxGroup props take precedence over the props passed into a single `CheckboxRoot`. Is this on purpose?