### PR TITLE
Migrate components to use useId for stable Unique IDs and harmonize ID handling

### DIFF
--- a/packages/vue/src/components/accordion/use-accordion.ts
+++ b/packages/vue/src/components/accordion/use-accordion.ts
@@ -1,9 +1,9 @@
 import * as accordion from '@zag-js/accordion'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/vue'
-import { type ComputedRef, computed, useId } from 'vue'
+import { type ComputedRef, computed } from 'vue'
 import { DEFAULT_LOCALE, useEnvironmentContext, useLocaleContext } from '../../providers'
 import type { EmitFn, Optional } from '../../types'
-import { cleanProps } from '../../utils'
+import { cleanProps, useId } from '../../utils'
 import type { RootEmits } from './accordion.types'
 
 export interface UseAccordionProps
@@ -25,7 +25,7 @@ export const useAccordion = (
   props: UseAccordionProps = {},
   emit?: EmitFn<RootEmits>,
 ): UseAccordionReturn => {
-  const id = useId()
+  const id = useId(props.id)
   const env = useEnvironmentContext()
   const locale = useLocaleContext(DEFAULT_LOCALE)
 

--- a/packages/vue/src/components/avatar/use-avatar.ts
+++ b/packages/vue/src/components/avatar/use-avatar.ts
@@ -1,9 +1,9 @@
 import * as avatar from '@zag-js/avatar'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/vue'
-import { type ComputedRef, computed, useId } from 'vue'
+import { type ComputedRef, computed } from 'vue'
 import { DEFAULT_LOCALE, useEnvironmentContext, useLocaleContext } from '../../providers'
 import type { EmitFn, Optional } from '../../types'
-import { cleanProps } from '../../utils'
+import { cleanProps, useId } from '../../utils'
 import type { RootEmits } from './avatar.types'
 
 export interface UseAvatarProps
@@ -14,7 +14,7 @@ export const useAvatar = (
   props: UseAvatarProps = {},
   emit?: EmitFn<RootEmits>,
 ): UseAvatarReturn => {
-  const id = useId()
+  const id = useId(props.id)
   const env = useEnvironmentContext()
   const locale = useLocaleContext(DEFAULT_LOCALE)
 

--- a/packages/vue/src/components/carousel/use-carousel.ts
+++ b/packages/vue/src/components/carousel/use-carousel.ts
@@ -1,9 +1,9 @@
 import * as carousel from '@zag-js/carousel'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/vue'
-import { type ComputedRef, computed, useId } from 'vue'
+import { type ComputedRef, computed } from 'vue'
 import { DEFAULT_LOCALE, useEnvironmentContext, useLocaleContext } from '../../providers'
 import type { EmitFn, Optional } from '../../types'
-import { cleanProps } from '../../utils'
+import { cleanProps, useId } from '../../utils'
 import type { RootEmits } from './carousel.types'
 
 export interface UseCarouselProps
@@ -20,7 +20,7 @@ export const useCarousel = (
   props: UseCarouselProps = {},
   emit?: EmitFn<RootEmits>,
 ): UseCarouselReturn => {
-  const id = useId()
+  const id = useId(props.id)
   const env = useEnvironmentContext()
   const locale = useLocaleContext(DEFAULT_LOCALE)
   const context = computed<carousel.Context>(() => ({

--- a/packages/vue/src/components/checkbox/use-checkbox.ts
+++ b/packages/vue/src/components/checkbox/use-checkbox.ts
@@ -1,9 +1,9 @@
 import * as checkbox from '@zag-js/checkbox'
 import { type PropTypes, mergeProps, normalizeProps, useMachine } from '@zag-js/vue'
-import { type ComputedRef, computed, useId } from 'vue'
+import { type ComputedRef, computed } from 'vue'
 import { DEFAULT_LOCALE, useEnvironmentContext, useLocaleContext } from '../../providers'
 import type { EmitFn, Optional } from '../../types'
-import { cleanProps } from '../../utils'
+import { cleanProps, useId } from '../../utils'
 import { useFieldContext } from '../field'
 import type { RootEmits } from './checkbox'
 import { useCheckboxGroupContext } from './use-checkbox-group-context'
@@ -20,7 +20,7 @@ export interface UseCheckboxProps
 export interface UseCheckboxReturn extends ComputedRef<checkbox.Api<PropTypes>> {}
 
 export const useCheckbox = (ownProps: UseCheckboxProps = {}, emit?: EmitFn<RootEmits>) => {
-  const id = useId()
+  const id = useId(ownProps.id)
   const env = useEnvironmentContext()
   const locale = useLocaleContext(DEFAULT_LOCALE)
   const field = useFieldContext()

--- a/packages/vue/src/components/clipboard/use-clipboard.ts
+++ b/packages/vue/src/components/clipboard/use-clipboard.ts
@@ -1,9 +1,9 @@
 import * as clipboard from '@zag-js/clipboard'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/vue'
-import { type ComputedRef, computed, useId } from 'vue'
+import { type ComputedRef, computed } from 'vue'
 import { useEnvironmentContext } from '../../providers'
 import type { EmitFn, Optional } from '../../types'
-import { cleanProps } from '../../utils'
+import { cleanProps, useId } from '../../utils'
 import type { RootEmits } from './clipboard.types'
 
 export interface UseClipboardProps
@@ -14,7 +14,7 @@ export const useClipboard = (
   props: UseClipboardProps = {},
   emit?: EmitFn<RootEmits>,
 ): UseClipboardReturn => {
-  const id = useId()
+  const id = useId(props.id)
   const env = useEnvironmentContext()
   const context = computed<clipboard.Context>(() => ({
     id,

--- a/packages/vue/src/components/collapsible/use-collapsible.ts
+++ b/packages/vue/src/components/collapsible/use-collapsible.ts
@@ -1,9 +1,9 @@
 import * as collapsible from '@zag-js/collapsible'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/vue'
-import { type ComputedRef, computed, ref, useId, watch } from 'vue'
+import { type ComputedRef, computed, ref, watch } from 'vue'
 import { DEFAULT_LOCALE, useEnvironmentContext, useLocaleContext } from '../../providers'
 import type { EmitFn, Optional } from '../../types'
-import { cleanProps } from '../../utils'
+import { cleanProps, useId } from '../../utils'
 import type { RenderStrategyProps } from '../../utils/use-render-strategy'
 import type { RootEmits } from './collapsible.types'
 
@@ -34,7 +34,7 @@ export const useCollapsible = (
   props: UseCollapsibleProps = {},
   emits?: EmitFn<RootEmits>,
 ): UseCollapsibleReturn => {
-  const id = useId()
+  const id = useId(props.id)
   const env = useEnvironmentContext()
   const locale = useLocaleContext(DEFAULT_LOCALE)
 

--- a/packages/vue/src/components/color-picker/use-color-picker.ts
+++ b/packages/vue/src/components/color-picker/use-color-picker.ts
@@ -1,9 +1,9 @@
 import * as colorPicker from '@zag-js/color-picker'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/vue'
-import { type ComputedRef, computed, useId } from 'vue'
+import { type ComputedRef, computed } from 'vue'
 import { DEFAULT_LOCALE, useEnvironmentContext, useLocaleContext } from '../../providers'
 import type { EmitFn, Optional } from '../../types'
-import { cleanProps } from '../../utils'
+import { cleanProps, useId } from '../../utils'
 import { useFieldContext } from '../field'
 import type { RootEmits } from './color-picker.types'
 
@@ -32,7 +32,7 @@ export const useColorPicker = (
   props: UseColorPickerProps = {},
   emit?: EmitFn<RootEmits>,
 ): UseColorPickerReturn => {
-  const id = useId()
+  const id = useId(props.id)
   const env = useEnvironmentContext()
   const locale = useLocaleContext(DEFAULT_LOCALE)
   const field = useFieldContext()

--- a/packages/vue/src/components/combobox/use-combobox.ts
+++ b/packages/vue/src/components/combobox/use-combobox.ts
@@ -1,10 +1,10 @@
 import * as combobox from '@zag-js/combobox'
 import { omit } from '@zag-js/utils'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/vue'
-import { type ComputedRef, computed, useId, watch } from 'vue'
+import { type ComputedRef, computed, watch } from 'vue'
 import { DEFAULT_LOCALE, useEnvironmentContext, useLocaleContext } from '../../providers'
 import type { EmitFn, Optional } from '../../types'
-import { cleanProps } from '../../utils'
+import { cleanProps, useId } from '../../utils'
 import type { CollectionItem } from '../collection'
 import { useFieldContext } from '../field'
 import type { RootEmits } from './combobox'
@@ -34,7 +34,7 @@ export const useCombobox = <T extends CollectionItem>(
   props: UseComboboxProps<T>,
   emit?: EmitFn<RootEmits<T>>,
 ): UseComboboxReturn<T> => {
-  const id = useId()
+  const id = useId(props.id)
   const env = useEnvironmentContext()
   const locale = useLocaleContext(DEFAULT_LOCALE)
   const field = useFieldContext()

--- a/packages/vue/src/components/date-picker/use-date-picker.ts
+++ b/packages/vue/src/components/date-picker/use-date-picker.ts
@@ -1,9 +1,9 @@
 import * as datePicker from '@zag-js/date-picker'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/vue'
-import { type ComputedRef, computed, useId } from 'vue'
+import { type ComputedRef, computed } from 'vue'
 import { DEFAULT_LOCALE, useEnvironmentContext, useLocaleContext } from '../../providers'
 import type { EmitFn, Optional } from '../../types'
-import { cleanProps } from '../../utils'
+import { cleanProps, useId } from '../../utils'
 import type { RootEmits } from './date-picker.types'
 
 export interface UseDatePickerProps
@@ -33,7 +33,7 @@ export const useDatePicker = (
   props: UseDatePickerProps = {},
   emit?: EmitFn<RootEmits>,
 ): UseDatePickerReturn => {
-  const id = useId()
+  const id = useId(props.id)
   const env = useEnvironmentContext()
   const locale = useLocaleContext(DEFAULT_LOCALE)
   const context = computed<datePicker.Context>(() => {

--- a/packages/vue/src/components/dialog/use-dialog.ts
+++ b/packages/vue/src/components/dialog/use-dialog.ts
@@ -1,9 +1,9 @@
 import * as dialog from '@zag-js/dialog'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/vue'
-import { type ComputedRef, computed, useId } from 'vue'
+import { type ComputedRef, computed } from 'vue'
 import { DEFAULT_LOCALE, useEnvironmentContext, useLocaleContext } from '../../providers'
 import type { EmitFn, Optional } from '../../types'
-import { cleanProps } from '../../utils'
+import { cleanProps, useId } from '../../utils'
 import type { RootEmits } from './dialog'
 
 export interface UseDialogProps
@@ -18,7 +18,7 @@ export interface UseDialogProps
 export interface UseDialogReturn extends ComputedRef<dialog.Api<PropTypes>> {}
 
 export const useDialog = (props: UseDialogProps = {}, emit?: EmitFn<RootEmits>) => {
-  const id = useId()
+  const id = useId(props.id)
   const env = useEnvironmentContext()
   const locale = useLocaleContext(DEFAULT_LOCALE)
   const context = computed<dialog.Context>(() => ({

--- a/packages/vue/src/components/editable/use-editable.ts
+++ b/packages/vue/src/components/editable/use-editable.ts
@@ -1,9 +1,9 @@
 import * as editable from '@zag-js/editable'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/vue'
-import { type ComputedRef, computed, useId } from 'vue'
+import { type ComputedRef, computed } from 'vue'
 import { DEFAULT_LOCALE, useEnvironmentContext, useLocaleContext } from '../../providers'
 import type { EmitFn, Optional } from '../../types'
-import { cleanProps } from '../../utils'
+import { cleanProps, useId } from '../../utils'
 import { useFieldContext } from '../field'
 import type { RootEmits } from './editable'
 
@@ -31,7 +31,7 @@ export const useEditable = (
   props: UseEditableProps = {},
   emit?: EmitFn<RootEmits>,
 ): UseEditableReturn => {
-  const id = useId()
+  const id = useId(props.id)
   const env = useEnvironmentContext()
   const locale = useLocaleContext(DEFAULT_LOCALE)
   const field = useFieldContext()

--- a/packages/vue/src/components/field/use-field.ts
+++ b/packages/vue/src/components/field/use-field.ts
@@ -2,6 +2,7 @@ import { ariaAttr, dataAttr, getWindow } from '@zag-js/dom-query'
 import { type HTMLAttributes, computed, onBeforeUnmount, onMounted, reactive, ref } from 'vue'
 import { parts } from './field.anatomy'
 import type { ElementIds } from './field.types'
+import { useId } from '../../utils'
 
 export interface UseFieldProps {
   /**
@@ -40,7 +41,7 @@ export const useField = (props: UseFieldProps) => {
     hasHelperText: false,
   })
 
-  const id = props.id ?? `field-${Math.random().toString(36).substr(2, 9)}`
+  const id = useId(props.id)
   const rootRef = ref(null)
 
   const rootId = ids?.control ?? `field::${id}`

--- a/packages/vue/src/components/fieldset/use-fieldset.ts
+++ b/packages/vue/src/components/fieldset/use-fieldset.ts
@@ -7,9 +7,9 @@ import {
   onMounted,
   reactive,
   ref,
-  useId,
 } from 'vue'
 import { parts } from './fieldset.anatomy'
+import { useId } from '../../utils'
 
 export interface UseFieldsetProps {
   /**
@@ -35,7 +35,7 @@ export const useFieldset = (props: UseFieldsetProps) => {
     hasHelperText: false,
   })
 
-  const id = props.id ?? useId()
+  const id = useId(props.id)
   const rootRef = ref(null)
   const errorTextId = `fieldset::${id}::error-text`
   const helperTextId = `fieldset::${id}::helper-text`

--- a/packages/vue/src/components/file-upload/use-file-upload.ts
+++ b/packages/vue/src/components/file-upload/use-file-upload.ts
@@ -1,9 +1,9 @@
 import * as fileUpload from '@zag-js/file-upload'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/vue'
-import { type ComputedRef, computed, useId } from 'vue'
+import { type ComputedRef, computed } from 'vue'
 import { DEFAULT_LOCALE, useEnvironmentContext, useLocaleContext } from '../../providers'
 import type { EmitFn, Optional } from '../../types'
-import { cleanProps } from '../../utils'
+import { cleanProps, useId } from '../../utils'
 import { useFieldContext } from '../field'
 import type { RootEmits } from './file-upload'
 
@@ -16,7 +16,7 @@ export const useFileUpload = (
   props: UseFileUploadProps = {},
   emit?: EmitFn<RootEmits>,
 ): UseFileUploadReturn => {
-  const id = useId()
+  const id = useId(props.id)
   const env = useEnvironmentContext()
   const locale = useLocaleContext(DEFAULT_LOCALE)
   const field = useFieldContext()

--- a/packages/vue/src/components/hover-card/use-hover-card.ts
+++ b/packages/vue/src/components/hover-card/use-hover-card.ts
@@ -1,9 +1,9 @@
 import * as hoverCard from '@zag-js/hover-card'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/vue'
-import { type ComputedRef, computed, useId } from 'vue'
+import { type ComputedRef, computed } from 'vue'
 import { DEFAULT_LOCALE, useEnvironmentContext, useLocaleContext } from '../../providers'
 import type { EmitFn, Optional } from '../../types'
-import { cleanProps } from '../../utils'
+import { cleanProps, useId } from '../../utils'
 import type { RootEmits } from './hover-card.types'
 
 export interface UseHoverCardProps
@@ -20,7 +20,7 @@ export const useHoverCard = (
   props: UseHoverCardProps = {},
   emit?: EmitFn<RootEmits>,
 ): UseHoverCardReturn => {
-  const id = useId()
+  const id = useId(props.id)
   const env = useEnvironmentContext()
   const locale = useLocaleContext(DEFAULT_LOCALE)
   const context = computed<hoverCard.Context>(() => ({

--- a/packages/vue/src/components/menu/use-menu.ts
+++ b/packages/vue/src/components/menu/use-menu.ts
@@ -1,9 +1,9 @@
 import * as menu from '@zag-js/menu'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/vue'
-import { type ComputedRef, computed, useId } from 'vue'
+import { type ComputedRef, computed } from 'vue'
 import { DEFAULT_LOCALE, useEnvironmentContext, useLocaleContext } from '../../providers'
 import type { EmitFn, Optional } from '../../types'
-import { cleanProps } from '../../utils'
+import { cleanProps, useId } from '../../utils'
 import type { RootEmits } from './menu'
 
 export interface UseMenuProps
@@ -21,7 +21,7 @@ export interface UseMenuReturn {
 }
 
 export const useMenu = (props: UseMenuProps = {}, emit?: EmitFn<RootEmits>): UseMenuReturn => {
-  const id = useId()
+  const id = useId(props.id)
   const env = useEnvironmentContext()
   const locale = useLocaleContext(DEFAULT_LOCALE)
 

--- a/packages/vue/src/components/number-input/use-number-input.ts
+++ b/packages/vue/src/components/number-input/use-number-input.ts
@@ -1,9 +1,9 @@
 import * as numberInput from '@zag-js/number-input'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/vue'
-import { type ComputedRef, computed, useId } from 'vue'
+import { type ComputedRef, computed } from 'vue'
 import { DEFAULT_LOCALE, useEnvironmentContext, useLocaleContext } from '../../providers'
 import type { EmitFn, Optional } from '../../types'
-import { cleanProps } from '../../utils'
+import { cleanProps, useId } from '../../utils'
 import { useFieldContext } from '../field'
 import type { RootEmits } from './number-input.types'
 
@@ -22,7 +22,7 @@ export const useNumberInput = (
   props: UseNumberInputProps = {},
   emit?: EmitFn<RootEmits>,
 ): UseNumberInputReturn => {
-  const id = useId()
+  const id = useId(props.id)
   const env = useEnvironmentContext()
   const locale = useLocaleContext(DEFAULT_LOCALE)
   const field = useFieldContext()

--- a/packages/vue/src/components/pagination/use-pagination.ts
+++ b/packages/vue/src/components/pagination/use-pagination.ts
@@ -1,9 +1,9 @@
 import * as pagination from '@zag-js/pagination'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/vue'
-import { type ComputedRef, computed, useId } from 'vue'
+import { type ComputedRef, computed } from 'vue'
 import { DEFAULT_LOCALE, useEnvironmentContext, useLocaleContext } from '../../providers'
 import type { EmitFn, Optional } from '../../types'
-import { cleanProps } from '../../utils'
+import { cleanProps, useId } from '../../utils'
 import type { RootEmits } from './pagination'
 
 export interface UsePaginationProps
@@ -20,7 +20,7 @@ export const usePagination = (
   props: UsePaginationProps,
   emit?: EmitFn<RootEmits>,
 ): UsePaginationReturn => {
-  const id = useId()
+  const id = useId(props.id)
   const env = useEnvironmentContext()
   const locale = useLocaleContext(DEFAULT_LOCALE)
 

--- a/packages/vue/src/components/pin-input/use-pin-input.ts
+++ b/packages/vue/src/components/pin-input/use-pin-input.ts
@@ -1,9 +1,9 @@
 import * as pinInput from '@zag-js/pin-input'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/vue'
-import { type ComputedRef, computed, useId } from 'vue'
+import { type ComputedRef, computed } from 'vue'
 import { DEFAULT_LOCALE, useEnvironmentContext, useLocaleContext } from '../../providers'
 import type { EmitFn, Optional } from '../../types'
-import { cleanProps } from '../../utils'
+import { cleanProps, useId } from '../../utils'
 import { useFieldContext } from '../field'
 import type { RootEmits } from './pin-input'
 
@@ -20,7 +20,7 @@ export interface UsePinInputProps
 export interface UsePinInputReturn extends ComputedRef<pinInput.Api<PropTypes>> {}
 
 export const usePinInput = (props: UsePinInputProps = {}, emit?: EmitFn<RootEmits>) => {
-  const id = useId()
+  const id = useId(props.id)
   const env = useEnvironmentContext()
   const locale = useLocaleContext(DEFAULT_LOCALE)
   const field = useFieldContext()

--- a/packages/vue/src/components/popover/use-popover.ts
+++ b/packages/vue/src/components/popover/use-popover.ts
@@ -1,9 +1,9 @@
 import * as popover from '@zag-js/popover'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/vue'
-import { type ComputedRef, computed, useId } from 'vue'
+import { type ComputedRef, computed } from 'vue'
 import { DEFAULT_LOCALE, useEnvironmentContext, useLocaleContext } from '../../providers'
 import type { EmitFn, Optional } from '../../types'
-import { cleanProps } from '../../utils'
+import { cleanProps, useId } from '../../utils'
 import type { RootEmits } from './popover.types'
 
 export interface UsePopoverProps
@@ -18,7 +18,7 @@ export interface UsePopoverProps
 export interface UsePopoverReturn extends ComputedRef<popover.Api<PropTypes>> {}
 
 export const usePopover = (props: UsePopoverProps = {}, emit?: EmitFn<RootEmits>) => {
-  const id = useId()
+  const id = useId(props.id)
   const env = useEnvironmentContext()
   const locale = useLocaleContext(DEFAULT_LOCALE)
 

--- a/packages/vue/src/components/progress/use-progress.ts
+++ b/packages/vue/src/components/progress/use-progress.ts
@@ -1,16 +1,16 @@
 import * as progress from '@zag-js/progress'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/vue'
-import { type ComputedRef, computed, useId } from 'vue'
+import { type ComputedRef, computed } from 'vue'
 import { DEFAULT_LOCALE, useEnvironmentContext, useLocaleContext } from '../../providers'
 import type { Optional } from '../../types'
-import { cleanProps } from '../../utils'
+import { cleanProps, useId } from '../../utils'
 
 export interface UseProgressProps
   extends Optional<Omit<progress.Context, 'dir' | 'getRootNode'>, 'id'> {}
 export interface UseProgressReturn extends ComputedRef<progress.Api<PropTypes>> {}
 
 export const useProgress = (props: UseProgressProps = {}): UseProgressReturn => {
-  const id = useId()
+  const id = useId(props.id)
   const env = useEnvironmentContext()
   const locale = useLocaleContext(DEFAULT_LOCALE)
 

--- a/packages/vue/src/components/qr-code/use-qr-code.ts
+++ b/packages/vue/src/components/qr-code/use-qr-code.ts
@@ -1,16 +1,16 @@
 import * as qrcode from '@zag-js/qr-code'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/vue'
-import { type ComputedRef, computed, useId } from 'vue'
+import { type ComputedRef, computed } from 'vue'
 import { DEFAULT_LOCALE, useEnvironmentContext, useLocaleContext } from '../../providers'
 import type { Optional } from '../../types'
-import { cleanProps } from '../../utils'
+import { cleanProps, useId } from '../../utils'
 
 export interface UseQrCodeProps
   extends Optional<Omit<qrcode.Context, 'dir' | 'getRootNode'>, 'id'> {}
 export interface UseQrCodeReturn extends ComputedRef<qrcode.Api<PropTypes>> {}
 
 export const useQrCode = (props: UseQrCodeProps = {}): UseQrCodeReturn => {
-  const id = useId()
+  const id = useId(props.id)
   const env = useEnvironmentContext()
   const locale = useLocaleContext(DEFAULT_LOCALE)
 

--- a/packages/vue/src/components/radio-group/use-radio-group.ts
+++ b/packages/vue/src/components/radio-group/use-radio-group.ts
@@ -1,9 +1,9 @@
 import * as radioGroup from '@zag-js/radio-group'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/vue'
-import { type ComputedRef, computed, useId } from 'vue'
+import { type ComputedRef, computed } from 'vue'
 import { DEFAULT_LOCALE, useEnvironmentContext, useLocaleContext } from '../../providers'
 import type { EmitFn, Optional } from '../../types'
-import { cleanProps } from '../../utils'
+import { cleanProps, useId } from '../../utils'
 import type { RootEmits } from './radio-group.types'
 
 export interface UseRadioGroupProps
@@ -21,7 +21,7 @@ export const useRadioGroup = (
   props: UseRadioGroupProps = {},
   emit?: EmitFn<RootEmits>,
 ): UseRadioGroupReturn => {
-  const id = useId()
+  const id = useId(props.id)
   const env = useEnvironmentContext()
   const locale = useLocaleContext(DEFAULT_LOCALE)
   const context = computed<radioGroup.Context>(() => ({

--- a/packages/vue/src/components/rating-group/use-rating-group.ts
+++ b/packages/vue/src/components/rating-group/use-rating-group.ts
@@ -1,9 +1,9 @@
 import * as ratingGroup from '@zag-js/rating-group'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/vue'
-import { type ComputedRef, computed, useId } from 'vue'
+import { type ComputedRef, computed } from 'vue'
 import { DEFAULT_LOCALE, useEnvironmentContext, useLocaleContext } from '../../providers'
 import type { EmitFn, Optional } from '../../types'
-import { cleanProps } from '../../utils'
+import { cleanProps, useId } from '../../utils'
 import { useFieldContext } from '../field'
 import type { RootEmits } from './rating-group'
 
@@ -23,7 +23,7 @@ export const useRatingGroup = (
   props: UseRatingGroupProps = {},
   emit?: EmitFn<RootEmits>,
 ): UseRatingGroupReturn => {
-  const id = useId()
+  const id = useId(props.id)
   const env = useEnvironmentContext()
   const locale = useLocaleContext(DEFAULT_LOCALE)
   const field = useFieldContext()

--- a/packages/vue/src/components/segment-group/use-segment-group.ts
+++ b/packages/vue/src/components/segment-group/use-segment-group.ts
@@ -1,9 +1,9 @@
 import * as segmentGroup from '@zag-js/radio-group'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/vue'
-import { type ComputedRef, computed, useId } from 'vue'
+import { type ComputedRef, computed } from 'vue'
 import { DEFAULT_LOCALE, useEnvironmentContext, useLocaleContext } from '../../providers'
 import type { EmitFn, Optional } from '../../types'
-import { cleanProps } from '../../utils'
+import { cleanProps, useId } from '../../utils'
 import type { RootEmits } from './segment-group.types'
 
 export interface UseSegmentGroupProps
@@ -22,7 +22,7 @@ export const useSegmentGroup = (
   props: UseSegmentGroupProps = {},
   emit?: EmitFn<RootEmits>,
 ): UseSegmentGroupReturn => {
-  const id = useId()
+  const id = useId(props.id)
   const env = useEnvironmentContext()
   const locale = useLocaleContext(DEFAULT_LOCALE)
 

--- a/packages/vue/src/components/select/use-select.ts
+++ b/packages/vue/src/components/select/use-select.ts
@@ -1,10 +1,10 @@
 import * as select from '@zag-js/select'
 import { omit } from '@zag-js/utils'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/vue'
-import { type ComputedRef, computed, useId, watch } from 'vue'
+import { type ComputedRef, computed, watch } from 'vue'
 import { DEFAULT_LOCALE, useEnvironmentContext, useLocaleContext } from '../../providers'
 import type { EmitFn, Optional } from '../../types'
-import { cleanProps } from '../../utils'
+import { cleanProps, useId } from '../../utils'
 import type { CollectionItem, ListCollection } from '../collection'
 import { useFieldContext } from '../field'
 import type { RootEmits } from './select'
@@ -38,7 +38,7 @@ export const useSelect = <T extends CollectionItem>(
   props: UseSelectProps<T>,
   emit?: EmitFn<RootEmits<T>>,
 ): UseSelectReturn<T> => {
-  const id = useId()
+  const id = useId(props.id)
   const env = useEnvironmentContext()
   const locale = useLocaleContext(DEFAULT_LOCALE)
   const field = useFieldContext()

--- a/packages/vue/src/components/signature-pad/use-signature-pad.ts
+++ b/packages/vue/src/components/signature-pad/use-signature-pad.ts
@@ -1,9 +1,9 @@
 import * as signaturepad from '@zag-js/signature-pad'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/vue'
-import { type ComputedRef, computed, useId } from 'vue'
+import { type ComputedRef, computed } from 'vue'
 import { DEFAULT_LOCALE, useEnvironmentContext, useLocaleContext } from '../../providers'
 import type { EmitFn, Optional } from '../../types'
-import { cleanProps } from '../../utils'
+import { cleanProps, useId } from '../../utils'
 import { useFieldContext } from '../field'
 import type { RootEmits } from './signature-pad.types'
 
@@ -15,7 +15,7 @@ export const useSignaturePad = (
   props: UseSignaturePadProps = {},
   emit?: EmitFn<RootEmits>,
 ): UseSignaturePadReturn => {
-  const id = useId()
+  const id = useId(props.id)
   const env = useEnvironmentContext()
   const locale = useLocaleContext(DEFAULT_LOCALE)
   const field = useFieldContext()

--- a/packages/vue/src/components/slider/use-slider.ts
+++ b/packages/vue/src/components/slider/use-slider.ts
@@ -1,9 +1,9 @@
 import * as slider from '@zag-js/slider'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/vue'
-import { type ComputedRef, computed, useId } from 'vue'
+import { type ComputedRef, computed } from 'vue'
 import { DEFAULT_LOCALE, useEnvironmentContext, useLocaleContext } from '../../providers'
 import type { EmitFn, Optional } from '../../types'
-import { cleanProps } from '../../utils'
+import { cleanProps, useId } from '../../utils'
 import type { RootEmits } from './slider'
 
 export interface UseSliderProps
@@ -21,7 +21,7 @@ export const useSlider = (
   props: UseSliderProps = {},
   emit?: EmitFn<RootEmits>,
 ): UseSliderReturn => {
-  const id = useId()
+  const id = useId(props.id)
   const env = useEnvironmentContext()
   const locale = useLocaleContext(DEFAULT_LOCALE)
   const context = computed<slider.Context>(() => ({

--- a/packages/vue/src/components/splitter/use-splitter.ts
+++ b/packages/vue/src/components/splitter/use-splitter.ts
@@ -1,9 +1,9 @@
 import * as splitter from '@zag-js/splitter'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/vue'
-import { type ComputedRef, computed, useId } from 'vue'
+import { type ComputedRef, computed } from 'vue'
 import { DEFAULT_LOCALE, useEnvironmentContext, useLocaleContext } from '../../providers'
 import type { EmitFn, Optional } from '../../types'
-import { cleanProps } from '../../utils'
+import { cleanProps, useId } from '../../utils'
 import type { RootEmits } from './splitter.types'
 
 export interface UseSplitterProps
@@ -21,7 +21,7 @@ export const useSplitter = (
   props: UseSplitterProps = {},
   emit?: EmitFn<RootEmits>,
 ): UseSplitterReturn => {
-  const id = useId()
+  const id = useId(props.id)
   const env = useEnvironmentContext()
   const locale = useLocaleContext(DEFAULT_LOCALE)
 

--- a/packages/vue/src/components/steps/use-steps.ts
+++ b/packages/vue/src/components/steps/use-steps.ts
@@ -1,9 +1,9 @@
 import * as steps from '@zag-js/steps'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/vue'
-import { type ComputedRef, computed, useId } from 'vue'
+import { type ComputedRef, computed } from 'vue'
 import { DEFAULT_LOCALE, useEnvironmentContext, useLocaleContext } from '../../providers'
 import type { EmitFn, Optional } from '../../types'
-import { cleanProps } from '../../utils'
+import { cleanProps, useId } from '../../utils'
 import type { RootEmits } from './steps.types'
 
 export interface UseStepsProps
@@ -21,9 +21,9 @@ export interface UseStepsProps
 export interface UseStepsReturn extends ComputedRef<steps.Api<PropTypes>> {}
 
 export function useSteps(props: UseStepsProps = {}, emit?: EmitFn<RootEmits>): UseStepsReturn {
+  const id = useId(props.id)
   const env = useEnvironmentContext()
   const locale = useLocaleContext(DEFAULT_LOCALE)
-  const id = useId()
 
   const context = computed<steps.Context>(() => ({
     id,

--- a/packages/vue/src/components/switch/use-switch.ts
+++ b/packages/vue/src/components/switch/use-switch.ts
@@ -1,9 +1,9 @@
 import * as zagSwitch from '@zag-js/switch'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/vue'
-import { type ComputedRef, computed, useId } from 'vue'
+import { type ComputedRef, computed } from 'vue'
 import { DEFAULT_LOCALE, useEnvironmentContext, useLocaleContext } from '../../providers'
 import type { EmitFn, Optional } from '../../types'
-import { cleanProps } from '../../utils'
+import { cleanProps, useId } from '../../utils'
 import { useFieldContext } from '../field'
 import type { RootEmits } from './switch'
 
@@ -22,7 +22,7 @@ export const useSwitch = (
   props: UseSwitchProps = {},
   emit?: EmitFn<RootEmits>,
 ): UseSwitchReturn => {
-  const id = useId()
+  const id = useId(props.id)
   const env = useEnvironmentContext()
   const locale = useLocaleContext(DEFAULT_LOCALE)
   const field = useFieldContext()

--- a/packages/vue/src/components/tabs/use-tabs.ts
+++ b/packages/vue/src/components/tabs/use-tabs.ts
@@ -1,9 +1,9 @@
 import * as tabs from '@zag-js/tabs'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/vue'
-import { type ComputedRef, computed, useId } from 'vue'
+import { type ComputedRef, computed } from 'vue'
 import { DEFAULT_LOCALE, useEnvironmentContext, useLocaleContext } from '../../providers'
 import type { EmitFn, Optional } from '../../types'
-import { cleanProps } from '../../utils'
+import { cleanProps, useId } from '../../utils'
 import type { RootEmits } from './tabs.types'
 
 export interface UseTabsProps
@@ -18,7 +18,7 @@ export interface UseTabsProps
 export interface UseTabsReturn extends ComputedRef<tabs.Api<PropTypes>> {}
 
 export const useTabs = (props: UseTabsProps = {}, emit?: EmitFn<RootEmits>): UseTabsReturn => {
-  const id = useId()
+  const id = useId(props.id)
   const env = useEnvironmentContext()
   const locale = useLocaleContext(DEFAULT_LOCALE)
 

--- a/packages/vue/src/components/tags-input/use-tags-input.ts
+++ b/packages/vue/src/components/tags-input/use-tags-input.ts
@@ -1,9 +1,9 @@
 import * as tagsInput from '@zag-js/tags-input'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/vue'
-import { type ComputedRef, computed, useId } from 'vue'
+import { type ComputedRef, computed } from 'vue'
 import { DEFAULT_LOCALE, useEnvironmentContext, useLocaleContext } from '../../providers'
 import type { EmitFn, Optional } from '../../types'
-import { cleanProps } from '../../utils'
+import { cleanProps, useId } from '../../utils'
 import { useFieldContext } from '../field'
 import type { RootEmits } from './tags-input.types'
 
@@ -22,7 +22,7 @@ export const useTagsInput = (
   props: UseTagsInputProps = {},
   emit?: EmitFn<RootEmits>,
 ): UseTagsInputReturn => {
-  const id = useId()
+  const id = useId(props.id)
   const env = useEnvironmentContext()
   const locale = useLocaleContext(DEFAULT_LOCALE)
   const field = useFieldContext()

--- a/packages/vue/src/components/time-picker/use-time-picker.ts
+++ b/packages/vue/src/components/time-picker/use-time-picker.ts
@@ -1,9 +1,9 @@
 import * as timePicker from '@zag-js/time-picker'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/vue'
-import { type ComputedRef, computed, useId } from 'vue'
+import { type ComputedRef, computed } from 'vue'
 import { DEFAULT_LOCALE, useEnvironmentContext, useLocaleContext } from '../../providers'
 import type { EmitFn, Optional } from '../../types'
-import { cleanProps } from '../../utils'
+import { cleanProps, useId } from '../../utils'
 import type { RootEmits } from './time-picker.types'
 
 export interface UseTimePickerProps
@@ -34,7 +34,7 @@ export const useTimePicker = (
   props: UseTimePickerProps = {},
   emit?: EmitFn<RootEmits>,
 ): UseTimePickerReturn => {
-  const id = useId()
+  const id = useId(props.id)
   const env = useEnvironmentContext()
   const locale = useLocaleContext(DEFAULT_LOCALE)
 

--- a/packages/vue/src/components/timer/use-timer.ts
+++ b/packages/vue/src/components/timer/use-timer.ts
@@ -1,9 +1,9 @@
 import * as timer from '@zag-js/timer'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/vue'
-import { type ComputedRef, computed, useId } from 'vue'
+import { type ComputedRef, computed } from 'vue'
 import { useEnvironmentContext } from '../../providers'
 import type { EmitFn, Optional } from '../../types'
-import { cleanProps } from '../../utils'
+import { cleanProps, useId } from '../../utils'
 import type { RootEmits } from './timer.types'
 
 export interface UseTimerProps extends Optional<Omit<timer.Context, 'dir' | 'getRootNode'>, 'id'> {}
@@ -11,7 +11,7 @@ export interface UseTimerProps extends Optional<Omit<timer.Context, 'dir' | 'get
 export interface UseTimerReturn extends ComputedRef<timer.Api<PropTypes>> {}
 
 export const useTimer = (props: UseTimerProps, emit?: EmitFn<RootEmits>): UseTimerReturn => {
-  const id = useId()
+  const id = useId(props.id)
   const env = useEnvironmentContext()
 
   const context = computed<timer.Context>(() => ({

--- a/packages/vue/src/components/toggle-group/use-toggle-group.ts
+++ b/packages/vue/src/components/toggle-group/use-toggle-group.ts
@@ -1,9 +1,9 @@
 import * as toggleGroup from '@zag-js/toggle-group'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/vue'
-import { type ComputedRef, computed, useId } from 'vue'
+import { type ComputedRef, computed } from 'vue'
 import { DEFAULT_LOCALE, useEnvironmentContext, useLocaleContext } from '../../providers'
 import type { EmitFn, Optional } from '../../types'
-import { cleanProps } from '../../utils'
+import { cleanProps, useId } from '../../utils'
 import type { RootEmits } from './toggle-group'
 
 export interface UseToggleGroupProps
@@ -22,7 +22,7 @@ export const useToggleGroup = (
   props: UseToggleGroupProps = {},
   emit?: EmitFn<RootEmits>,
 ): UseToggleGroupReturn => {
-  const id = useId()
+  const id = useId(props.id)
   const env = useEnvironmentContext()
   const locale = useLocaleContext(DEFAULT_LOCALE)
 

--- a/packages/vue/src/components/tooltip/use-tooltip.ts
+++ b/packages/vue/src/components/tooltip/use-tooltip.ts
@@ -1,9 +1,9 @@
 import * as tooltip from '@zag-js/tooltip'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/vue'
-import { type ComputedRef, computed, useId } from 'vue'
+import { type ComputedRef, computed } from 'vue'
 import { DEFAULT_LOCALE, useEnvironmentContext, useLocaleContext } from '../../providers'
 import type { EmitFn, Optional } from '../../types'
-import { cleanProps } from '../../utils'
+import { cleanProps, useId } from '../../utils'
 import type { RootEmits } from './tooltip.types'
 
 export interface UseTooltipProps
@@ -21,7 +21,7 @@ export const useTooltip = (
   props: UseTooltipProps = {},
   emit?: EmitFn<RootEmits>,
 ): UseTooltipReturn => {
-  const id = useId()
+  const id = useId(props.id)
   const env = useEnvironmentContext()
   const locale = useLocaleContext(DEFAULT_LOCALE)
 

--- a/packages/vue/src/components/tree-view/use-tree-view.ts
+++ b/packages/vue/src/components/tree-view/use-tree-view.ts
@@ -1,9 +1,9 @@
 import * as treeView from '@zag-js/tree-view'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/vue'
-import { type ComputedRef, computed, useId } from 'vue'
+import { type ComputedRef, computed } from 'vue'
 import { DEFAULT_LOCALE, useEnvironmentContext, useLocaleContext } from '../../providers'
 import type { EmitFn, Optional } from '../../types'
-import { cleanProps } from '../../utils'
+import { cleanProps, useId } from '../../utils'
 import type { TreeCollection, TreeNode } from '../collection'
 import type { RootEmits } from './tree-view.types'
 
@@ -32,7 +32,7 @@ export const useTreeView = <T extends TreeNode>(
   props: UseTreeViewProps<T>,
   emit?: EmitFn<RootEmits>,
 ): UseTreeViewReturn<T> => {
-  const id = useId()
+  const id = useId(props.id)
   const env = useEnvironmentContext()
   const locale = useLocaleContext(DEFAULT_LOCALE)
 

--- a/packages/vue/src/utils/index.ts
+++ b/packages/vue/src/utils/index.ts
@@ -1,4 +1,5 @@
 export { cleanProps } from './clean-props'
+export { useId } from './use-id'
 export { createContext } from './create-context'
 export { runIfFn } from './run-if-fn'
 export { useEmitAsProps } from './use-emits-as-props'

--- a/packages/vue/src/utils/use-id.ts
+++ b/packages/vue/src/utils/use-id.ts
@@ -1,0 +1,5 @@
+import { useId as vueUseId } from 'vue'
+
+export function useId(id?: string) {
+	return id ?? vueUseId()
+}


### PR DESCRIPTION
Hey there! 👋🏻 

This PR updates the components to consistently use the `useId` composable introduced in Vue 3.5 for generating stable unique IDs. This ensures IDs remain consistent across both server-side and client-side renders, preventing hydration issues caused by mismatched IDs. Additionally, the PR harmonizes the handling of IDs across components by ensuring that any ID passed as a prop is properly respected, addressing the current behavior where the `useId` helper disregarded the given prop in some cases.

Closes https://github.com/chakra-ui/ark/issues/3154