### PR TITLE
feat(llms): implement LLMs.txt support and related routes

### DIFF
--- a/website/src/app/(llms)/llms-full.txt/route.ts
+++ b/website/src/app/(llms)/llms-full.txt/route.ts
@@ -1,0 +1,30 @@
+import { cleanupPageContent } from '~/app/(llms)/shared'
+import { frameworks } from '~/app/sitemap'
+import { categories, getSidebarGroups } from '~/lib/sidebar'
+import type { Pages } from '.velite'
+
+export const dynamic = 'force-static'
+
+const generatePageContent = async (page: Pages) =>
+  (
+    await Promise.all(
+      frameworks.map(async (framework) => {
+        return `# ${page.title} (${framework.toUpperCase()})\n\n${await cleanupPageContent(page, framework)}\n\n`
+      }),
+    )
+  ).join('\n')
+
+const generateCategorySection = async (category: string, pages: Pages[]) => {
+  const header = `# ${category.toUpperCase()}\n\n---\n`
+  const pagesContent = await Promise.all(pages.map(generatePageContent))
+  return `${header}\n${pagesContent.join('\n')}`
+}
+
+export const GET = async () => {
+  const sidebarGroups = getSidebarGroups()
+  const content = await Promise.all(
+    categories.map((category, index) => generateCategorySection(category, sidebarGroups[index])),
+  ).then((sections) => sections.join('\n\n'))
+
+  return new Response(content)
+}

--- a/website/src/app/(llms)/llms-react.txt/route.ts
+++ b/website/src/app/(llms)/llms-react.txt/route.ts
@@ -1,0 +1,23 @@
+import { cleanupPageContent } from '~/app/(llms)/shared'
+import { frameworks } from '~/app/sitemap'
+import { categories, getSidebarGroups } from '~/lib/sidebar'
+import type { Pages } from '.velite'
+
+export const dynamic = 'force-static'
+
+const generatePageContent = async (page: Pages) => `# ${page.title}\n\n${await cleanupPageContent(page, 'react')}\n\n`
+
+const generateCategorySection = async (category: string, pages: Pages[]) => {
+  const header = `# ${category.toUpperCase()}\n\n---\n`
+  const pagesContent = await Promise.all(pages.map(generatePageContent))
+  return `${header}\n${pagesContent.join('\n')}`
+}
+
+export const GET = async () => {
+  const sidebarGroups = getSidebarGroups()
+  const content = await Promise.all(
+    categories.map((category, index) => generateCategorySection(category, sidebarGroups[index])),
+  ).then((sections) => sections.join('\n\n'))
+
+  return new Response(content)
+}

--- a/website/src/app/(llms)/llms-solid.txt/route.ts
+++ b/website/src/app/(llms)/llms-solid.txt/route.ts
@@ -1,0 +1,23 @@
+import { cleanupPageContent } from '~/app/(llms)/shared'
+import { frameworks } from '~/app/sitemap'
+import { categories, getSidebarGroups } from '~/lib/sidebar'
+import type { Pages } from '.velite'
+
+export const dynamic = 'force-static'
+
+const generatePageContent = async (page: Pages) => `# ${page.title}\n\n${await cleanupPageContent(page, 'solid')}\n\n`
+
+const generateCategorySection = async (category: string, pages: Pages[]) => {
+  const header = `# ${category.toUpperCase()}\n\n---\n`
+  const pagesContent = await Promise.all(pages.map(generatePageContent))
+  return `${header}\n${pagesContent.join('\n')}`
+}
+
+export const GET = async () => {
+  const sidebarGroups = getSidebarGroups()
+  const content = await Promise.all(
+    categories.map((category, index) => generateCategorySection(category, sidebarGroups[index])),
+  ).then((sections) => sections.join('\n\n'))
+
+  return new Response(content)
+}

--- a/website/src/app/(llms)/llms-svelte.txt/route.ts
+++ b/website/src/app/(llms)/llms-svelte.txt/route.ts
@@ -1,0 +1,23 @@
+import { cleanupPageContent } from '~/app/(llms)/shared'
+import { frameworks } from '~/app/sitemap'
+import { categories, getSidebarGroups } from '~/lib/sidebar'
+import type { Pages } from '.velite'
+
+export const dynamic = 'force-static'
+
+const generatePageContent = async (page: Pages) => `# ${page.title}\n\n${await cleanupPageContent(page, 'svelte')}\n\n`
+
+const generateCategorySection = async (category: string, pages: Pages[]) => {
+  const header = `# ${category.toUpperCase()}\n\n---\n`
+  const pagesContent = await Promise.all(pages.map(generatePageContent))
+  return `${header}\n${pagesContent.join('\n')}`
+}
+
+export const GET = async () => {
+  const sidebarGroups = getSidebarGroups()
+  const content = await Promise.all(
+    categories.map((category, index) => generateCategorySection(category, sidebarGroups[index])),
+  ).then((sections) => sections.join('\n\n'))
+
+  return new Response(content)
+}

--- a/website/src/app/(llms)/llms-vue.txt/route.ts
+++ b/website/src/app/(llms)/llms-vue.txt/route.ts
@@ -1,0 +1,23 @@
+import { cleanupPageContent } from '~/app/(llms)/shared'
+import { frameworks } from '~/app/sitemap'
+import { categories, getSidebarGroups } from '~/lib/sidebar'
+import type { Pages } from '.velite'
+
+export const dynamic = 'force-static'
+
+const generatePageContent = async (page: Pages) => `# ${page.title}\n\n${await cleanupPageContent(page, 'vue')}\n\n`
+
+const generateCategorySection = async (category: string, pages: Pages[]) => {
+  const header = `# ${category.toUpperCase()}\n\n---\n`
+  const pagesContent = await Promise.all(pages.map(generatePageContent))
+  return `${header}\n${pagesContent.join('\n')}`
+}
+
+export const GET = async () => {
+  const sidebarGroups = getSidebarGroups()
+  const content = await Promise.all(
+    categories.map((category, index) => generateCategorySection(category, sidebarGroups[index])),
+  ).then((sections) => sections.join('\n\n'))
+
+  return new Response(content)
+}

--- a/website/src/app/(llms)/llms.txt/route.ts
+++ b/website/src/app/(llms)/llms.txt/route.ts
@@ -1,0 +1,25 @@
+import { frameworks } from '~/app/sitemap'
+import { categories, getSidebarGroups } from '~/lib/sidebar'
+
+export const dynamic = 'force-static'
+
+export const GET = async () => {
+  const sidebarGroups = getSidebarGroups()
+
+  const generateUrl = (framework: string, slug: string) => `https://ark-ui.com/${framework}/docs/${slug}`
+
+  const generatePageLinks = (page: { title: string; slug: string }) =>
+    frameworks.map((framework) => `- [${page.title}](${generateUrl(framework, page.slug)})`).join('\n')
+
+  const generateCategorySection = (category: string, pages: (typeof sidebarGroups)[number]) => {
+    const header = `# ${category.toUpperCase()}\n`
+    const pageLinks = pages.map(generatePageLinks).join('\n')
+    return `${header}\n${pageLinks}`
+  }
+
+  const content = categories
+    .map((category, index) => generateCategorySection(category, sidebarGroups[index]))
+    .join('\n\n')
+
+  return new Response(content)
+}

--- a/website/src/app/(llms)/shared.ts
+++ b/website/src/app/(llms)/shared.ts
@@ -1,0 +1,150 @@
+import { type AccessibilityDocKey, type DataAttrDocKey, getAccessibilityDoc, getDataAttrDoc } from '@zag-js/docs'
+import { frameworkExample } from '~/components/example'
+import { cmdMap } from '~/components/install-cmd'
+import type { Pages } from '.velite'
+import { types } from '.velite'
+
+// Constants for regex patterns
+const PATTERNS = {
+  EXAMPLE: /<Example\s+(?:(?:id="[^"]*"|component="[^"]*")\s*)+\s*\/>/g,
+  EXAMPLE_ID: /id="([^"]*)"/,
+  EXAMPLE_COMPONENT: /component="([^"]*)"/,
+  ANATOMY: /<Anatomy\s+id="[^"]*"\s*\/>/g,
+  COMPONENT_PREVIEW: /<ComponentPreview\s+id="[^"]*"\s*\/>/g,
+  FAQ: /## FAQ\s*<Faq\s*\/>/g,
+  IMAGES: /\/images/g,
+} as const
+
+// Quick links and templates
+const TEMPLATES = {
+  NEXTJS: 'https://stackblitz.com/edit/github-qcm2dskf',
+  SOLID: 'https://stackblitz.com/edit/github-1hgkbbln',
+  NUXT: 'https://stackblitz.com/edit/github-s3sg6syq',
+} as const
+
+// Component replacement functions
+const replaceQuickstart = () =>
+  [
+    `- [Next.js Template](${TEMPLATES.NEXTJS})`,
+    `- [Solid Start Template](${TEMPLATES.SOLID})`,
+    `- [Nuxt Template](${TEMPLATES.NUXT})`,
+  ].join('\n')
+
+const replaceInstallCmd = (framework: string) =>
+  [
+    '```bash',
+    Object.values(cmdMap)
+      .map((cmd) => `${cmd} @ark-ui/${framework}`)
+      .join('\n// or\n'),
+    '```',
+  ].join('\n')
+
+// Accessibility documentation
+const replaceKeyboardTable = (id: string) => {
+  try {
+    const keyboardDoc = getAccessibilityDoc(id as AccessibilityDocKey)
+    return keyboardDoc.keyboard
+      .map((item) => {
+        return [`**\`${item.keys.join(' + ')}\`**`, `Description: ${item.description}`].join('\n')
+      })
+      .join('\n\n')
+  } catch {
+    return ''
+  }
+}
+
+type Part = (typeof types)[number]['parts'][keyof (typeof types)[number]['parts']]
+
+// Component type formatting
+const formatPropTypes = (props: NonNullable<Part['props']>) =>
+  Object.entries(props ?? {}).map(([propName, propDetails]) =>
+    [
+      `**\`${propName}\`**`,
+      `Type: \`${propDetails.type}\``,
+      `Required: ${propDetails.isRequired ? 'true' : 'false'}`,
+      `Default Value: \`${propDetails.defaultValue}\``,
+      `Description: ${propDetails.description}`,
+    ].join('\n'),
+  )
+
+const formatEmitTypes = (emits: NonNullable<Part['emits']>) =>
+  Object.entries(emits ?? {}).map(([emitName, emitDetails]) =>
+    [`**\`${emitName}\`**`, `Type: \`${emitDetails.type}\``, `Description: ${emitDetails.description}`].join('\n'),
+  )
+
+const formatDataAttributes = (key: string, id: string) => {
+  try {
+    const dataAttrDoc = getDataAttrDoc(id as DataAttrDocKey)
+    const dataAttrForPart = dataAttrDoc[key as DataAttrDocKey]
+    return Object.entries(dataAttrForPart)
+      .map(([key, value]) => `**\`${key}\`**: ${value}`)
+      .join('\n')
+  } catch {
+    return ''
+  }
+}
+
+const formatComponentType = (key: string, part: Part, id: string) => {
+  const lines = [`### ${key}`, '#### Props', ...formatPropTypes(part.props)]
+
+  if (part.emits) {
+    lines.push('#### Emits', ...formatEmitTypes(part.emits))
+  }
+
+  const dataAttrItems = formatDataAttributes(key, id)
+  if (dataAttrItems) {
+    lines.push('#### Data Attributes', dataAttrItems)
+  }
+
+  return lines.join('\n\n')
+}
+
+const replaceComponentTypes = (id: string, framework: string) => {
+  const api = types.find((type) => type.component === id && type.framework === framework)
+  if (!api) return ''
+
+  return Object.entries(api.parts)
+    .sort(([key]) => (key === 'Root' ? -1 : 1))
+    .map(([key, part]) => formatComponentType(key, part, id))
+    .join('\n\n')
+}
+
+const replaceExamples = async (content: string, page: Pages, framework: string) => {
+  const examples = content.match(PATTERNS.EXAMPLE) || []
+  let res = content
+
+  for (const example of examples) {
+    const idMatch = example.match(PATTERNS.EXAMPLE_ID)
+    const componentMatch = example.match(PATTERNS.EXAMPLE_COMPONENT)
+
+    const id = idMatch?.[1]
+    if (!id) continue
+
+    const component = componentMatch?.[1] || page.slug.split('/')[1]
+    const { code, extension } = await frameworkExample(framework, component, id)
+    res = res.replace(example, `\`\`\`${extension}\n${code}\`\`\``)
+  }
+
+  return res
+}
+
+export const cleanupPageContent = async (page: Pages, framework: 'react' | 'solid' | 'vue' | 'svelte') => {
+  if (!page.llm) return ''
+  let res = page.llm
+
+  // Remove unwanted components
+  res = res.replace(PATTERNS.ANATOMY, '')
+  res = res.replace(PATTERNS.COMPONENT_PREVIEW, '')
+  res = res.replace(PATTERNS.FAQ, '')
+  res = res.replace(PATTERNS.IMAGES, 'https://ark-ui.com/images')
+
+  // Replace components with their content
+  res = res.replace(/<Quickstart\s*\/>/g, replaceQuickstart())
+  res = res.replace(/<InstallCmd\s*\/>/g, replaceInstallCmd(framework))
+  res = res.replace(/<KeyBindingsTable\s+id="([^"]*)"\s*\/>/g, (_, id) => replaceKeyboardTable(id))
+  res = res.replace(/<ComponentTypes\s+id="([^"]*)"\s*\/>/g, (_, id) => replaceComponentTypes(id, framework))
+
+  res = await replaceExamples(res, page, framework)
+
+  return res
+}

--- a/website/src/app/sitemap.ts
+++ b/website/src/app/sitemap.ts
@@ -2,9 +2,9 @@ import type { MetadataRoute } from 'next'
 import { fetchExamples } from '~/lib/examples'
 import { getSidebarGroups } from '~/lib/sidebar'
 
-export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const frameworks = ['react', 'solid', 'vue']
+export const frameworks = ['react', 'solid', 'vue'] as const
 
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const docsPages = frameworks.flatMap((framework) =>
     getSidebarGroups()
       .flat()
@@ -13,7 +13,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   const examples = await fetchExamples()
   const examplePages = frameworks.flatMap((framework) =>
-    examples.map((example) => ({ url: `https://ark-ui.com/${framework}/examples/${example.id}` })),
+    examples.map((example) => ({ url: `https://ark-ui.com/${framework}/examples/${example}` })),
   )
 
   return [{ url: 'https://ark-ui.com' }, ...docsPages, ...examplePages]

--- a/website/src/components/example.tsx
+++ b/website/src/components/example.tsx
@@ -18,6 +18,34 @@ export const Example = async (props: Props) => {
   return <CodeTabs examples={examples} defaultValue={framework} />
 }
 
+export const frameworkExample = async (framework: string, component: string, id: string) => {
+  const extension = Match.value(framework).pipe(
+    Match.when('vue', () => 'vue'),
+    Match.orElse(() => 'tsx'),
+  )
+  const examplePath = Match.value(component).pipe(
+    Match.when(
+      () => ['progress-circular', 'progress-linear'].includes(component),
+      () => `components/progress/examples/${component.split('-')[1]}`,
+    ),
+    Match.when(
+      () => ['environment', 'locale'].includes(component),
+      () => `providers/${component}/examples`,
+    ),
+    Match.orElse(() => `components/${component}/examples`),
+  )
+
+  const basePath = `../packages/${framework}/src`
+  const fileName = [id, extension].join('.')
+
+  const content = await readFile(join(process.cwd(), basePath, examplePath, fileName), 'utf-8').catch(
+    () => 'Example not found',
+  )
+
+  const code = content.replaceAll(/from '\.\/icons'/g, `from 'lucide-vue-next'`).replace(/.*@ts-expect-error.*\n/g, '')
+  return { code, extension }
+}
+
 const findExamples = async (props: Props) => {
   const id = props.id
   const serverContext = getServerContext()
@@ -27,32 +55,7 @@ const findExamples = async (props: Props) => {
 
   return Promise.all(
     ['react', 'solid', 'vue'].map(async (framework) => {
-      const extension = Match.value(framework).pipe(
-        Match.when('vue', () => 'vue'),
-        Match.orElse(() => 'tsx'),
-      )
-      const examplePath = Match.value(component).pipe(
-        Match.when(
-          () => ['progress-circular', 'progress-linear'].includes(component),
-          () => `components/progress/examples/${component.split('-')[1]}`,
-        ),
-        Match.when(
-          () => ['environment', 'locale'].includes(component),
-          () => `providers/${component}/examples`,
-        ),
-        Match.orElse(() => `components/${component}/examples`),
-      )
-
-      const basePath = `../packages/${framework}/src`
-      const fileName = [id, extension].join('.')
-
-      const content = await readFile(join(process.cwd(), basePath, examplePath, fileName), 'utf-8').catch(
-        () => 'Example not found',
-      )
-
-      const code = content
-        .replaceAll(/from '\.\/icons'/g, `from 'lucide-vue-next'`)
-        .replace(/.*@ts-expect-error.*\n/g, '')
+      const { code, extension } = await frameworkExample(framework, component, id)
 
       const html = await codeToHtml(code, {
         lang: extension,

--- a/website/src/components/install-cmd.tsx
+++ b/website/src/components/install-cmd.tsx
@@ -10,17 +10,17 @@ export const InstallCmd = async () => {
 
 type PackageManger = 'npm' | 'pnpm' | 'yarn' | 'bun'
 
+export const cmdMap: Record<PackageManger, string> = {
+  npm: 'npm install',
+  pnpm: 'pnpm install',
+  yarn: 'yarn add',
+  bun: 'bun add',
+}
+
 const getInstallCmds = async () => {
   const serverContext = getServerContext()
   const framework = serverContext.framework
   const pkgmanagers = ['npm', 'pnpm', 'yarn', 'bun'] as const
-
-  const cmdMap: Record<PackageManger, string> = {
-    npm: 'npm install',
-    pnpm: 'pnpm install',
-    yarn: 'yarn add',
-    bun: 'bun add',
-  }
 
   return Promise.all(
     pkgmanagers.map(async (pkgManager) => {

--- a/website/src/components/quickstart.tsx
+++ b/website/src/components/quickstart.tsx
@@ -2,15 +2,15 @@ import { Flex, Grid, Stack } from 'styled-system/jsx'
 import { Text } from '~/components/ui/text'
 import { NextJsIcon, NuxtIcon, SolidStartIcon } from './marketing/icons'
 
+export const quickstartFrameworks = [
+  { name: 'Next.js', icon: NextJsIcon, href: 'https://stackblitz.com/edit/github-qcm2dskf' },
+  { name: 'Solid Start', icon: SolidStartIcon, href: 'https://stackblitz.com/edit/github-1hgkbbln' },
+  { name: 'Nuxt', icon: NuxtIcon, shreflug: 'https://stackblitz.com/edit/github-s3sg6syq' },
+]
 export const Quickstart = () => {
-  const frameworks = [
-    { name: 'Next.js', icon: NextJsIcon, href: 'https://stackblitz.com/edit/github-qcm2dskf' },
-    { name: 'Solid Start', icon: SolidStartIcon, href: 'https://stackblitz.com/edit/github-1hgkbbln' },
-    { name: 'Nuxt', icon: NuxtIcon, shreflug: 'https://stackblitz.com/edit/github-s3sg6syq' },
-  ]
   return (
     <Grid gap={{ base: '4', md: '6' }} columns={{ base: 2, sm: 3, xl: 5 }} className="not-prose">
-      {frameworks.map(({ name, icon: Icon, href }) => (
+      {quickstartFrameworks.map(({ name, icon: Icon, href }) => (
         <a key={name} href={href} target="_blank" rel="noreferrer">
           <Flex
             borderRadius="l3"

--- a/website/src/components/story.tsx
+++ b/website/src/components/story.tsx
@@ -1,1 +1,0 @@
-export const Story = () => <div>Story</div>

--- a/website/src/content/pages/overview/llms.txt.mdx
+++ b/website/src/content/pages/overview/llms.txt.mdx
@@ -1,0 +1,45 @@
+---
+id: llms.txt
+title: LLMs.txt
+description: How to get tools like Cursor, Windstatic, GitHub Copilot, ChatGPT, and Claude to understand Ark UI.
+---
+
+# LLMs.txt
+
+## What is LLMs.txt?
+
+We support [LLMs.txt](https://llmstxt.org/) files for making the Ark UI documentation available to large language models
+(LLMs). This feature helps AI tools better understand our component library, its APIs, and usage patterns.
+
+## Available Routes
+
+We provide several LLMs.txt routes to help AI tools access our documentation:
+
+- <LLMsTxtLink href="/llms.txt" /> - Contains a structured overview of all components and their documentation links
+- <LLMsTxtLink href="/llms-full.txt" /> - Provides comprehensive documentation including implementation details and
+  examples
+- <LLMsTxtLink href="/llms-react.txt" /> - React-specific documentation and implementation details
+- <LLMsTxtLink href="/llms-solid.txt" /> - SolidJS-specific documentation and implementation details
+- <LLMsTxtLink href="/llms-vue.txt" /> - Vue-specific documentation and implementation details
+- <LLMsTxtLink href="/llms-svelte.txt" /> - Svelte-specific documentation and implementation details
+
+## Usage with AI Tools
+
+### Cursor
+
+Use the `@Docs` feature in Cursor to include the LLMs.txt files in your project. This helps Cursor provide more accurate
+code suggestions and documentation for Ark UI components.
+
+[Read more about @Docs in Cursor](https://docs.cursor.com/context/@-symbols/@-docs)
+
+### Windstatic
+
+Reference the LLMs.txt files using `@` or in your `.windsurfrules` files to enhance Windstatic's understanding of Ark UI
+components.
+
+[Read more about Windstatic Memories](https://docs.codeium.com/windsurf/memories#memories-and-rules)
+
+### Other AI Tools
+
+Any AI tool that supports LLMs.txt can use these routes to better understand Ark UI. Simply point your tool to any of
+the routes above based on your framework of choice.

--- a/website/src/lib/sidebar.ts
+++ b/website/src/lib/sidebar.ts
@@ -1,8 +1,8 @@
 import { type Pages, pages } from '.velite'
 
+export const categories = ['overview', 'guides', 'components', 'utilities']
 export const getSidebarGroups = (): Pages[][] => {
-  const categories = ['overview', 'guides', 'components', 'utilities']
-  const overviewPriority = ['introduction', 'getting-started', 'changelog', 'about']
+  const overviewPriority = ['introduction', 'getting-started', 'changelog', 'about', 'llms.txt']
 
   const sortedCategories = pages.reduce<Record<string, Pages[]>>((acc, page) => {
     const category = page.category

--- a/website/src/mdx-content.tsx
+++ b/website/src/mdx-content.tsx
@@ -11,7 +11,6 @@ import { InstallCmd } from './components/install-cmd'
 import { KeyBindingsTable } from './components/key-bindings-table'
 import { Pre } from './components/pre'
 import { Quickstart } from './components/quickstart'
-import { Story } from './components/story'
 
 import { Step, Steps } from '~/components/ui/stepper'
 import { ThemeImage } from './components/theme-image'
@@ -31,7 +30,6 @@ const sharedComponents = {
   Quickstart,
   Step,
   Steps,
-  Story,
   ThemeImage,
 }
 

--- a/website/velite.config.ts
+++ b/website/velite.config.ts
@@ -18,6 +18,9 @@ const pages = defineCollection({
       status: s.string().optional(),
       toc: s.toc(),
       code: s.mdx(),
+      llm: s.custom().transform((_data, { meta }) => {
+        return meta.content
+      }),
     })
     .transform((data, { meta }) => {
       if (data.id === 'changelog') {


### PR DESCRIPTION
- Added support for LLMs.txt files to enhance AI tools' understanding of Ark UI documentation.
- Created multiple routes for framework-specific documentation (React, Solid, Vue, Svelte) and a comprehensive overview.
- Updated sidebar to include new LLMs.txt category.
- Removed unused Story component and refactored example fetching logic.
- Introduced new utility functions for content cleanup and example retrieval.