### PR TITLE
fix(timer): add missing vue slots

### DIFF
--- a/packages/vue/src/components/timer/examples/events.vue
+++ b/packages/vue/src/components/timer/examples/events.vue
@@ -4,7 +4,9 @@ import { Timer } from '@ark-ui/vue/timer'
 
 <template>
   <Timer.Root
-    :targetMs="5 * 1000"
+    :autoStart="true"
+    :countdown="true"
+    :startMs="5 * 1000"
     @complete="() => console.log('Timer completed')"
     @tick="(details) => console.log('Tick:', details.formattedTime)"
   >

--- a/packages/vue/src/components/timer/timer-area.vue
+++ b/packages/vue/src/components/timer/timer-area.vue
@@ -23,5 +23,7 @@ useForwardExpose()
 </script>
 
 <template>
-  <ark.div v-bind="timer.getAreaProps()" :as-child="asChild" />
+  <ark.div v-bind="timer.getAreaProps()" :as-child="asChild">
+    <slot />
+  </ark.div>
 </template>

--- a/packages/vue/src/components/timer/timer-control.vue
+++ b/packages/vue/src/components/timer/timer-control.vue
@@ -23,5 +23,7 @@ useForwardExpose()
 </script>
 
 <template>
-  <ark.div v-bind="timer.getControlProps()" :as-child="asChild" />
+  <ark.div v-bind="timer.getControlProps()" :as-child="asChild">
+    <slot />
+  </ark.div>
 </template>


### PR DESCRIPTION
## Description

The following timer component would not render timer items inside of `Timer.Area` or the action triggers inside of `Timer.Control` due to the missing slots for those parts, resulting in a empty state (first screenshot).

```vue
<template>
  <Timer.Root :targetMs="60 * 60 * 1000">
    <Timer.Area>
      <Timer.Item type="days" />
      <Timer.Separator>:</Timer.Separator>
      <Timer.Item type="hours" />
      <Timer.Separator>:</Timer.Separator>
      <Timer.Item type="minutes" />
      <Timer.Separator>:</Timer.Separator>
      <Timer.Item type="seconds" />
    </Timer.Area>
    <Timer.Control>
      <Timer.ActionTrigger action="start">Play</Timer.ActionTrigger>
      <Timer.ActionTrigger action="resume">Resume</Timer.ActionTrigger>
      <Timer.ActionTrigger action="pause">Pause</Timer.ActionTrigger>
    </Timer.Control>
  </Timer.Root>
</template>

```

![Screenshot 2025-03-31 at 16 49 51](https://github.com/user-attachments/assets/5dcb6e43-48a5-4258-9a04-032e34a37eda)

By adding the slots we can see the items, separators and triggers are rendered.
The other stories are also now working properly.

![Screenshot 2025-03-31 at 16 49 07](https://github.com/user-attachments/assets/6fd7999a-af94-4201-b838-9998310d46a0)
