### PR TITLE
fix(scroll-area): update ScrollAreaProvider bind rootProps

### DIFF
--- a/packages/vue/src/components/scroll-area/scroll-area-root-provider.vue
+++ b/packages/vue/src/components/scroll-area/scroll-area-root-provider.vue
@@ -20,14 +20,15 @@ import { ark } from '../factory'
 import { ScrollAreaProvider } from './use-scroll-area-context'
 
 const props = defineProps<ScrollAreaRootProviderBaseProps>()
+const scrollArea = computed(() => props.value)
 
-ScrollAreaProvider(computed(() => props.value))
+ScrollAreaProvider(scrollArea)
 
 useForwardExpose()
 </script>
 
 <template>
-  <ark.div :as-child="asChild">
+  <ark.div v-bind="scrollArea.getRootProps()" :as-child="asChild">
     <slot />
   </ark.div>
 </template>


### PR DESCRIPTION
It seems we miss to bind root props in `<ScrollAreaProvider>` component which in Vue framework

### Framwork

- [ ] React
- [x] Vue
- [ ] Sevetle
- [ ] Solid

### Ark Version
5.30.0