### PR TITLE
fix(password-input): prevent fallback property from leaking to DOM as invalid HTML attribute

### DIFF
--- a/packages/react/src/components/password-input/password-input-indicator.tsx
+++ b/packages/react/src/components/password-input/password-input-indicator.tsx
@@ -15,11 +15,12 @@ export interface PasswordInputIndicatorProps extends HTMLProps<'span'>, Password
 
 export const PasswordInputIndicator = forwardRef<HTMLSpanElement, PasswordInputIndicatorProps>((props, ref) => {
   const passwordInput = usePasswordInputContext()
-  const mergedProps = mergeProps(passwordInput.getIndicatorProps(), props)
+  const { fallback, children, ...rest } = props
+  const mergedProps = mergeProps(passwordInput.getIndicatorProps(), rest)
 
   return (
     <ark.span {...mergedProps} ref={ref}>
-      {passwordInput.visible ? props.children : props.fallback}
+      {passwordInput.visible ? children : fallback}
     </ark.span>
   )
 })

--- a/packages/solid/src/components/password-input/password-input-indicator.tsx
+++ b/packages/solid/src/components/password-input/password-input-indicator.tsx
@@ -1,5 +1,5 @@
 import { mergeProps } from '@zag-js/solid'
-import { type JSX, Show } from 'solid-js'
+import { type JSX, Show, splitProps } from 'solid-js'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { usePasswordInputContext } from './use-password-input-context'
 
@@ -13,12 +13,13 @@ export interface PasswordInputIndicatorProps extends HTMLProps<'span'>, Password
 
 export const PasswordInputIndicator = (props: PasswordInputIndicatorProps) => {
   const passwordInput = usePasswordInputContext()
-  const mergedProps = mergeProps(() => passwordInput().getIndicatorProps(), props)
+  const [local, rest] = splitProps(props, ['fallback', 'children'])
+  const mergedProps = mergeProps(() => passwordInput().getIndicatorProps(), rest)
 
   return (
     <ark.span {...mergedProps}>
-      <Show when={passwordInput().visible} fallback={props.fallback}>
-        {props.children}
+      <Show when={passwordInput().visible} fallback={local.fallback}>
+        {local.children}
       </Show>
     </ark.span>
   )


### PR DESCRIPTION
When using `PasswordInput.Indicator` with `fallback` property,
the prop leaks to the  `<span>` as an invalid HTML attribute:

**Frameworks**
- [x] React
- [x] Solid
- [ ] Vue
- [ ] Svelte

**Example**

```tsx
<PasswordInput.Root>
  <PasswordInput.Control>
    <PasswordInput.Input />
    <PasswordInput.VisibilityTrigger>
      <PasswordInput.Indicator fallback={<EyeOffIcon />}>
        <EyeIcon />
      </PasswordInput.Indicator>
    </PasswordInput.VisibilityTrigger>
  </PasswordInput.Control>
</PasswordInput.Root>
```

**Result in input indicator part**

```html
<span
  data-scope="password-input"
  data-part="indicator"
  aria-hidden="true"
  data-state="hidden"
  fallback="[object SVGSVGElement]"></span>
```