### PR TITLE
Fix: Disable the formatter in biome

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -21,5 +21,8 @@
         "noLabelWithoutControl": "off"
       }
     }
+  },
+  "formatter": {
+    "enabled": false
   }
 }


### PR DESCRIPTION
**Issue:**
When committing the code, it got formatted differently than the prettier config does in the IDE.

**Cause:**
In the `lefthook.yml` config file, we have two steps, format and lint. In the format step, prettier is used to format the code.
In the lint step, biome is used to check for linting errors, biome does also have a formatter. Which does format the code and overwrites the changes prettier did in the format step.

**Fix:**
Fixed this by disabling the formatter in Biome.js to not conflict with prettier.
```json
"formatter": {
  "enabled": false
}
```

**Question:**

Do we want to run `format` and `lint` now on the whole repo to align everything? If I do, I do have 81 file changes