### PR TITLE
docs: update Tark UI link and MCP Server reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ Visit [ark-ui.com](https://ark-ui.com) for:
 
 - **[Chakra UI v3](https://chakra-ui.com)** - A simple, modular component library
 - **[Park UI](https://park-ui.com)** - Beautifully designed components built with Ark UI and Panda CSS
-- **[Tark UI](https://www.tarkui.xyz/)** - Ark UI components styled with Tailwind CSS
+- **[Tark UI](https://www.tarkui.com/)** - Ark UI components styled with Tailwind CSS
 
 ### Styling Libraries
 
@@ -299,7 +299,7 @@ Ark UI works seamlessly with:
 
 ### Developer Tools
 
-- **[MCP Server](https://github.com/chakra-ui/ark-mcp)** - AI-assisted development with Claude and other AI agents
+- **[MCP Server](https://github.com/chakra-ui/ark/tree/main/integrations/mcp)** - AI-assisted development with Claude and other AI agents
 
 ## Community
 


### PR DESCRIPTION
## Description

This PR fixes two broken links in the README:

- **Tark UI**: Updated URL from `https://www.tarkui.xyz/` to `https://www.tarkui.com/` (domain changed)
- **MCP Server**: Updated URL from `https://github.com/chakra-ui/ark-mcp` to `https://github.com/chakra-ui/ark/tree/main/integrations/mcp`