### PR TITLE
fix(vue): presence of componets with `Positioner`

### DIFF
--- a/packages/vue/src/components/color-picker/color-picker-content.vue
+++ b/packages/vue/src/components/color-picker/color-picker-content.vue
@@ -24,7 +24,7 @@ const mergedProps = computed(() => mergeProps(colorPicker.value.getContentProps(
 </script>
 
 <template>
-  <ark.div v-bind="mergedProps">
+  <ark.div v-if="!presence.unmounted" v-bind="mergedProps" :as-child="asChild">
     <slot />
   </ark.div>
 </template>

--- a/packages/vue/src/components/color-picker/color-picker-content.vue
+++ b/packages/vue/src/components/color-picker/color-picker-content.vue
@@ -1,7 +1,8 @@
 <script lang="ts">
-import type { HTMLAttributes } from 'vue'
+import { mergeProps } from '@zag-js/vue'
+import { type HTMLAttributes, computed } from 'vue'
 import type { PolymorphicProps } from '../factory'
-import type { PresenceProps } from '../presence'
+import { type PresenceProps, usePresenceContext } from '../presence'
 
 export interface ColorPickerContentBaseProps extends PresenceProps, PolymorphicProps {}
 export interface ColorPickerContentProps
@@ -18,10 +19,12 @@ import { useColorPickerContext } from './use-color-picker-context'
 
 defineProps<ColorPickerContentProps>()
 const colorPicker = useColorPickerContext()
+const presence = usePresenceContext()
+const mergedProps = computed(() => mergeProps(colorPicker.value.getContentProps(), presence.value.presenceProps))
 </script>
 
 <template>
-  <ark.div v-bind="colorPicker.getContentProps()">
+  <ark.div v-bind="mergedProps">
     <slot />
   </ark.div>
 </template>

--- a/packages/vue/src/components/color-picker/color-picker-positioner.vue
+++ b/packages/vue/src/components/color-picker/color-picker-positioner.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
-import type { HTMLAttributes } from 'vue'
-import type { PolymorphicProps } from '../factory'
+import { type HTMLAttributes, computed } from 'vue'
+import { type PolymorphicProps, ark } from '../factory'
 
 export interface ColorPickerPositionerBaseProps extends PolymorphicProps {}
 export interface ColorPickerPositionerProps
@@ -13,21 +13,24 @@ export interface ColorPickerPositionerProps
 
 <script setup lang="ts">
 import { useRenderStrategyProps } from '../../utils'
-import { Presence } from '../presence'
+import { PresenceProvider, usePresence } from '../presence'
 import { useColorPickerContext } from './use-color-picker-context'
 
 defineProps<ColorPickerPositionerProps>()
 const colorPicker = useColorPickerContext()
 const renderStrategy = useRenderStrategyProps()
+
+const presence = usePresence(
+  computed(() => ({
+    ...renderStrategy.value,
+    present: colorPicker.value.open,
+  })),
+)
+PresenceProvider(presence)
 </script>
 
 <template>
-  <Presence
-    v-bind="colorPicker.getPositionerProps()"
-    :present="colorPicker.open"
-    :lazy-mount="renderStrategy.lazyMount"
-    :unmount-on-exit="renderStrategy.unmountOnExit"
-  >
+  <ark.div v-if="!presence.unmounted" v-bind="colorPicker.getPositionerProps()" :as-child="asChild">
     <slot />
-  </Presence>
+  </ark.div>
 </template>

--- a/packages/vue/src/components/combobox/combobox-content.vue
+++ b/packages/vue/src/components/combobox/combobox-content.vue
@@ -1,6 +1,8 @@
 <script lang="ts">
-import type { HTMLAttributes } from 'vue'
+import { mergeProps } from '@zag-js/vue'
+import { type HTMLAttributes, computed } from 'vue'
 import type { PolymorphicProps } from '../factory'
+import { usePresenceContext } from '../presence'
 
 export interface ComboboxContentBaseProps extends PolymorphicProps {}
 export interface ComboboxContentProps
@@ -17,10 +19,13 @@ import { useComboboxContext } from './use-combobox-context'
 
 defineProps<ComboboxContentProps>()
 const combobox = useComboboxContext()
+const presence = usePresenceContext()
+const mergedProps = computed(() => mergeProps(combobox.value.getContentProps(), presence.value.presenceProps))
 </script>
 
 <template>
-  <ark.div v-bind="combobox.getContentProps()" :as-child="asChild">
+  <ark.div v-if="!presence.unmounted" v-bind="mergedProps" :as-child="asChild">
     <slot />
   </ark.div>
 </template>
+

--- a/packages/vue/src/components/combobox/combobox-positioner.vue
+++ b/packages/vue/src/components/combobox/combobox-positioner.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
-import type { HTMLAttributes } from 'vue'
-import type { PolymorphicProps } from '../factory'
+import { type HTMLAttributes, computed } from 'vue'
+import { type PolymorphicProps, ark } from '../factory'
 
 export interface ComboboxPositionerBaseProps extends PolymorphicProps {}
 export interface ComboboxPositionerProps
@@ -13,21 +13,24 @@ export interface ComboboxPositionerProps
 
 <script setup lang="ts">
 import { useRenderStrategyProps } from '../../utils'
-import { Presence } from '../presence'
+import { PresenceProvider, usePresence } from '../presence'
 import { useComboboxContext } from './use-combobox-context'
 
 defineProps<ComboboxPositionerProps>()
 const combobox = useComboboxContext()
 const renderStrategy = useRenderStrategyProps()
+
+const presence = usePresence(
+  computed(() => ({
+    ...renderStrategy.value,
+    present: combobox.value.open,
+  })),
+)
+PresenceProvider(presence)
 </script>
 
 <template>
-  <Presence
-    v-bind="combobox.getPositionerProps()"
-    :present="combobox.open"
-    :lazy-mount="renderStrategy.lazyMount"
-    :unmount-on-exit="renderStrategy.unmountOnExit"
-  >
+  <ark.div v-if="!presence.unmounted" v-bind="combobox.getPositionerProps()" :as-child="asChild">
     <slot />
-  </Presence>
+  </ark.div>
 </template>

--- a/packages/vue/src/components/date-picker/date-picker-content.vue
+++ b/packages/vue/src/components/date-picker/date-picker-content.vue
@@ -1,6 +1,8 @@
 <script lang="ts">
-import type { HTMLAttributes } from 'vue'
+import { mergeProps } from '@zag-js/vue'
+import { type HTMLAttributes, computed } from 'vue'
 import type { PolymorphicProps } from '../factory'
+import { usePresenceContext } from '../presence'
 
 export interface DatePickerContentBaseProps extends PolymorphicProps {}
 export interface DatePickerContentProps
@@ -17,10 +19,12 @@ import { useDatePickerContext } from './use-date-picker-context'
 
 defineProps<DatePickerContentProps>()
 const datePicker = useDatePickerContext()
+const presence = usePresenceContext()
+const mergedProps = computed(() => mergeProps(datePicker.value.getContentProps(), presence.value.presenceProps))
 </script>
 
 <template>
-  <ark.div v-bind="datePicker.getContentProps()" :as-child="asChild">
+  <ark.div v-if="!presence.unmounted" v-bind="mergedProps" :as-child="asChild">
     <slot />
   </ark.div>
 </template>

--- a/packages/vue/src/components/date-picker/date-picker-positioner.vue
+++ b/packages/vue/src/components/date-picker/date-picker-positioner.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
-import type { HTMLAttributes } from 'vue'
-import type { PolymorphicProps } from '../factory'
+import { type HTMLAttributes, computed } from 'vue'
+import { type PolymorphicProps, ark } from '../factory'
 
 export interface DatePickerPositionerBaseProps extends PolymorphicProps {}
 export interface DatePickerPositionerProps
@@ -13,21 +13,24 @@ export interface DatePickerPositionerProps
 
 <script setup lang="ts">
 import { useRenderStrategyProps } from '../../utils'
-import { Presence } from '../presence'
+import { PresenceProvider, usePresence } from '../presence'
 import { useDatePickerContext } from './use-date-picker-context'
 
 defineProps<DatePickerPositionerProps>()
 const datePicker = useDatePickerContext()
 const renderStrategy = useRenderStrategyProps()
+
+const presence = usePresence(
+  computed(() => ({
+    ...renderStrategy.value,
+    present: datePicker.value.open,
+  })),
+)
+PresenceProvider(presence)
 </script>
 
 <template>
-  <Presence
-    v-bind="datePicker.getPositionerProps()"
-    :present="datePicker.open"
-    :lazy-mount="renderStrategy.lazyMount"
-    :unmount-on-exit="renderStrategy.unmountOnExit"
-  >
+  <ark.div v-if="!presence.unmounted" v-bind="datePicker.getPositionerProps()" :as-child="asChild">
     <slot />
-  </Presence>
+  </ark.div>
 </template>

--- a/packages/vue/src/components/dialog/dialog-content.vue
+++ b/packages/vue/src/components/dialog/dialog-content.vue
@@ -1,6 +1,8 @@
 <script lang="ts">
-import type { HTMLAttributes } from 'vue'
+import { mergeProps } from '@zag-js/vue'
+import { type HTMLAttributes, computed } from 'vue'
 import type { PolymorphicProps } from '../factory'
+import { usePresenceContext } from '../presence'
 
 export interface DialogContentBaseProps extends PolymorphicProps {}
 export interface DialogContentProps
@@ -16,11 +18,14 @@ import { ark } from '../factory'
 import { useDialogContext } from './use-dialog-context'
 
 defineProps<DialogContentProps>()
+
 const dialog = useDialogContext()
+const presence = usePresenceContext()
+const mergedProps = computed(() => mergeProps(dialog.value.getContentProps(), presence.value.presenceProps))
 </script>
 
 <template>
-  <ark.div v-bind="dialog.getContentProps()" :as-child="asChild">
+  <ark.div v-if="!presence.unmounted" v-bind="mergedProps" :as-child="asChild">
     <slot />
   </ark.div>
 </template>

--- a/packages/vue/src/components/dialog/dialog-positioner.vue
+++ b/packages/vue/src/components/dialog/dialog-positioner.vue
@@ -1,5 +1,6 @@
 <script lang="ts">
-import type { HTMLAttributes } from 'vue'
+import { type HTMLAttributes, computed } from 'vue'
+import { useRenderStrategyProps } from '../../utils'
 import type { PolymorphicProps } from '../factory'
 
 export interface DialogPositionerBaseProps extends PolymorphicProps {}
@@ -12,22 +13,26 @@ export interface DialogPositionerProps
 </script>
 
 <script setup lang="ts">
-import { useRenderStrategyProps } from '../../utils'
-import { Presence } from '../presence'
+import { ark } from '../factory'
+import { PresenceProvider, usePresence } from '../presence'
 import { useDialogContext } from './use-dialog-context'
 
 defineProps<DialogPositionerProps>()
+
 const dialog = useDialogContext()
 const renderStrategy = useRenderStrategyProps()
+
+const presence = usePresence(
+  computed(() => ({
+    ...renderStrategy.value,
+    present: dialog.value.open,
+  })),
+)
+PresenceProvider(presence)
 </script>
 
 <template>
-  <Presence
-    v-bind="dialog.getPositionerProps()"
-    :present="dialog.open"
-    :lazy-mount="renderStrategy.lazyMount"
-    :unmount-on-exit="renderStrategy.unmountOnExit"
-  >
+  <ark.div v-if="!presence.unmounted" v-bind="dialog.getPositionerProps()" :as-child="asChild">
     <slot />
-  </Presence>
+  </ark.div>
 </template>

--- a/packages/vue/src/components/dialog/tests/dialog.test.ts
+++ b/packages/vue/src/components/dialog/tests/dialog.test.ts
@@ -19,10 +19,11 @@ describe('Dialog', () => {
     render(ComponentUnderTest)
 
     await user.click(screen.getByText('Open Dialog'))
-    expect(await screen.findByText('Dialog Title')).toBeVisible()
+
+    await waitFor(async () => expect(await screen.findByText('Dialog Title')).toBeVisible())
 
     await user.click(screen.getByText('Close'))
-    expect(await screen.findByText('Dialog Title')).not.toBeVisible()
+    await waitFor(async () => expect(await screen.findByText('Dialog Title')).not.toBeVisible())
   })
 
   it('should invoke onOpenChange if dialog is closed', async () => {

--- a/packages/vue/src/components/hover-card/hover-card-content.vue
+++ b/packages/vue/src/components/hover-card/hover-card-content.vue
@@ -1,6 +1,8 @@
 <script lang="ts">
-import type { HTMLAttributes } from 'vue'
+import { mergeProps } from '@zag-js/vue'
+import { type HTMLAttributes, computed } from 'vue'
 import type { PolymorphicProps } from '../factory'
+import { usePresenceContext } from '../presence'
 
 export interface HoverCardContentBaseProps extends PolymorphicProps {}
 export interface HoverCardContentProps
@@ -17,10 +19,12 @@ import { useHoverCardContext } from './use-hover-card-context'
 
 defineProps<HoverCardContentProps>()
 const hoverCard = useHoverCardContext()
+const presence = usePresenceContext()
+const mergedProps = computed(() => mergeProps(hoverCard.value.getContentProps(), presence.value.presenceProps))
 </script>
 
 <template>
-  <ark.div v-bind="hoverCard.getContentProps()" :as-child="asChild">
+  <ark.div v-if="!presence.unmounted" v-bind="mergedProps" :as-child="asChild">
     <slot />
   </ark.div>
 </template>

--- a/packages/vue/src/components/hover-card/hover-card-positioner.vue
+++ b/packages/vue/src/components/hover-card/hover-card-positioner.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
-import type { HTMLAttributes } from 'vue'
-import type { PolymorphicProps } from '../factory'
+import { type HTMLAttributes, computed } from 'vue'
+import { type PolymorphicProps, ark } from '../factory'
 
 export interface HoverCardPositionerBaseProps extends PolymorphicProps {}
 export interface HoverCardPositionerProps
@@ -13,21 +13,25 @@ export interface HoverCardPositionerProps
 
 <script setup lang="ts">
 import { useRenderStrategyProps } from '../../utils'
-import { Presence } from '../presence'
+import { PresenceProvider, usePresence } from '../presence'
 import { useHoverCardContext } from './use-hover-card-context'
 
 defineProps<HoverCardPositionerProps>()
 const hoverCard = useHoverCardContext()
 const renderStrategy = useRenderStrategyProps()
+
+const presence = usePresence(
+  computed(() => ({
+    ...renderStrategy.value,
+    present: hoverCard.value.open,
+  })),
+)
+PresenceProvider(presence)
 </script>
 
 <template>
-  <Presence
-    v-bind="hoverCard.getPositionerProps()"
-    :present="hoverCard.open"
-    :lazy-mount="renderStrategy.lazyMount"
-    :unmount-on-exit="renderStrategy.unmountOnExit"
-  >
+  <ark.div v-if="!presence.unmounted" v-bind="hoverCard.getPositionerProps()" :as-child="asChild">
     <slot />
-  </Presence>
+  </ark.div>
 </template>
+

--- a/packages/vue/src/components/menu/menu-content.vue
+++ b/packages/vue/src/components/menu/menu-content.vue
@@ -1,6 +1,8 @@
 <script lang="ts">
-import type { HTMLAttributes } from 'vue'
+import { mergeProps } from '@zag-js/vue'
+import { type HTMLAttributes, computed } from 'vue'
 import type { PolymorphicProps } from '../factory'
+import { usePresenceContext } from '../presence'
 
 export interface MenuContentBaseProps extends PolymorphicProps {}
 export interface MenuContentProps
@@ -17,10 +19,12 @@ import { useMenuContext } from './use-menu-context'
 
 defineProps<MenuContentProps>()
 const menu = useMenuContext()
+const presence = usePresenceContext()
+const mergedProps = computed(() => mergeProps(menu.value.getContentProps(), presence.value.presenceProps))
 </script>
 
 <template>
-  <ark.div v-bind="menu.getContentProps()" :as-child="asChild">
+  <ark.div v-if="!presence.unmounted" v-bind="mergedProps" :as-child="asChild">
     <slot />
   </ark.div>
 </template>

--- a/packages/vue/src/components/menu/menu-positioner.vue
+++ b/packages/vue/src/components/menu/menu-positioner.vue
@@ -1,6 +1,7 @@
 <script lang="ts">
-import type { HTMLAttributes } from 'vue'
-import type { PolymorphicProps } from '../factory'
+import { type HTMLAttributes, computed } from 'vue'
+import { useRenderStrategyProps } from '../../utils'
+import { type PolymorphicProps, ark } from '../factory'
 
 export interface MenuPositionerBaseProps extends PolymorphicProps {}
 export interface MenuPositionerProps
@@ -12,17 +13,24 @@ export interface MenuPositionerProps
 </script>
 
 <script setup lang="ts">
-import { Presence } from '../presence'
-import { useMenuContext } from './use-menu-context'
+import { PresenceProvider, usePresence } from '../presence';
+import { useMenuContext } from './use-menu-context';
 
 defineProps<MenuPositionerProps>()
 const menu = useMenuContext()
-// TODO is undefined ?!
-// const renderStrategy = useRenderStrategyProps()
+const renderStrategy = useRenderStrategyProps()
+
+const presence = usePresence(
+  computed(() => ({
+    ...renderStrategy.value,
+    present: menu.value.open,
+  })),
+)
+PresenceProvider(presence)
 </script>
 
 <template>
-  <Presence v-bind="menu.getPositionerProps()" :present="menu.open">
+  <ark.div v-if="!presence.unmounted" v-bind="menu.getPositionerProps()" :as-child="asChild">
     <slot />
-  </Presence>
+  </ark.div>
 </template>

--- a/packages/vue/src/components/popover/popover-content.vue
+++ b/packages/vue/src/components/popover/popover-content.vue
@@ -1,6 +1,8 @@
 <script lang="ts">
-import type { HTMLAttributes } from 'vue'
+import { mergeProps } from '@zag-js/vue'
+import { type HTMLAttributes, computed } from 'vue'
 import type { PolymorphicProps } from '../factory'
+import { usePresenceContext } from '../presence'
 
 export interface PopoverContentBaseProps extends PolymorphicProps {}
 export interface PopoverContentProps
@@ -17,10 +19,12 @@ import { usePopoverContext } from './use-popover-context'
 
 defineProps<PopoverContentProps>()
 const popover = usePopoverContext()
+const presence = usePresenceContext()
+const mergedProps = computed(() => mergeProps(popover.value.getContentProps(), presence.value.presenceProps))
 </script>
 
 <template>
-  <ark.div v-bind="popover.getContentProps()" :as-child="asChild">
+  <ark.div v-if="!presence.unmounted" v-bind="mergedProps" :as-child="asChild">
     <slot />
   </ark.div>
 </template>

--- a/packages/vue/src/components/popover/popover-positioner.vue
+++ b/packages/vue/src/components/popover/popover-positioner.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
-import type { HTMLAttributes } from 'vue'
-import type { PolymorphicProps } from '../factory'
+import { type HTMLAttributes, computed } from 'vue'
+import { type PolymorphicProps, ark } from '../factory'
 
 export interface PopoverPositionerBaseProps extends PolymorphicProps {}
 export interface PopoverPositionerProps
@@ -13,22 +13,25 @@ export interface PopoverPositionerProps
 
 <script setup lang="ts">
 import { useRenderStrategyProps } from '../../utils'
-import { Presence } from '../presence'
+import { PresenceProvider, usePresence } from '../presence'
 import { usePopoverContext } from './use-popover-context'
 
 defineProps<PopoverPositionerProps>()
 
 const popover = usePopoverContext()
 const renderStrategy = useRenderStrategyProps()
+
+const presence = usePresence(
+  computed(() => ({
+    ...renderStrategy.value,
+    present: popover.value.open,
+  })),
+)
+PresenceProvider(presence)
 </script>
 
 <template>
-  <Presence
-    v-bind="popover.getPositionerProps()"
-    :present="popover.open"
-    :lazy-mount="renderStrategy.lazyMount"
-    :unmount-on-exit="renderStrategy.unmountOnExit"
-  >
+  <ark.div v-if="!presence.unmounted" v-bind="popover.getPositionerProps()" :as-child="asChild">
     <slot />
-  </Presence>
+  </ark.div>
 </template>

--- a/packages/vue/src/components/select/select-content.vue
+++ b/packages/vue/src/components/select/select-content.vue
@@ -1,6 +1,8 @@
 <script lang="ts">
-import type { HTMLAttributes } from 'vue'
+import { mergeProps } from '@zag-js/vue'
+import { type HTMLAttributes, computed } from 'vue'
 import type { PolymorphicProps } from '../factory'
+import { usePresenceContext } from '../presence'
 
 export interface SelectContentBaseProps extends PolymorphicProps {}
 export interface SelectContentProps
@@ -17,10 +19,12 @@ import { useSelectContext } from './use-select-context'
 
 defineProps<SelectContentProps>()
 const select = useSelectContext()
+const presence = usePresenceContext()
+const mergedProps = computed(() => mergeProps(select.value.getContentProps(), presence.value.presenceProps))
 </script>
 
 <template>
-  <ark.div v-bind="select.getContentProps()" :as-child="asChild">
+  <ark.div v-if="!presence.unmounted" v-bind="mergedProps" :as-child="asChild">
     <slot />
   </ark.div>
 </template>

--- a/packages/vue/src/components/select/select-positioner.vue
+++ b/packages/vue/src/components/select/select-positioner.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
-import type { HTMLAttributes } from 'vue'
-import type { PolymorphicProps } from '../factory'
+import { type HTMLAttributes, computed } from 'vue'
+import { type PolymorphicProps, ark } from '../factory'
 
 export interface SelectPositionerBaseProps extends PolymorphicProps {}
 export interface SelectPositionerProps
@@ -13,21 +13,25 @@ export interface SelectPositionerProps
 
 <script setup lang="ts">
 import { useRenderStrategyProps } from '../../utils'
-import { Presence } from '../presence'
+import { PresenceProvider, usePresence } from '../presence'
 import { useSelectContext } from './use-select-context'
 
 defineProps<SelectPositionerProps>()
 const select = useSelectContext()
 const renderStrategy = useRenderStrategyProps()
+
+const presence = usePresence(
+  computed(() => ({
+    ...renderStrategy.value,
+    present: select.value.open,
+  })),
+)
+PresenceProvider(presence)
 </script>
 
 <template>
-  <Presence
-    v-bind="select.getPositionerProps()"
-    :present="select.open"
-    :lazy-mount="renderStrategy.lazyMount"
-    :unmount-on-exit="renderStrategy.unmountOnExit"
-  >
+  <ark.div v-if="!presence.unmounted" v-bind="select.getPositionerProps()" :as-child="asChild">
     <slot />
-  </Presence>
+  </ark.div>
 </template>
+

--- a/packages/vue/src/components/time-picker/time-picker-content.vue
+++ b/packages/vue/src/components/time-picker/time-picker-content.vue
@@ -1,6 +1,8 @@
 <script lang="ts">
-import type { HTMLAttributes } from 'vue'
+import { mergeProps } from '@zag-js/vue'
+import { type HTMLAttributes, computed } from 'vue'
 import type { PolymorphicProps } from '../factory'
+import { usePresenceContext } from '../presence'
 
 export interface TimePickerContentBaseProps extends PolymorphicProps {}
 export interface TimePickerContentProps
@@ -17,10 +19,12 @@ import { useTimePickerContext } from './use-time-picker-context'
 
 defineProps<TimePickerContentProps>()
 const timePicker = useTimePickerContext()
+const presence = usePresenceContext()
+const mergedProps = computed(() => mergeProps(timePicker.value.getContentProps(), presence.value.presenceProps))
 </script>
 
 <template>
-  <ark.div v-bind="timePicker.getContentProps()" :as-child="asChild">
+  <ark.div v-if="!presence.unmounted" v-bind="mergedProps" :as-child="asChild">
     <slot />
   </ark.div>
 </template>

--- a/packages/vue/src/components/time-picker/time-picker-positioner.vue
+++ b/packages/vue/src/components/time-picker/time-picker-positioner.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
-import type { HTMLAttributes } from 'vue'
-import type { PolymorphicProps } from '../factory'
+import { type HTMLAttributes, computed } from 'vue'
+import { type PolymorphicProps, ark } from '../factory'
 
 export interface TimePickerPositionerBaseProps extends PolymorphicProps {}
 export interface TimePickerPositionerProps
@@ -13,21 +13,25 @@ export interface TimePickerPositionerProps
 
 <script setup lang="ts">
 import { useRenderStrategyProps } from '../../utils'
-import { Presence } from '../presence'
+import { PresenceProvider, usePresence } from '../presence'
 import { useTimePickerContext } from './use-time-picker-context'
 
 defineProps<TimePickerPositionerProps>()
 const timePicker = useTimePickerContext()
 const renderStrategy = useRenderStrategyProps()
+
+const presence = usePresence(
+  computed(() => ({
+    ...renderStrategy.value,
+    present: timePicker.value.open,
+  })),
+)
+PresenceProvider(presence)
 </script>
 
 <template>
-  <Presence
-    v-bind="timePicker.getPositionerProps()"
-    :present="timePicker.open"
-    :lazy-mount="renderStrategy.lazyMount"
-    :unmount-on-exit="renderStrategy.unmountOnExit"
-  >
+  <ark.div v-if="!presence.unmounted" v-bind="timePicker.getPositionerProps()" :as-child="asChild">
     <slot />
-  </Presence>
+  </ark.div>
 </template>
+

--- a/packages/vue/src/components/tooltip/tests/tooltip.test.ts
+++ b/packages/vue/src/components/tooltip/tests/tooltip.test.ts
@@ -119,9 +119,9 @@ describe('Tooltip', () => {
     expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
 
     await user.hover(trigger)
-    expect(screen.getByRole('tooltip')).toBeVisible()
+    await waitFor(() => expect(screen.getByRole('tooltip')).toBeVisible())
 
     await user.unhover(trigger)
-    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+    await waitFor(() => expect(screen.queryByRole('tooltip')).not.toBeInTheDocument())
   })
 })

--- a/packages/vue/src/components/tooltip/tooltip-content.vue
+++ b/packages/vue/src/components/tooltip/tooltip-content.vue
@@ -1,6 +1,8 @@
 <script lang="ts">
-import type { HTMLAttributes } from 'vue'
+import { mergeProps } from '@zag-js/vue'
+import { type HTMLAttributes, computed } from 'vue'
 import type { PolymorphicProps } from '../factory'
+import { usePresenceContext } from '../presence'
 
 export interface TooltipContentBaseProps extends PolymorphicProps {}
 export interface TooltipContentProps
@@ -17,10 +19,12 @@ import { useTooltipContext } from './use-tooltip-context'
 
 defineProps<TooltipContentProps>()
 const tooltip = useTooltipContext()
+const presence = usePresenceContext()
+const mergedProps = computed(() => mergeProps(tooltip.value.getContentProps(), presence.value.presenceProps))
 </script>
 
 <template>
-  <ark.div v-bind="tooltip.getContentProps()" :as-child="asChild">
+  <ark.div v-bind="mergedProps" :as-child="asChild">
     <slot />
   </ark.div>
 </template>

--- a/packages/vue/src/components/tooltip/tooltip-content.vue
+++ b/packages/vue/src/components/tooltip/tooltip-content.vue
@@ -24,7 +24,7 @@ const mergedProps = computed(() => mergeProps(tooltip.value.getContentProps(), p
 </script>
 
 <template>
-  <ark.div v-bind="mergedProps" :as-child="asChild">
+  <ark.div v-if="!presence.unmounted" v-bind="mergedProps" :as-child="asChild">
     <slot />
   </ark.div>
 </template>

--- a/packages/vue/src/components/tooltip/tooltip-positioner.vue
+++ b/packages/vue/src/components/tooltip/tooltip-positioner.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
-import type { HTMLAttributes } from 'vue'
-import type { PolymorphicProps } from '../factory'
+import { type HTMLAttributes, computed } from 'vue'
+import { type PolymorphicProps, ark } from '../factory'
 
 export interface TooltipPositionerBaseProps extends PolymorphicProps {}
 export interface TooltipPositionerProps
@@ -13,21 +13,24 @@ export interface TooltipPositionerProps
 
 <script setup lang="ts">
 import { useRenderStrategyProps } from '../../utils'
-import { Presence } from '../presence'
+import { PresenceProvider, usePresence } from '../presence'
 import { useTooltipContext } from './use-tooltip-context'
 
 defineProps<TooltipPositionerProps>()
 const tooltip = useTooltipContext()
 const renderStrategy = useRenderStrategyProps()
+
+const presence = usePresence(
+  computed(() => ({
+    ...renderStrategy.value,
+    present: tooltip.value.open,
+  })),
+)
+PresenceProvider(presence)
 </script>
 
 <template>
-  <Presence
-    v-bind="tooltip.getPositionerProps()"
-    :present="tooltip.open"
-    :lazy-mount="renderStrategy.lazyMount"
-    :unmount-on-exit="renderStrategy.unmountOnExit"
-  >
+  <ark.div v-if="!presence.unmounted" v-bind="tooltip.getPositionerProps()" :as-child="asChild">
     <slot />
-  </Presence>
+  </ark.div>
 </template>


### PR DESCRIPTION
Resolves #2739.

As stated in the issue, any component with `Positioner` part has an issue with an exit animation, because `Presence` is used on the `Positioner` instead of a `Content`.

This PR fixes all of the related vue components. 

Code changes are made taking React implementation as an example and briefly tested in histoire stories. 