### PR TITLE
fix(docs): fix typo in hero for react plus button

### DIFF
--- a/website/src/components/marketing/hero.tsx
+++ b/website/src/components/marketing/hero.tsx
@@ -21,7 +21,7 @@ export const Hero = () => {
         <Stack gap={{ base: '8', md: '12' }} maxW="3xl">
           <Stack gap={{ base: '4', md: '6' }}>
             <Stack gap="4">
-              <NextLink href="/reat/plus">
+              <NextLink href="/react/plus">
                 <Badge size="lg" variant="outline">
                   <RocketIcon />
                   New: Launching Ark UI Plus


### PR DESCRIPTION
Fix a typo in the hero of the doc website where it stated `reat/plus` instead of `react/plus`.

(Guess this is my Hacktober PR 🫣)