### PR TITLE
wrap ResizeObserver callback with requestAnimationFrame

### DIFF
--- a/packages/react/src/components/frame/frame.tsx
+++ b/packages/react/src/components/frame/frame.tsx
@@ -57,10 +57,12 @@ export const Frame = forwardRef<HTMLIFrameElement, FrameProps>((props, ref) => {
     if (!mountNode) return
 
     const exec = () => {
-      const rootEl = frameRef.contentDocument?.documentElement
-      if (!rootEl) return
-      frameRef.style.setProperty('--width', `${mountNode.scrollWidth}px`)
-      frameRef.style.setProperty('--height', `${mountNode.scrollHeight}px`)
+      win.requestAnimationFrame(() => {
+        const rootEl = frameRef.contentDocument?.documentElement
+        if (!rootEl) return
+        frameRef.style.setProperty('--width', `${mountNode.scrollWidth}px`)
+        frameRef.style.setProperty('--height', `${mountNode.scrollHeight}px`)
+      })
     }
 
     const resizeObserver = new win.ResizeObserver(exec)

--- a/packages/solid/src/components/frame/frame.tsx
+++ b/packages/solid/src/components/frame/frame.tsx
@@ -60,10 +60,12 @@ export const Frame = (props: FrameProps) => {
     if (!node) return
 
     const exec = () => {
-      const rootEl = frame.contentDocument?.documentElement
-      if (!rootEl) return
-      frame.style.setProperty('--width', `${node.scrollWidth}px`)
-      frame.style.setProperty('--height', `${node.scrollHeight}px`)
+      win.requestAnimationFrame(() => {
+        const rootEl = frame.contentDocument?.documentElement
+        if (!rootEl) return
+        frame.style.setProperty('--width', `${node.scrollWidth}px`)
+        frame.style.setProperty('--height', `${node.scrollHeight}px`)
+      })
     }
 
     const resizeObserver = new win.ResizeObserver(exec)

--- a/packages/svelte/src/lib/components/frame/frame.svelte
+++ b/packages/svelte/src/lib/components/frame/frame.svelte
@@ -60,12 +60,14 @@
     if (!win || !mountNode) return
 
     const exec = () => {
-      if (!(mountNode && frameRef && frameRef.contentDocument)) return
+      win.requestAnimationFrame(() => {
+        if (!(mountNode && frameRef && frameRef.contentDocument)) return
 
-      const rootEl = frameRef.contentDocument?.documentElement
-      if (!rootEl) return
-      frameRef.style.setProperty('--width', `${mountNode.scrollWidth}px`)
-      frameRef.style.setProperty('--height', `${mountNode.scrollHeight}px`)
+        const rootEl = frameRef.contentDocument?.documentElement
+        if (!rootEl) return
+        frameRef.style.setProperty('--width', `${mountNode.scrollWidth}px`)
+        frameRef.style.setProperty('--height', `${mountNode.scrollHeight}px`)
+      })
     }
 
     const resizeObserver = new win.ResizeObserver(exec)

--- a/packages/vue/src/components/frame/frame.vue
+++ b/packages/vue/src/components/frame/frame.vue
@@ -60,10 +60,12 @@ watch(
     if (!win) return
 
     const exec = () => {
-      const rootEl = frameNode.contentDocument?.documentElement
-      if (!rootEl || !mountNode) return
-      frameNode.style.setProperty('--width', `${mountNode.scrollWidth}px`)
-      frameNode.style.setProperty('--height', `${mountNode.scrollHeight}px`)
+      win.requestAnimationFrame(() => {
+        const rootEl = frameNode.contentDocument?.documentElement
+        if (!rootEl || !mountNode) return
+        frameNode.style.setProperty('--width', `${mountNode.scrollWidth}px`)
+        frameNode.style.setProperty('--height', `${mountNode.scrollHeight}px`)
+      })
     }
 
     const resizeObserver = new win.ResizeObserver(exec)


### PR DESCRIPTION
Since I've implemented a Frame feature in one of my projects, I get a lot of `Error ResizeObserver loop completed with undelivered notifications.` errors in BugSnag on the pages where I use the frame.
It is extremely hard to replicate, and I was not able to do that on my end. But the context points to the Frame component.
So, being honest, this is a blind attempt to resolve the issue, and according to my research, it appears to be a good practice to wrap `ResizeObserver` callback with `requestAnimationFrame` to prevent resize observer loops, which should not hurt anyway.