### PR TITLE
Fix Combobox/Grouping example for SolidJS

### DIFF
--- a/packages/solid/src/components/combobox/examples/grouping.tsx
+++ b/packages/solid/src/components/combobox/examples/grouping.tsx
@@ -9,6 +9,7 @@ export const Grouping = () => {
   const { collection, filter } = useListCollection({
     initialItems,
     filter: filterFn().contains,
+    groupBy: (item) => item.type,
   })
 
   const handleInputChange = (details: Combobox.InputValueChangeDetails) => {


### PR DESCRIPTION
The SolidJS example for Grouping in Combobox is missing group specification, which means the groups don't get rendered.
This PR fixes the example.