### PR TITLE
useField to respect FieldsetContext's invalid state

### DIFF
--- a/packages/react/src/components/field/use-field.ts
+++ b/packages/react/src/components/field/use-field.ts
@@ -47,7 +47,7 @@ export const useField = (props: UseFieldProps) => {
   const {
     ids,
     disabled = Boolean(fieldset?.disabled),
-    invalid = false,
+    invalid = Boolean(fieldset?.invalid),
     readOnly = false,
     required = false,
   } = props

--- a/packages/react/src/components/fieldset/fieldset.test.tsx
+++ b/packages/react/src/components/fieldset/fieldset.test.tsx
@@ -55,6 +55,11 @@ describe('Fieldset', () => {
     expect(screen.getByRole('textbox', { name: /label/i })).toBeDisabled()
   })
 
+  it('should light up textbox as invalid', async () => {
+    render(<ComponentUnderTest invalid />)
+    expect(screen.getByRole('textbox', { name: /label/i })).toHaveAttribute('data-invalid')
+  })
+
   it('should display helper text', async () => {
     render(<ComponentUnderTest />)
     expect(screen.getByText('Fieldset Helper Text')).toBeInTheDocument()


### PR DESCRIPTION
Makes field components respect FieldsetContext's invalid state, as [docs state](https://ark-ui.com/react/docs/components/fieldset#:~:text=most%20Ark%20UI%20components%20natively%20support%20these%20contexts).

See https://github.com/chakra-ui/ark/issues/2928 for more details.

Closes https://github.com/chakra-ui/ark/issues/2928