### PR TITLE
feat(react): expose CreateToasterReturn prop

### DIFF
--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -6,6 +6,10 @@ description: All notable changes will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- **Toast**: Exported `CreateToasterReturn` type to improve type inference when creating a toaster.
+
 ## [3.5.0] - 2024-06-30
 
 ### Added

--- a/packages/react/src/components/toast/index.ts
+++ b/packages/react/src/components/toast/index.ts
@@ -1,6 +1,7 @@
 export {
   createToaster,
   type CreateToasterProps,
+  type CreateToasterReturn,
 } from './create-toaster'
 export {
   ToastActionTrigger,

--- a/packages/solid/CHANGELOG.md
+++ b/packages/solid/CHANGELOG.md
@@ -6,6 +6,10 @@ description: All notable changes will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- **Toast**: Exported `CreateToasterReturn` type to improve type inference when creating a toaster.
+
 ## [3.5.0] - 2024-06-30
 
 - **All Components**: Exported each component's anatomy. For example:

--- a/packages/solid/src/components/toast/index.ts
+++ b/packages/solid/src/components/toast/index.ts
@@ -1,6 +1,7 @@
 export {
   createToaster,
   type CreateToasterProps,
+  type CreateToasterReturn,
 } from './create-toaster'
 export {
   ToastActionTrigger,

--- a/packages/vue/CHANGELOG.md
+++ b/packages/vue/CHANGELOG.md
@@ -6,6 +6,10 @@ description: All notable changes will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- **Toast**: Exported `CreateToasterReturn` type to improve type inference when creating a toaster.
+
 ## [3.6.0] - 2024-06-30
 
 - **All Components**: Exported each component's anatomy. For example:

--- a/packages/vue/src/components/toast/index.ts
+++ b/packages/vue/src/components/toast/index.ts
@@ -1,4 +1,8 @@
-export { createToaster, type CreateToasterProps } from './create-toaster'
+export {
+  createToaster,
+  type CreateToasterProps,
+  type CreateToasterReturn,
+} from './create-toaster'
 export {
   default as ToastActionTrigger,
   type ToastActionTriggerProps,


### PR DESCRIPTION
I need the CreateToasterReturn prop in my project. I figured other people may need it too. I don't see any harm in exposing it.