### PR TITLE
fix: update controlled example to showcase bi-directional controlled state

### DIFF
--- a/packages/react/src/components/tooltip/examples/controlled.tsx
+++ b/packages/react/src/components/tooltip/examples/controlled.tsx
@@ -8,7 +8,7 @@ export const Controlled = () => {
       <button type="button" onClick={() => setIsOpen(!isOpen)}>
         Toggle
       </button>
-      <Tooltip.Root open={isOpen}>
+      <Tooltip.Root open={isOpen} onOpenChange={({open}) => setIsOpen(open)}>
         <Tooltip.Trigger>Hover Me</Tooltip.Trigger>
         <Tooltip.Positioner>
           <Tooltip.Content>I am a tooltip!</Tooltip.Content>


### PR DESCRIPTION
## Problem

The controlled tooltip example showcases the button managing state, but it doesn't showcase bi-directional flow of controlled state.

By adding the onOpenChange handler we can also allow for hovering (as the example implies).