### PR TITLE
docs: Update prop referenced in "Disable tag editing" section of TagsInput

### DIFF
--- a/website/src/content/pages/components/tags-input.mdx
+++ b/website/src/content/pages/components/tags-input.mdx
@@ -80,7 +80,7 @@ When a value is pasted, the component will:
 
 by default the tags can be edited by double-clicking on the tag or focusing on them and pressing
 
-<kbd>Enter</kbd>. To disable this behavior, pass `allowEditTag={false}`
+<kbd>Enter</kbd>. To disable this behavior, pass `editable={false}`
 
 <Example id="disabled-editing" />
 


### PR DESCRIPTION
The `TagsInput` docs refers to a prop called `allowEditTag` which is superseded by `editable`.