### PR TITLE
fix(docs): fix z-index of docs navbar to 2

### DIFF
--- a/website/src/components/navigation/docs/docs-navbar.tsx
+++ b/website/src/components/navigation/docs/docs-navbar.tsx
@@ -20,7 +20,7 @@ export const DocsNavbar = () => {
       right="0"
       top="16"
       bg="bg.canvas"
-      zIndex="1"
+      zIndex="2"
     >
       <MobileSidebarContainer>
         <DocsSidebar groups={groups} />


### PR DESCRIPTION
This PR should fix: https://github.com/chakra-ui/ark/issues/2625
and is addition to this PR: #2676 

Noticed the same behavior on the docs navbar on the mobile view.
I bumped the z-index of the docs navbar to 2, this will be higher than the z-index of the tabs (which is 1).