### PR TITLE
fix(docs): fix z-index of top navigation to 2

### DIFF
--- a/website/src/components/navigation/navbar-container.tsx
+++ b/website/src/components/navigation/navbar-container.tsx
@@ -8,7 +8,7 @@ export const NavbarContainer = (props: BoxProps) => {
       top="0"
       width="full"
       background="bg.canvas"
-      zIndex="1"
+      zIndex="2"
       borderBottomWidth="1px"
       borderColor={{ _light: 'border.subtle', _dark: 'black' }}
     >


### PR DESCRIPTION
This PR should fix: #2625 

I bumped the z-index of the navbar to 2, this will be higher than the z-index of the tabs (which is 1).