### PR TITLE
feat(tags input): export type InputValueChangeDetails

### DIFF
--- a/packages/react/src/components/tags-input/tags-input.ts
+++ b/packages/react/src/components/tags-input/tags-input.ts
@@ -2,6 +2,7 @@ export type {
   HighlightChangeDetails,
   ValidityChangeDetails,
   ValueChangeDetails,
+  InputValueChangeDetails,
 } from '@zag-js/tags-input'
 export {
   TagsInputClearTrigger as ClearTrigger,


### PR DESCRIPTION
# Tags Input — export type InputValueChangeDetails

## Problem

Ark-UI tags-input exports type `ValueChangeDetails` but not `InputValueChangeDetails`, which creates an inconsistency in the API. Both types are available from the underlying `@zag-js/tags-input` package:

```ts
interface ValueChangeDetails {
    value: string[];
}
interface InputValueChangeDetails {
    inputValue: string;
}
```

## Use Case

This export is needed for proper type safety when handling input value changes in current components. ie `useTags` component needs to handle both value changes and input value changes:

```tsx
import { useTags, type UseTagsInputProps, type TagsInputValueChangeDetails } from './park-ui/TagsInput'

// Currently missing type for input value changes
const handleInputChange = (details: { inputValue: string }) => {
  // Need proper typing for tags-input input value changes
}

const handleValueChange = (details: TagsInputValueChangeDetails) => {
  // This works fine
}
```

## Changes

- Added `InputValueChangeDetails` to the exports in `packages/react/src/components/tags-input/tags-input.ts`

## Why

This type was available from `@zag-js/tags-input` but not exported, making it unavailable to users of the library who need to properly type their input value change handlers.

## Testing

The change is minimal and only adds an export for an existing type that was already available from the underlying package. No breaking changes or new functionality is introduced.

## Related

This addresses the inconsistency where `ValueChangeDetails` is exported but `InputValueChangeDetails` was not, despite both being available from the same source package.