### PR TITLE
fix(dynamic): ensure first child exists before merging props

### DIFF
--- a/packages/vue/src/utils/dynamic.ts
+++ b/packages/vue/src/utils/dynamic.ts
@@ -10,7 +10,7 @@ export const Dynamic = defineComponent({
       const children = renderSlotFragments(slots.default())
       const [firstChildren, ...otherChildren] = children
 
-      if (Object.keys(attrs).length > 0) {
+      if (firstChildren && Object.keys(attrs).length > 0) {
         delete firstChildren.props?.ref
         const mergedProps = mergeProps(attrs, firstChildren.props ?? {})
         const cloned = cloneVNode(firstChildren, mergedProps)


### PR DESCRIPTION
Closes #3752

In this case [#3752 ](https://github.com/chakra-ui/ark/issues/3752),  when `visible` becomes `false`, the `children` of the dynamic component turn into an empty array, so we need to make sure `firstChildren` exists before entering the `if` block.
