### PR TITLE
fix(template-nuxt): update quickstart doc and add TS as dev dependency

### DIFF
--- a/templates/nuxt/package.json
+++ b/templates/nuxt/package.json
@@ -14,5 +14,8 @@
     "nuxt": "3.16.1",
     "vue": "3.5.13",
     "vue-router": "4.5.0"
+  },
+  "devDependencies": {
+    "typescript": "5.8.2"
   }
 }

--- a/website/src/components/quickstart.tsx
+++ b/website/src/components/quickstart.tsx
@@ -5,7 +5,7 @@ import { NextJsIcon, NuxtIcon, SolidStartIcon } from './marketing/icons'
 export const quickstartFrameworks = [
   { name: 'Next.js', icon: NextJsIcon, href: 'https://stackblitz.com/edit/github-qcm2dskf' },
   { name: 'Solid Start', icon: SolidStartIcon, href: 'https://stackblitz.com/edit/github-1hgkbbln' },
-  { name: 'Nuxt', icon: NuxtIcon, shreflug: 'https://stackblitz.com/edit/github-s3sg6syq' },
+  { name: 'Nuxt', icon: NuxtIcon, href: 'https://stackblitz.com/edit/github-s3sg6syq' },
 ]
 export const Quickstart = () => {
   return (


### PR DESCRIPTION
### **Summary**
This PR includes two small updates:
1. Fixed the `href` property in the Nuxt Framework quickstart documentation.
2. Added TypeScript as a dev dependency to the Nuxt template.

### **Changes**
- **Documentation**: Corrected the `href` in the Nuxt quickstart guide.
- **Template**: Added TypeScript as a dev dependency.