### PR TITLE
fix(react): restart popover positioning after lazy mount

### DIFF
--- a/packages/react/src/components/popover/popover-positioner.tsx
+++ b/packages/react/src/components/popover/popover-positioner.tsx
@@ -1,5 +1,6 @@
 import { mergeProps } from '@zag-js/react'
 import { forwardRef } from 'react'
+import { useSafeLayoutEffect } from '../../utils/use-safe-layout-effect'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { usePresenceContext } from '../presence'
 import { usePopoverContext } from './use-popover-context'
@@ -10,11 +11,19 @@ export interface PopoverPositionerProps extends HTMLProps<'div'>, PopoverPositio
 export const PopoverPositioner = forwardRef<HTMLDivElement, PopoverPositionerProps>((props, ref) => {
   const popover = usePopoverContext()
   const presence = usePresenceContext()
-  const mergedProps = mergeProps(popover.getPositionerProps(), props)
+
+  const mounting = !presence.unmounted && !presence.wasEverPresent
+  useSafeLayoutEffect(() => {
+    if (mounting) {
+      popover.restartPositioning()
+    }
+  }, [mounting, popover])
 
   if (presence.unmounted) {
     return null
   }
+
+  const mergedProps = mergeProps(popover.getPositionerProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
 })

--- a/packages/react/src/components/presence/use-presence.ts
+++ b/packages/react/src/components/presence/use-presence.ts
@@ -28,10 +28,11 @@ export const usePresence = (props: UsePresenceProps = {}) => {
 
   if (api.present) {
     wasEverPresent.current = true
+  } else if (unmountOnExit) {
+    wasEverPresent.current = false
   }
 
-  const unmounted =
-    (!api.present && !wasEverPresent.current && lazyMount) || (unmountOnExit && !api.present && wasEverPresent.current)
+  const unmounted = !api.present && (wasEverPresent.current ? unmountOnExit : lazyMount)
 
   const getPresenceProps = () => ({
     'data-state': api.skip && skipAnimationOnMount ? undefined : present ? 'open' : 'closed',
@@ -42,6 +43,7 @@ export const usePresence = (props: UsePresenceProps = {}) => {
     ref: api.setNode,
     getPresenceProps,
     present: api.present,
+    wasEverPresent: wasEverPresent.current,
     unmounted,
   }
 }


### PR DESCRIPTION
## Description
Restarts React popover positioning after the lazily mounted positioner first appears.

## Current behavior
When the positioner is lazy-mounted, the initial tracked positioning session can miss the floating node.

## New behavior
`@ark-ui/react` now calls `restartPositioning()` when `Popover.Positioner` first mounts, which lets Zag rebuild the tracked positioning session once the DOM node exists.

## Additional Information
See https://github.com/chakra-ui/zag/pull/3092 for the associated Zag PR.

This draft only covers the React package and does not include tests. I won't have time to push it through to the finish from here, so it'd be great if someone could pick it up. Thanks for your time.
