### PR TITLE
Fix: Use correct context method for `optionItemState` in `MenuCheckboxItem`

### DIFF
--- a/packages/solid/src/components/menu/menu-checkbox-item.tsx
+++ b/packages/solid/src/components/menu/menu-checkbox-item.tsx
@@ -27,7 +27,7 @@ export const MenuCheckboxItem = (props: MenuCheckboxItemProps) => {
 
   const context = useMenuContext()
   const mergedProps = mergeProps(() => context().getOptionItemProps(optionItemProps), localProps)
-  const optionItemState = createMemo(() => context().getItemState(optionItemProps))
+  const optionItemState = createMemo(() => context().getOptionItemState(optionItemProps))
 
   return (
     <MenuItemPropsProvider value={optionItemProps}>


### PR DESCRIPTION
Updated `optionItemState` to use `getOptionItemState` instead of `getItemState` to ensure checkbox items track their state correctly.
