### PR TITLE
fix: call `React.isValidElement()` before `Children.only()`

### DIFF
--- a/packages/react/src/components/factory.ts
+++ b/packages/react/src/components/factory.ts
@@ -53,12 +53,12 @@ const withAsChild = (Component: React.ElementType) => {
       if (!asChild) {
         return createElement(Component, { ...restProps, ref }, children)
       }
-
-      const onlyChild: React.ReactNode = Children.only(children)
-
-      if (!isValidElement<Record<string, unknown>>(onlyChild)) {
+      
+      if (!isValidElement<Record<string, unknown>>(children)) {
         return null
       }
+
+      const onlyChild: React.ReactNode = Children.only(children)
 
       const childRef = getRef(onlyChild)
 


### PR DESCRIPTION
Closes #3561

We've tested this change by modifying `node_modules`. cf. https://github.com/chakra-ui/ark/issues/3561#issuecomment-3126863671