### PR TITLE
fix(collection): remove export alias from clean-package config

### DIFF
--- a/packages/react/clean-package.config.json
+++ b/packages/react/clean-package.config.json
@@ -24,16 +24,6 @@
           "default": "./dist/components/anatomy.cjs"
         }
       },
-      "./collection": {
-        "import": {
-          "types": "./dist/components/collection.d.ts",
-          "default": "./dist/components/collection.js"
-        },
-        "require": {
-          "types": "./dist/components/collection.d.cts",
-          "default": "./dist/components/collection.cjs"
-        }
-      },
       "./factory": {
         "import": {
           "types": "./dist/components/factory.d.ts",


### PR DESCRIPTION
Fix an issue with the export of the `collection` utilities.

The `collection` files have been moved in a recent update but in the `clean-package.config.json` file, the export alias was pointing to the old destination for `collection` files.