### PR TITLE
fix(use-forward-expose): fix useForwardExpose crash when node is not existed

### DIFF
--- a/packages/vue/src/utils/use-forward-expose.ts
+++ b/packages/vue/src/utils/use-forward-expose.ts
@@ -62,13 +62,13 @@ export function useForwardExpose() {
   function forwardRef(ref: Element | ComponentPublicInstance | null) {
     currentRef.value = ref
 
-    if (isElement(ref) || !ref) return
+    if (!ref) return
 
     // retrieve the forwarded element
     Object.defineProperty(ret, '$el', {
       enumerable: true,
       configurable: true,
-      get: () => ref.$el,
+      get: () => (isElement(ref) ? ref : ref.$el),
     })
 
     instance.exposed = ret


### PR DESCRIPTION
When I was using useForwardExpose in Vue, I found that if an element is bound with `forwardRef` and the element does not exist at that time, it throws an error and causes a crash.

Here is a simple example to reproduce this issue :  https://stackblitz.com/edit/9tedmmel

Steps to reproduce: 
1. Click the button to hide the block below. 
2. An error message will be printed in the console.

Fixed an incorrect null check order inside the `forwardRef` function that could cause this crash.

- [x] Just in Vue