### PR TITLE
docs: correct navigator in changelog page

### DIFF
--- a/website/src/app/docs/[...slug]/page.tsx
+++ b/website/src/app/docs/[...slug]/page.tsx
@@ -76,6 +76,7 @@ export const generateMetadata = async (props: Props): Promise<Metadata> => {
 }
 
 const pages = getSidebarGroups().flat()
+const uniquePages = pages.filter((page, index, self) => self.findIndex((p) => p.slug === page.slug) === index)
 
 export const generateStaticParams = () =>
   ['react', 'solid', 'vue'].flatMap((framework) => pages.map((page) => ({ framework, slug: page.slug.split('/') })))
@@ -90,11 +91,11 @@ const getPageBySlug = (slug: string[], framework?: string) => {
 }
 
 const getNextPage = (slug: string[]) => {
-  const index = pages.findIndex((page) => page.slug === slug.join('/'))
-  return pages[index + 1]
+  const index = uniquePages.findIndex((page) => page.slug === slug.join('/'))
+  return uniquePages[index + 1]
 }
 
 const getPrevPage = (slug: string[]) => {
-  const index = pages.findIndex((page) => page.slug === slug.join('/'))
-  return pages[index - 1]
+  const index = uniquePages.findIndex((page) => page.slug === slug.join('/'))
+  return uniquePages[index - 1]
 }


### PR DESCRIPTION
Issue
====

Hello, while reviewing the Ark UI documentation, I found an issue on the `/docs/overview/changelog` page where the `Next page` navigation button at the bottom of the page (alongside `Prev page`) incorrectly points to `/docs/overview/changelog` instead of `/docs/overview/about`.

https://ark-ui.com/docs/overview/changelog

<img width="3266" height="2020" alt="image" src="https://github.com/user-attachments/assets/2379c129-5e0c-4620-801d-807412f2d3c6" />

There is an issue where the Changelog page loops infinitely. Of course, you can exit through the left sidebar, but I'm opening a PR because I consider it a bug.

Solution
======

This pull request makes `Prev Post` and `Next Post` look for items in the deduplicated page list (`uniquePages`).

This phenomenon occurs because there are multiple `Page` objects in the `pages` variable that have `/overview/changelog` as their `slug`.

~~~~ javascript
[
  { slug: 'overview/introduction', framework: '*' },
  { slug: 'overview/getting-started', framework: '*' },
  { slug: 'overview/changelog', framework: 'react' },
  { slug: 'overview/changelog', framework: 'solid' },
  { slug: 'overview/changelog', framework: 'svelte' },
  { slug: 'overview/changelog', framework: 'vue' },
  { slug: 'overview/about', framework: '*' },
  ...
]
~~~~

It appears that similar processing is done in the `DocsSidebar` component used to display the sidebar.

~~~~ typescript
const uniqueByTitle = (items: Pages[]): Pages[] => Array.from(new Map(items.map((item) => [item.title, item])).values())
~~~~

