### PR TITLE
feat(field): use aria-errormessage for error text association

### DIFF
--- a/packages/react/src/components/field/field.test.tsx
+++ b/packages/react/src/components/field/field.test.tsx
@@ -50,6 +50,7 @@ describe('Field / Input', () => {
   it('should display error text when error is present', async () => {
     render(<ComponentUnderTest invalid />)
     expect(screen.getByText('Error Info')).toBeInTheDocument()
+    expect(screen.getByRole('textbox')).toHaveAccessibleErrorMessage('Error Info')
   })
 
   it('should focus on input when label is clicked', async () => {

--- a/packages/react/src/components/field/use-field.ts
+++ b/packages/react/src/components/field/use-field.ts
@@ -93,12 +93,6 @@ export const useField = (props: UseFieldProps = {}) => {
     return () => observer.disconnect()
   }, [env, errorTextId, helperTextId])
 
-  const labelIds = useMemo(() => {
-    const ids: string[] = []
-    if (hasHelperText) ids.push(helperTextId)
-    return ids.join(' ') || undefined
-  }, [helperTextId, hasHelperText])
-
   const getRootProps = useMemo(
     () => () =>
       ({
@@ -134,7 +128,7 @@ export const useField = (props: UseFieldProps = {}) => {
   const getControlProps = useMemo(
     () => () =>
       ({
-        'aria-describedby': labelIds,
+        'aria-describedby': hasHelperText ? helperTextId : undefined,
         'aria-errormessage': errorMessageId,
         'aria-invalid': ariaAttr(invalid),
         'data-invalid': dataAttr(invalid),
@@ -145,7 +139,7 @@ export const useField = (props: UseFieldProps = {}) => {
         disabled,
         readOnly,
       }) as HTMLProps<'input'>,
-    [labelIds, invalid, required, readOnly, id, errorMessageId, disabled],
+    [hasHelperText, helperTextId, invalid, required, readOnly, id, errorMessageId, disabled],
   )
 
   const getInputProps = useMemo(
@@ -205,7 +199,7 @@ export const useField = (props: UseFieldProps = {}) => {
   )
 
   return {
-    ariaDescribedby: labelIds,
+    ariaDescribedby: hasHelperText ? helperTextId : undefined,
     ids: {
       root: rootId,
       control: id,

--- a/packages/react/src/components/field/use-field.ts
+++ b/packages/react/src/components/field/use-field.ts
@@ -95,10 +95,9 @@ export const useField = (props: UseFieldProps = {}) => {
 
   const labelIds = useMemo(() => {
     const ids: string[] = []
-    if (hasErrorText && invalid) ids.push(errorTextId)
     if (hasHelperText) ids.push(helperTextId)
     return ids.join(' ') || undefined
-  }, [invalid, errorTextId, helperTextId, hasErrorText, hasHelperText])
+  }, [helperTextId, hasHelperText])
 
   const getRootProps = useMemo(
     () => () =>
@@ -130,10 +129,13 @@ export const useField = (props: UseFieldProps = {}) => {
     [disabled, invalid, readOnly, required, id, labelId, targetControlId],
   )
 
+  const errorMessageId = hasErrorText && invalid ? errorTextId : undefined
+
   const getControlProps = useMemo(
     () => () =>
       ({
         'aria-describedby': labelIds,
+        'aria-errormessage': errorMessageId,
         'aria-invalid': ariaAttr(invalid),
         'data-invalid': dataAttr(invalid),
         'data-required': dataAttr(required),
@@ -143,7 +145,7 @@ export const useField = (props: UseFieldProps = {}) => {
         disabled,
         readOnly,
       }) as HTMLProps<'input'>,
-    [labelIds, invalid, required, readOnly, id, disabled],
+    [labelIds, invalid, required, readOnly, id, errorMessageId, disabled],
   )
 
   const getInputProps = useMemo(

--- a/packages/solid/src/components/field/field.test.tsx
+++ b/packages/solid/src/components/field/field.test.tsx
@@ -42,6 +42,7 @@ describe('Field / Input', () => {
   it('should display error text when error is present', async () => {
     render(() => <ComponentUnderTest invalid />)
     expect(screen.getByText('Error Info')).toBeInTheDocument()
+    expect(screen.getByRole('textbox')).toHaveAccessibleErrorMessage('Error Info')
   })
 
   it('should focus on input when label is clicked', async () => {

--- a/packages/solid/src/components/field/use-field.ts
+++ b/packages/solid/src/components/field/use-field.ts
@@ -109,13 +109,15 @@ export const useField = (props?: MaybeAccessor<UseFieldProps>) => {
 
   const labelIds = createMemo(() => {
     const ids: string[] = []
-    if (hasErrorText() && fieldProps.invalid) ids.push(errorTextId)
     if (hasHelperText()) ids.push(helperTextId)
     return ids
   })
 
+  const errorMessageId = createMemo(() => (hasErrorText() && fieldProps.invalid ? errorTextId : undefined))
+
   const getControlProps = () => ({
     'aria-describedby': labelIds().join(' ') || undefined,
+    'aria-errormessage': errorMessageId(),
     'aria-invalid': ariaAttr(fieldProps.invalid),
     'data-invalid': dataAttr(fieldProps.invalid),
     'data-required': dataAttr(fieldProps.required),

--- a/packages/solid/src/components/field/use-field.ts
+++ b/packages/solid/src/components/field/use-field.ts
@@ -107,16 +107,10 @@ export const useField = (props?: MaybeAccessor<UseFieldProps>) => {
     htmlFor: targetControlId ?? id,
   })
 
-  const labelIds = createMemo(() => {
-    const ids: string[] = []
-    if (hasHelperText()) ids.push(helperTextId)
-    return ids
-  })
-
   const errorMessageId = createMemo(() => (hasErrorText() && fieldProps.invalid ? errorTextId : undefined))
 
   const getControlProps = () => ({
-    'aria-describedby': labelIds().join(' ') || undefined,
+    'aria-describedby': hasHelperText() ? helperTextId : undefined,
     'aria-errormessage': errorMessageId(),
     'aria-invalid': ariaAttr(fieldProps.invalid),
     'data-invalid': dataAttr(fieldProps.invalid),
@@ -161,7 +155,7 @@ export const useField = (props?: MaybeAccessor<UseFieldProps>) => {
   })
 
   return createMemo(() => ({
-    ariaDescribedby: labelIds().join(' '),
+    ariaDescribedby: hasHelperText() ? helperTextId : undefined,
     ids: {
       control: id,
       label: labelId,

--- a/packages/svelte/src/lib/components/field/tests/field-item.test.ts
+++ b/packages/svelte/src/lib/components/field/tests/field-item.test.ts
@@ -96,6 +96,7 @@ describe('Field / Item', () => {
     expect(screen.getByTestId('amount-input')).toHaveAttribute('aria-invalid', 'true')
     expect(screen.getByTestId('amount-input')).toHaveAttribute('data-invalid')
     expect(screen.getByText('Invalid amount')).toBeInTheDocument()
+    expect(screen.getByTestId('amount-input')).toHaveAccessibleErrorMessage('Invalid amount')
   })
 
   it('should throw when Field.Item is used outside Field.Root', () => {

--- a/packages/svelte/src/lib/components/field/use-field.svelte.ts
+++ b/packages/svelte/src/lib/components/field/use-field.svelte.ts
@@ -98,12 +98,6 @@ export const useField = (inProps: MaybeFunction<UseFieldProps> = {}) => {
     }
   })
 
-  const labelIds = $derived(() => {
-    const ids: string[] = []
-    if (hasHelperText) ids.push(helperTextId)
-    return ids.join(' ') || undefined
-  })
-
   const errorMessageId = $derived(hasErrorText && invalid ? errorTextId : undefined)
 
   const getRootProps = () =>
@@ -131,7 +125,7 @@ export const useField = (inProps: MaybeFunction<UseFieldProps> = {}) => {
 
   const getControlProps = () =>
     ({
-      'aria-describedby': labelIds(),
+      'aria-describedby': hasHelperText ? helperTextId : undefined,
       'aria-errormessage': errorMessageId,
       'aria-invalid': ariaAttr(invalid),
       'data-invalid': dataAttr(invalid),
@@ -183,7 +177,7 @@ export const useField = (inProps: MaybeFunction<UseFieldProps> = {}) => {
 
   const api = $derived({
     setRootRef,
-    ariaDescribedby: labelIds(),
+    ariaDescribedby: hasHelperText ? helperTextId : undefined,
     ids: {
       root: rootId,
       control: controlId,

--- a/packages/svelte/src/lib/components/field/use-field.svelte.ts
+++ b/packages/svelte/src/lib/components/field/use-field.svelte.ts
@@ -100,10 +100,11 @@ export const useField = (inProps: MaybeFunction<UseFieldProps> = {}) => {
 
   const labelIds = $derived(() => {
     const ids: string[] = []
-    if (hasErrorText && invalid) ids.push(errorTextId)
     if (hasHelperText) ids.push(helperTextId)
     return ids.join(' ') || undefined
   })
+
+  const errorMessageId = $derived(hasErrorText && invalid ? errorTextId : undefined)
 
   const getRootProps = () =>
     ({
@@ -131,6 +132,7 @@ export const useField = (inProps: MaybeFunction<UseFieldProps> = {}) => {
   const getControlProps = () =>
     ({
       'aria-describedby': labelIds(),
+      'aria-errormessage': errorMessageId,
       'aria-invalid': ariaAttr(invalid),
       'data-invalid': dataAttr(invalid),
       'data-required': dataAttr(required),

--- a/packages/svelte/src/lib/components/radio-group/radio-group-item.svelte
+++ b/packages/svelte/src/lib/components/radio-group/radio-group-item.svelte
@@ -16,9 +16,7 @@
 
   let { ref = $bindable(null), ...props }: RadioGroupItemProps = $props()
   const radioGroup = useRadioGroupContext()
-  const [itemProps, localProps] = $derived(
-    createSplitProps<ItemProps>()(props, ['value', 'disabled', 'invalid']),
-  )
+  const [itemProps, localProps] = $derived(createSplitProps<ItemProps>()(props, ['value', 'disabled', 'invalid']))
 
   const itemState = $derived(radioGroup().getItemState(itemProps))
   const mergedProps = $derived(mergeProps(radioGroup().getItemProps(itemProps), localProps))

--- a/packages/vue/src/components/field/tests/field.test.tsx
+++ b/packages/vue/src/components/field/tests/field.test.tsx
@@ -1,6 +1,7 @@
 import user from '@testing-library/user-event'
 import { render, screen, waitFor } from '@testing-library/vue'
 import ComponentUnderTest from './field.test.vue'
+import { nextTick } from 'vue'
 
 describe('Field', () => {
   it('should set textbox as required', async () => {
@@ -29,7 +30,9 @@ describe('Field', () => {
 
   it('should display error text when error is present', async () => {
     render(ComponentUnderTest, { props: { invalid: true } })
+    await nextTick()
     expect(screen.getByText('Error Info')).toBeInTheDocument()
+    expect(screen.getByRole('textbox')).toHaveAccessibleErrorMessage('Error Info')
   })
 
   it('should focus on input when label is clicked', async () => {

--- a/packages/vue/src/components/field/use-field.ts
+++ b/packages/vue/src/components/field/use-field.ts
@@ -119,17 +119,18 @@ export const useField = (props: MaybeRef<UseFieldProps> = {}) => {
   }
 
   const labelIds = computed(() => {
-    const values = toValue(props)
     const ids: string[] = []
-    if (state.hasErrorText && values.invalid) ids.push(errorTextId.value)
     if (state.hasHelperText) ids.push(helperTextId.value)
     return ids
   })
+
+  const errorMessageId = computed(() => (state.hasErrorText && toValue(props).invalid ? errorTextId.value : undefined))
 
   const getControlProps = () => {
     const values = toValue(props)
     return {
       'aria-describedby': labelIds.value.join(' ') || undefined,
+      'aria-errormessage': errorMessageId.value,
       'aria-invalid': ariaAttr(values.invalid),
       'data-invalid': dataAttr(values.invalid),
       'data-required': dataAttr(values.required),

--- a/packages/vue/src/components/field/use-field.ts
+++ b/packages/vue/src/components/field/use-field.ts
@@ -118,18 +118,12 @@ export const useField = (props: MaybeRef<UseFieldProps> = {}) => {
     }
   }
 
-  const labelIds = computed(() => {
-    const ids: string[] = []
-    if (state.hasHelperText) ids.push(helperTextId.value)
-    return ids
-  })
-
   const errorMessageId = computed(() => (state.hasErrorText && toValue(props).invalid ? errorTextId.value : undefined))
 
   const getControlProps = () => {
     const values = toValue(props)
     return {
-      'aria-describedby': labelIds.value.join(' ') || undefined,
+      'aria-describedby': state.hasHelperText ? helperTextId.value : undefined,
       'aria-errormessage': errorMessageId.value,
       'aria-invalid': ariaAttr(values.invalid),
       'data-invalid': dataAttr(values.invalid),
@@ -180,7 +174,7 @@ export const useField = (props: MaybeRef<UseFieldProps> = {}) => {
   return computed(() => {
     const values = toValue(props)
     return {
-      ariaDescribedby: labelIds.value.join(' ') || undefined,
+      ariaDescribedby: state.hasHelperText ? helperTextId.value : undefined,
       ids: {
         control: id.value,
         label: labelId.value,


### PR DESCRIPTION
`Field.ErrorText` is currently associated with the control via `aria-describedby`. I believe [`aria-errormessage`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-errormessage) is the semantically correct attribute for this relationship. It exists specifically to identify error messages and pairs with `aria-invalid`. 

Testing Library and Playwright both ship `toHaveAccessibleErrorMessage()` as a first-class assertion that reads `aria-errormessage`. I take that to mean this API should be stable and safe to support. I discovered this because I was attempting to write unit tests in my project with both of those and realized I couldn't use `toHaveAccessibleErrorMessage()` out of the box with Ark UI.

This change should be minimal because the infrastructure already correctly sets `aria-invalid` and determines `hasErrorText` with a `MutationObserver`. The error text ID just needs to move from `aria-describedby` to `aria-errormessage`, leaving `aria-describedby` for helper text exclusively, which I believe is the correct semantic split.


Thank you!