### PR TITLE
fix(vue): missing asChild prop binding on collapsible trigger

### DIFF
--- a/packages/vue/src/components/collapsible/collapsible-trigger.vue
+++ b/packages/vue/src/components/collapsible/collapsible-trigger.vue
@@ -23,7 +23,7 @@ useForwardExpose()
 </script>
 
 <template>
-  <ark.button v-bind="collapsible.getTriggerProps()">
+  <ark.button v-bind="collapsible.getTriggerProps()" :as-child="asChild">
     <slot />
   </ark.button>
 </template>


### PR DESCRIPTION
closes https://github.com/chakra-ui/ark/issues/3538