### PR TITLE
fix(solid): fix option value and disabled in hidden select

### DIFF
--- a/packages/solid/src/components/select/select-hidden-select.tsx
+++ b/packages/solid/src/components/select/select-hidden-select.tsx
@@ -21,8 +21,8 @@ export const SelectHiddenSelect = (props: SelectHiddenSelectProps) => {
       <Index each={select().collection.items}>
         {(item) => (
           <option
-            value={select().collection.getItemValue(item) ?? ''}
-            disabled={select().collection.getItemDisabled(item)}
+            value={select().collection.getItemValue(item()) ?? ''}
+            disabled={select().collection.getItemDisabled(item())}
           />
         )}
       </Index>


### PR DESCRIPTION
The item type of Index component is `() => T`, we should call it to access the value.

Related: #2665