### PR TITLE
Remove unnecessary "1" in useSelectContext

### DIFF
--- a/packages/vue/src/components/select/use-select-context.ts
+++ b/packages/vue/src/components/select/use-select-context.ts
@@ -6,4 +6,3 @@ export interface UseSelectContext<T extends CollectionItem> extends UseSelectRet
 
 export const [SelectProvider, useSelectContext] =
   createContext<UseSelectContext<CollectionItem>>('SelectContext')
-1


### PR DESCRIPTION
Hey there! 👋🏻 

This PR removes an unnecessary random "1" that was present in the `useSelectContext`. This character does not serve any purpose and should not be in the code.