### PR TITLE
refactor(react)!: remove forwardRef

### DIFF
--- a/packages/react/src/components/accordion/accordion-item-content.tsx
+++ b/packages/react/src/components/accordion/accordion-item-content.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { Collapsible } from '../collapsible'
 import type { HTMLProps, PolymorphicProps } from '../factory'
@@ -18,7 +17,7 @@ interface VisibilityProps {
 
 const splitVisibilityProps = createSplitProps<VisibilityProps>()
 
-export const AccordionItemContent = forwardRef<HTMLDivElement, AccordionItemContentProps>((props, ref) => {
+export const AccordionItemContent = ({ ref, ...props }: AccordionItemContentProps) => {
   const accordion = useAccordionContext()
   const itemProps = useAccordionItemPropsContext()
 
@@ -28,6 +27,6 @@ export const AccordionItemContent = forwardRef<HTMLDivElement, AccordionItemCont
   const mergedProps = mergeProps(itemContentProps, props)
 
   return <Collapsible.Content ref={ref} {...mergedProps} />
-})
+}
 
 AccordionItemContent.displayName = 'AccordionItemContent'

--- a/packages/react/src/components/accordion/accordion-item-indicator.tsx
+++ b/packages/react/src/components/accordion/accordion-item-indicator.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useAccordionContext } from './use-accordion-context'
 import { useAccordionItemPropsContext } from './use-accordion-item-props-context'
@@ -9,12 +8,12 @@ import { useAccordionItemPropsContext } from './use-accordion-item-props-context
 export interface AccordionItemIndicatorBaseProps extends PolymorphicProps {}
 export interface AccordionItemIndicatorProps extends HTMLProps<'div'>, AccordionItemIndicatorBaseProps {}
 
-export const AccordionItemIndicator = forwardRef<HTMLDivElement, AccordionItemIndicatorProps>((props, ref) => {
+export const AccordionItemIndicator = ({ ref, ...props }: AccordionItemIndicatorProps) => {
   const accordion = useAccordionContext()
   const itemProps = useAccordionItemPropsContext()
   const mergedProps = mergeProps(accordion.getItemIndicatorProps(itemProps), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 AccordionItemIndicator.displayName = 'AccordionItemIndicator'

--- a/packages/react/src/components/accordion/accordion-item-trigger.tsx
+++ b/packages/react/src/components/accordion/accordion-item-trigger.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { useCollapsibleContext } from '../collapsible'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useAccordionContext } from './use-accordion-context'
@@ -10,7 +9,7 @@ import { useAccordionItemPropsContext } from './use-accordion-item-props-context
 export interface AccordionItemTriggerBaseProps extends PolymorphicProps {}
 export interface AccordionItemTriggerProps extends HTMLProps<'button'>, AccordionItemTriggerBaseProps {}
 
-export const AccordionItemTrigger = forwardRef<HTMLButtonElement, AccordionItemTriggerProps>((props, ref) => {
+export const AccordionItemTrigger = ({ ref, ...props }: AccordionItemTriggerProps) => {
   const accordion = useAccordionContext()
   const itemProps = useAccordionItemPropsContext()
   const collapsible = useCollapsibleContext()
@@ -24,6 +23,6 @@ export const AccordionItemTrigger = forwardRef<HTMLButtonElement, AccordionItemT
   )
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 AccordionItemTrigger.displayName = 'AccordionItemTrigger'

--- a/packages/react/src/components/accordion/accordion-item.tsx
+++ b/packages/react/src/components/accordion/accordion-item.tsx
@@ -2,7 +2,6 @@
 
 import type { ItemProps } from '@zag-js/accordion'
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { Collapsible } from '../../components'
 import { createSplitProps } from '../../utils/create-split-props'
 import { useRenderStrategyPropsContext } from '../../utils/render-strategy'
@@ -16,7 +15,7 @@ export interface AccordionItemProps extends HTMLProps<'div'>, AccordionItemBaseP
 
 const splitItemProps = createSplitProps<ItemProps>()
 
-export const AccordionItem = forwardRef<HTMLDivElement, AccordionItemProps>((props, ref) => {
+export const AccordionItem = ({ ref, ...props }: AccordionItemProps) => {
   const [itemProps, localProps] = splitItemProps(props, ['value', 'disabled'])
   const accordion = useAccordionContext()
   const renderStrategy = useRenderStrategyPropsContext()
@@ -37,6 +36,6 @@ export const AccordionItem = forwardRef<HTMLDivElement, AccordionItemProps>((pro
       </AccordionItemProvider>
     </AccordionItemPropsProvider>
   )
-})
+}
 
 AccordionItem.displayName = 'AccordionItem'

--- a/packages/react/src/components/accordion/accordion-root-provider.tsx
+++ b/packages/react/src/components/accordion/accordion-root-provider.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import {
   type RenderStrategyProps,
@@ -21,7 +20,7 @@ export interface AccordionRootProviderProps extends HTMLProps<'div'>, AccordionR
 
 const splitRootProviderProps = createSplitProps<RootProviderProps>()
 
-export const AccordionRootProvider = forwardRef<HTMLDivElement, AccordionRootProviderProps>((props, ref) => {
+export const AccordionRootProvider = ({ ref, ...props }: AccordionRootProviderProps) => {
   const [renderStrategyProps, accordionProps] = splitRenderStrategyProps(props)
   const [{ value: accordion }, localProps] = splitRootProviderProps(accordionProps, ['value'])
   const mergedProps = mergeProps(accordion.getRootProps(), localProps)
@@ -33,6 +32,6 @@ export const AccordionRootProvider = forwardRef<HTMLDivElement, AccordionRootPro
       </RenderStrategyPropsProvider>
     </AccordionProvider>
   )
-})
+}
 
 AccordionRootProvider.displayName = 'AccordionRootProvider'

--- a/packages/react/src/components/accordion/accordion-root.tsx
+++ b/packages/react/src/components/accordion/accordion-root.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import type { Assign } from '../../types'
 import { createSplitProps } from '../../utils/create-split-props'
 import {
@@ -18,7 +17,7 @@ export interface AccordionRootProps extends Assign<HTMLProps<'div'>, AccordionRo
 
 const splitRootProps = createSplitProps<UseAccordionProps>()
 
-export const AccordionRoot = forwardRef<HTMLDivElement, AccordionRootProps>((props, ref) => {
+export const AccordionRoot = ({ ref, ...props }: AccordionRootProps) => {
   const [renderStrategyProps, accordionProps] = splitRenderStrategyProps(props)
   const [useAccordionProps, localProps] = splitRootProps(accordionProps, [
     'collapsible',
@@ -42,6 +41,6 @@ export const AccordionRoot = forwardRef<HTMLDivElement, AccordionRootProps>((pro
       </RenderStrategyPropsProvider>
     </AccordionProvider>
   )
-})
+}
 
 AccordionRoot.displayName = 'AccordionRoot'

--- a/packages/react/src/components/angle-slider/angle-slider-control.tsx
+++ b/packages/react/src/components/angle-slider/angle-slider-control.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useAngleSliderContext } from './use-angle-slider-context'
 
 export interface AngleSliderControlBaseProps extends PolymorphicProps {}
 export interface AngleSliderControlProps extends HTMLProps<'div'>, AngleSliderControlBaseProps {}
 
-export const AngleSliderControl = forwardRef<HTMLDivElement, AngleSliderControlProps>((props, ref) => {
+export const AngleSliderControl = ({ ref, ...props }: AngleSliderControlProps) => {
   const angleSlider = useAngleSliderContext()
   const mergedProps = mergeProps(angleSlider.getControlProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 AngleSliderControl.displayName = 'AngleSliderControl'

--- a/packages/react/src/components/angle-slider/angle-slider-hidden-input.tsx
+++ b/packages/react/src/components/angle-slider/angle-slider-hidden-input.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useAngleSliderContext } from './use-angle-slider-context'
 
 export interface AngleSliderHiddenInputBaseProps extends PolymorphicProps {}
 export interface AngleSliderHiddenInputProps extends HTMLProps<'input'>, AngleSliderHiddenInputBaseProps {}
 
-export const AngleSliderHiddenInput = forwardRef<HTMLInputElement, AngleSliderHiddenInputProps>((props, ref) => {
+export const AngleSliderHiddenInput = ({ ref, ...props }: AngleSliderHiddenInputProps) => {
   const angleSlider = useAngleSliderContext()
   const mergedProps = mergeProps(angleSlider.getHiddenInputProps(), props)
 
   return <ark.input {...mergedProps} ref={ref} />
-})
+}
 
 AngleSliderHiddenInput.displayName = 'AngleSliderHiddenInput'

--- a/packages/react/src/components/angle-slider/angle-slider-label.tsx
+++ b/packages/react/src/components/angle-slider/angle-slider-label.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useAngleSliderContext } from './use-angle-slider-context'
 
 export interface AngleSliderLabelBaseProps extends PolymorphicProps {}
 export interface AngleSliderLabelProps extends HTMLProps<'label'>, AngleSliderLabelBaseProps {}
 
-export const AngleSliderLabel = forwardRef<HTMLLabelElement, AngleSliderLabelProps>((props, ref) => {
+export const AngleSliderLabel = ({ ref, ...props }: AngleSliderLabelProps) => {
   const angleSlider = useAngleSliderContext()
   const mergedProps = mergeProps(angleSlider.getLabelProps(), props)
 
   return <ark.label {...mergedProps} ref={ref} />
-})
+}
 
 AngleSliderLabel.displayName = 'AngleSliderLabel'

--- a/packages/react/src/components/angle-slider/angle-slider-marker-group.tsx
+++ b/packages/react/src/components/angle-slider/angle-slider-marker-group.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useAngleSliderContext } from './use-angle-slider-context'
 
 export interface AngleSliderMarkerGroupBaseProps extends PolymorphicProps {}
 export interface AngleSliderMarkerGroupProps extends HTMLProps<'div'>, AngleSliderMarkerGroupBaseProps {}
 
-export const AngleSliderMarkerGroup = forwardRef<HTMLDivElement, AngleSliderMarkerGroupProps>((props, ref) => {
+export const AngleSliderMarkerGroup = ({ ref, ...props }: AngleSliderMarkerGroupProps) => {
   const angleSlider = useAngleSliderContext()
   const mergedProps = mergeProps(angleSlider.getMarkerGroupProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 AngleSliderMarkerGroup.displayName = 'AngleSliderMarkerGroup'

--- a/packages/react/src/components/angle-slider/angle-slider-marker.tsx
+++ b/packages/react/src/components/angle-slider/angle-slider-marker.tsx
@@ -2,7 +2,6 @@
 
 import type { MarkerProps } from '@zag-js/angle-slider'
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import type { Assign } from '../../types'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -13,13 +12,13 @@ export interface AngleSliderMarkerProps extends Assign<HTMLProps<'div'>, AngleSl
 
 const splitMarkerProps = createSplitProps<MarkerProps>()
 
-export const AngleSliderMarker = forwardRef<HTMLDivElement, AngleSliderMarkerProps>((props, ref) => {
+export const AngleSliderMarker = ({ ref, ...props }: AngleSliderMarkerProps) => {
   const [markerProps, localProps] = splitMarkerProps(props, ['value'])
 
   const angleSlider = useAngleSliderContext()
   const mergedProps = mergeProps(angleSlider.getMarkerProps(markerProps), localProps)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 AngleSliderMarker.displayName = 'AngleSliderMarker'

--- a/packages/react/src/components/angle-slider/angle-slider-root-provider.tsx
+++ b/packages/react/src/components/angle-slider/angle-slider-root-provider.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import type { UseAngleSliderReturn } from './use-angle-slider'
@@ -16,7 +15,7 @@ export interface AngleSliderRootProviderProps extends HTMLProps<'div'>, AngleSli
 
 const splitRootProviderProps = createSplitProps<RootProviderProps>()
 
-export const AngleSliderRootProvider = forwardRef<HTMLDivElement, AngleSliderRootProviderProps>((props, ref) => {
+export const AngleSliderRootProvider = ({ ref, ...props }: AngleSliderRootProviderProps) => {
   const [{ value: angleSlider }, localProps] = splitRootProviderProps(props, ['value'])
   const mergedProps = mergeProps(angleSlider.getRootProps(), localProps)
 
@@ -25,6 +24,6 @@ export const AngleSliderRootProvider = forwardRef<HTMLDivElement, AngleSliderRoo
       <ark.div {...mergedProps} ref={ref} />
     </AngleSliderProvider>
   )
-})
+}
 
 AngleSliderRootProvider.displayName = 'AngleSliderRootProvider'

--- a/packages/react/src/components/angle-slider/angle-slider-root.tsx
+++ b/packages/react/src/components/angle-slider/angle-slider-root.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import type { Assign } from '../../types'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -14,7 +13,7 @@ export interface AngleSliderRootProps extends Assign<HTMLProps<'div'>, AngleSlid
 
 const splitRootProps = createSplitProps<UseAngleSliderProps>()
 
-export const AngleSliderRoot = forwardRef<HTMLDivElement, AngleSliderRootProps>((props, ref) => {
+export const AngleSliderRoot = ({ ref, ...props }: AngleSliderRootProps) => {
   const [useAngleSliderProps, localProps] = splitRootProps(props, [
     'id',
     'ids',
@@ -39,6 +38,6 @@ export const AngleSliderRoot = forwardRef<HTMLDivElement, AngleSliderRootProps>(
       <ark.div {...mergedProps} ref={ref} />
     </AngleSliderProvider>
   )
-})
+}
 
 AngleSliderRoot.displayName = 'AngleSliderRoot'

--- a/packages/react/src/components/angle-slider/angle-slider-thumb.tsx
+++ b/packages/react/src/components/angle-slider/angle-slider-thumb.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useAngleSliderContext } from './use-angle-slider-context'
 
 export interface AngleSliderThumbBaseProps extends PolymorphicProps {}
 export interface AngleSliderThumbProps extends HTMLProps<'div'>, AngleSliderThumbBaseProps {}
 
-export const AngleSliderThumb = forwardRef<HTMLDivElement, AngleSliderThumbProps>((props, ref) => {
+export const AngleSliderThumb = ({ ref, ...props }: AngleSliderThumbProps) => {
   const angleSlider = useAngleSliderContext()
   const mergedProps = mergeProps(angleSlider.getThumbProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 AngleSliderThumb.displayName = 'AngleSliderThumb'

--- a/packages/react/src/components/angle-slider/angle-slider-value-text.tsx
+++ b/packages/react/src/components/angle-slider/angle-slider-value-text.tsx
@@ -1,19 +1,18 @@
 'use client'
 
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useAngleSliderContext } from './use-angle-slider-context'
 
 export interface AngleSliderValueTextBaseProps extends PolymorphicProps {}
 export interface AngleSliderValueTextProps extends HTMLProps<'div'>, AngleSliderValueTextBaseProps {}
 
-export const AngleSliderValueText = forwardRef<HTMLDivElement, AngleSliderValueTextProps>((props, ref) => {
+export const AngleSliderValueText = ({ ref, ...props }: AngleSliderValueTextProps) => {
   const angleSlider = useAngleSliderContext()
   return (
     <ark.div {...props} ref={ref}>
       {props.children || angleSlider.valueAsDegree}
     </ark.div>
   )
-})
+}
 
 AngleSliderValueText.displayName = 'AngleSliderValueText'

--- a/packages/react/src/components/avatar/avatar-fallback.tsx
+++ b/packages/react/src/components/avatar/avatar-fallback.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useAvatarContext } from './use-avatar-context'
 
 export interface AvatarFallbackBaseProps extends PolymorphicProps {}
 export interface AvatarFallbackProps extends HTMLProps<'span'>, AvatarFallbackBaseProps {}
 
-export const AvatarFallback = forwardRef<HTMLSpanElement, AvatarFallbackProps>((props, ref) => {
+export const AvatarFallback = ({ ref, ...props }: AvatarFallbackProps) => {
   const avatar = useAvatarContext()
   const mergedProps = mergeProps(avatar.getFallbackProps(), props)
 
   return <ark.span {...mergedProps} ref={ref} />
-})
+}
 
 AvatarFallback.displayName = 'AvatarFallback'

--- a/packages/react/src/components/avatar/avatar-image.tsx
+++ b/packages/react/src/components/avatar/avatar-image.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useAvatarContext } from './use-avatar-context'
 
 export interface AvatarImageBaseProps extends PolymorphicProps {}
 export interface AvatarImageProps extends HTMLProps<'img'>, AvatarImageBaseProps {}
 
-export const AvatarImage = forwardRef<HTMLImageElement, AvatarImageProps>((props, ref) => {
+export const AvatarImage = ({ ref, ...props }: AvatarImageProps) => {
   const avatar = useAvatarContext()
   const mergedProps = mergeProps(avatar.getImageProps(), props)
 
   return <ark.img {...mergedProps} ref={ref} />
-})
+}
 
 AvatarImage.displayName = 'AvatarImage'

--- a/packages/react/src/components/avatar/avatar-root-provider.tsx
+++ b/packages/react/src/components/avatar/avatar-root-provider.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import type { UseAvatarReturn } from './use-avatar'
@@ -16,7 +15,7 @@ export interface AvatarRootProviderProps extends HTMLProps<'div'>, AvatarRootPro
 
 const splitRootProviderProps = createSplitProps<RootProviderProps>()
 
-export const AvatarRootProvider = forwardRef<HTMLDivElement, AvatarRootProviderProps>((props, ref) => {
+export const AvatarRootProvider = ({ ref, ...props }: AvatarRootProviderProps) => {
   const [{ value: avatar }, localProps] = splitRootProviderProps(props, ['value'])
   const mergedProps = mergeProps(avatar.getRootProps(), localProps)
 
@@ -25,6 +24,6 @@ export const AvatarRootProvider = forwardRef<HTMLDivElement, AvatarRootProviderP
       <ark.div {...mergedProps} ref={ref} />
     </AvatarProvider>
   )
-})
+}
 
 AvatarRootProvider.displayName = 'AvatarRootProvider'

--- a/packages/react/src/components/avatar/avatar-root.tsx
+++ b/packages/react/src/components/avatar/avatar-root.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { type UseAvatarProps, useAvatar } from './use-avatar'
@@ -12,7 +11,7 @@ export interface AvatarRootProps extends HTMLProps<'div'>, AvatarRootBaseProps {
 
 const splitRootProps = createSplitProps<UseAvatarProps>()
 
-export const AvatarRoot = forwardRef<HTMLDivElement, AvatarRootProps>((props, ref) => {
+export const AvatarRoot = ({ ref, ...props }: AvatarRootProps) => {
   const [useAvatarProps, localProps] = splitRootProps(props, ['id', 'ids', 'onStatusChange'])
   const avatar = useAvatar(useAvatarProps)
   const mergedProps = mergeProps(avatar.getRootProps(), localProps)
@@ -22,6 +21,6 @@ export const AvatarRoot = forwardRef<HTMLDivElement, AvatarRootProps>((props, re
       <ark.div {...mergedProps} ref={ref} />
     </AvatarProvider>
   )
-})
+}
 
 AvatarRoot.displayName = 'AvatarRoot'

--- a/packages/react/src/components/carousel/carousel-autoplay-indicator.tsx
+++ b/packages/react/src/components/carousel/carousel-autoplay-indicator.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { carouselAnatomy } from './carousel.anatomy'
 import { useCarouselContext } from './use-carousel-context'
@@ -15,7 +14,7 @@ export interface CarouselAutoplayIndicatorBaseProps extends PolymorphicProps {
 }
 export interface CarouselAutoplayIndicatorProps extends HTMLProps<'span'>, CarouselAutoplayIndicatorBaseProps {}
 
-export const CarouselAutoplayIndicator = forwardRef<HTMLSpanElement, CarouselAutoplayIndicatorProps>((props, ref) => {
+export const CarouselAutoplayIndicator = ({ ref, ...props }: CarouselAutoplayIndicatorProps) => {
   const { children, fallback, ...restProps } = props
   const carousel = useCarouselContext()
   return (
@@ -23,6 +22,6 @@ export const CarouselAutoplayIndicator = forwardRef<HTMLSpanElement, CarouselAut
       {carousel.isPlaying ? children : fallback}
     </ark.span>
   )
-})
+}
 
 CarouselAutoplayIndicator.displayName = 'CarouselAutoplayIndicator'

--- a/packages/react/src/components/carousel/carousel-autoplay-trigger.tsx
+++ b/packages/react/src/components/carousel/carousel-autoplay-trigger.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useCarouselContext } from './use-carousel-context'
 
 export interface CarouselAutoplayTriggerBaseProps extends PolymorphicProps {}
 export interface CarouselAutoplayTriggerProps extends HTMLProps<'button'>, CarouselAutoplayTriggerBaseProps {}
 
-export const CarouselAutoplayTrigger = forwardRef<HTMLButtonElement, CarouselAutoplayTriggerProps>((props, ref) => {
+export const CarouselAutoplayTrigger = ({ ref, ...props }: CarouselAutoplayTriggerProps) => {
   const carousel = useCarouselContext()
   const mergedProps = mergeProps(carousel.getAutoplayTriggerProps(), props)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 CarouselAutoplayTrigger.displayName = 'CarouselAutoplayTrigger'

--- a/packages/react/src/components/carousel/carousel-control.tsx
+++ b/packages/react/src/components/carousel/carousel-control.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useCarouselContext } from './use-carousel-context'
 
 export interface CarouselControlBaseProps extends PolymorphicProps {}
 export interface CarouselControlProps extends HTMLProps<'div'>, CarouselControlBaseProps {}
 
-export const CarouselControl = forwardRef<HTMLDivElement, CarouselControlProps>((props, ref) => {
+export const CarouselControl = ({ ref, ...props }: CarouselControlProps) => {
   const carousel = useCarouselContext()
   const mergedProps = mergeProps(carousel.getControlProps(), props)
 
   return <ark.div {...mergedProps} {...props} ref={ref} />
-})
+}
 
 CarouselControl.displayName = 'CarouselControl'

--- a/packages/react/src/components/carousel/carousel-indicator-group.tsx
+++ b/packages/react/src/components/carousel/carousel-indicator-group.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useCarouselContext } from './use-carousel-context'
 
 export interface CarouselIndicatorGroupBaseProps extends PolymorphicProps {}
 export interface CarouselIndicatorGroupProps extends HTMLProps<'div'>, CarouselIndicatorGroupBaseProps {}
 
-export const CarouselIndicatorGroup = forwardRef<HTMLDivElement, CarouselIndicatorGroupProps>((props, ref) => {
+export const CarouselIndicatorGroup = ({ ref, ...props }: CarouselIndicatorGroupProps) => {
   const carousel = useCarouselContext()
   const mergedProps = mergeProps(carousel.getIndicatorGroupProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 CarouselIndicatorGroup.displayName = 'CarouselIndicatorGroup'

--- a/packages/react/src/components/carousel/carousel-indicator.tsx
+++ b/packages/react/src/components/carousel/carousel-indicator.tsx
@@ -2,7 +2,6 @@
 
 import type { IndicatorProps } from '@zag-js/carousel'
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useCarouselContext } from './use-carousel-context'
@@ -12,13 +11,13 @@ export interface CarouselIndicatorProps extends HTMLProps<'button'>, CarouselInd
 
 const splitIndicatorProps = createSplitProps<IndicatorProps>()
 
-export const CarouselIndicator = forwardRef<HTMLButtonElement, CarouselIndicatorProps>((props, ref) => {
+export const CarouselIndicator = ({ ref, ...props }: CarouselIndicatorProps) => {
   const [indicatorProps, localProps] = splitIndicatorProps(props, ['readOnly', 'index'])
 
   const carousel = useCarouselContext()
   const mergedProps = mergeProps(carousel.getIndicatorProps(indicatorProps), localProps)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 CarouselIndicator.displayName = 'CarouselIndicator'

--- a/packages/react/src/components/carousel/carousel-item-group.tsx
+++ b/packages/react/src/components/carousel/carousel-item-group.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useCarouselContext } from './use-carousel-context'
 
 export interface CarouselItemGroupBaseProps extends PolymorphicProps {}
 export interface CarouselItemGroupProps extends HTMLProps<'div'>, CarouselItemGroupBaseProps {}
 
-export const CarouselItemGroup = forwardRef<HTMLDivElement, CarouselItemGroupProps>((props, ref) => {
+export const CarouselItemGroup = ({ ref, ...props }: CarouselItemGroupProps) => {
   const carousel = useCarouselContext()
   const mergedProps = mergeProps(carousel.getItemGroupProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 CarouselItemGroup.displayName = 'CarouselItemGroup'

--- a/packages/react/src/components/carousel/carousel-item.tsx
+++ b/packages/react/src/components/carousel/carousel-item.tsx
@@ -2,7 +2,6 @@
 
 import type { ItemProps } from '@zag-js/carousel'
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useCarouselContext } from './use-carousel-context'
@@ -12,12 +11,12 @@ export interface CarouselItemProps extends HTMLProps<'div'>, CarouselItemBasePro
 
 const splitItemProps = createSplitProps<ItemProps>()
 
-export const CarouselItem = forwardRef<HTMLDivElement, CarouselItemProps>((props, ref) => {
+export const CarouselItem = ({ ref, ...props }: CarouselItemProps) => {
   const [itemProps, localProps] = splitItemProps(props, ['index', 'snapAlign'])
   const carousel = useCarouselContext()
   const mergedProps = mergeProps(carousel.getItemProps(itemProps), localProps)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 CarouselItem.displayName = 'CarouselItem'

--- a/packages/react/src/components/carousel/carousel-next-trigger.tsx
+++ b/packages/react/src/components/carousel/carousel-next-trigger.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useCarouselContext } from './use-carousel-context'
 
 export interface CarouselNextTriggerBaseProps extends PolymorphicProps {}
 export interface CarouselNextTriggerProps extends HTMLProps<'button'>, CarouselNextTriggerBaseProps {}
 
-export const CarouselNextTrigger = forwardRef<HTMLButtonElement, CarouselNextTriggerProps>((props, ref) => {
+export const CarouselNextTrigger = ({ ref, ...props }: CarouselNextTriggerProps) => {
   const carousel = useCarouselContext()
   const mergedProps = mergeProps(carousel.getNextTriggerProps(), props)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 CarouselNextTrigger.displayName = 'CarouselNextTrigger'

--- a/packages/react/src/components/carousel/carousel-prev-trigger.tsx
+++ b/packages/react/src/components/carousel/carousel-prev-trigger.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useCarouselContext } from './use-carousel-context'
 
 export interface CarouselPrevTriggerBaseProps extends PolymorphicProps {}
 export interface CarouselPrevTriggerProps extends HTMLProps<'button'>, CarouselPrevTriggerBaseProps {}
 
-export const CarouselPrevTrigger = forwardRef<HTMLButtonElement, CarouselPrevTriggerProps>((props, ref) => {
+export const CarouselPrevTrigger = ({ ref, ...props }: CarouselPrevTriggerProps) => {
   const carousel = useCarouselContext()
   const mergedProps = mergeProps(carousel.getPrevTriggerProps(), props)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 CarouselPrevTrigger.displayName = 'CarouselPrevTrigger'

--- a/packages/react/src/components/carousel/carousel-progress-text.tsx
+++ b/packages/react/src/components/carousel/carousel-progress-text.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { forwardRef, useMemo } from 'react'
+import { useMemo } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { carouselAnatomy } from './carousel.anatomy'
 import { useCarouselContext } from './use-carousel-context'
@@ -10,7 +10,7 @@ const parts = carouselAnatomy.build()
 export interface CarouselProgressTextBaseProps extends PolymorphicProps {}
 export interface CarouselProgressTextProps extends HTMLProps<'span'>, CarouselProgressTextBaseProps {}
 
-export const CarouselProgressText = forwardRef<HTMLSpanElement, CarouselProgressTextProps>((props, ref) => {
+export const CarouselProgressText = ({ ref, ...props }: CarouselProgressTextProps) => {
   const carousel = useCarouselContext()
 
   const progressText = useMemo(() => {
@@ -24,6 +24,6 @@ export const CarouselProgressText = forwardRef<HTMLSpanElement, CarouselProgress
       {props.children || progressText}
     </ark.span>
   )
-})
+}
 
 CarouselProgressText.displayName = 'CarouselProgressText'

--- a/packages/react/src/components/carousel/carousel-root-provider.tsx
+++ b/packages/react/src/components/carousel/carousel-root-provider.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import type { UseCarouselReturn } from './use-carousel'
@@ -16,7 +15,7 @@ export interface CarouselRootProviderProps extends HTMLProps<'div'>, CarouselRoo
 
 const splitRootProviderProps = createSplitProps<RootProviderProps>()
 
-export const CarouselRootProvider = forwardRef<HTMLDivElement, CarouselRootProviderProps>((props, ref) => {
+export const CarouselRootProvider = ({ ref, ...props }: CarouselRootProviderProps) => {
   const [{ value: carousel }, localProps] = splitRootProviderProps(props, ['value'])
   const mergedProps = mergeProps(carousel.getRootProps(), localProps)
 
@@ -25,6 +24,6 @@ export const CarouselRootProvider = forwardRef<HTMLDivElement, CarouselRootProvi
       <ark.div {...mergedProps} ref={ref} />
     </CarouselProvider>
   )
-})
+}
 
 CarouselRootProvider.displayName = 'CarouselRootProvider'

--- a/packages/react/src/components/carousel/carousel-root.tsx
+++ b/packages/react/src/components/carousel/carousel-root.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { type UseCarouselProps, useCarousel } from './use-carousel'
@@ -12,7 +11,7 @@ export interface CarouselRootProps extends HTMLProps<'div'>, CarouselRootBasePro
 
 const splitRootProps = createSplitProps<UseCarouselProps>()
 
-export const CarouselRoot = forwardRef<HTMLDivElement, CarouselRootProps>((props, ref) => {
+export const CarouselRoot = ({ ref, ...props }: CarouselRootProps) => {
   const [useCarouselProps, localProps] = splitRootProps(props, [
     'allowMouseDrag',
     'autoplay',
@@ -43,6 +42,6 @@ export const CarouselRoot = forwardRef<HTMLDivElement, CarouselRootProps>((props
       <ark.div {...mergedProps} ref={ref} />
     </CarouselProvider>
   )
-})
+}
 
 CarouselRoot.displayName = 'CarouselRoot'

--- a/packages/react/src/components/checkbox/checkbox-control.tsx
+++ b/packages/react/src/components/checkbox/checkbox-control.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useCheckboxContext } from './use-checkbox-context'
 
 export interface CheckboxControlBaseProps extends PolymorphicProps {}
 export interface CheckboxControlProps extends HTMLProps<'div'>, CheckboxControlBaseProps {}
 
-export const CheckboxControl = forwardRef<HTMLDivElement, CheckboxControlProps>((props, ref) => {
+export const CheckboxControl = ({ ref, ...props }: CheckboxControlProps) => {
   const checkbox = useCheckboxContext()
   const mergedProps = mergeProps(checkbox.getControlProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 CheckboxControl.displayName = 'CheckboxControl'

--- a/packages/react/src/components/checkbox/checkbox-group-provider.tsx
+++ b/packages/react/src/components/checkbox/checkbox-group-provider.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { forwardRef } from 'react'
 import type { Assign } from '../../types'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -16,7 +15,7 @@ export interface CheckboxGroupProviderProps extends Assign<HTMLProps<'div'>, Che
 
 const splitProviderProps = createSplitProps<ProviderProps>()
 
-export const CheckboxGroupProvider = forwardRef<HTMLDivElement, CheckboxGroupProviderProps>((props, ref) => {
+export const CheckboxGroupProvider = ({ ref, ...props }: CheckboxGroupProviderProps) => {
   const [localProps, restProps] = splitProviderProps(props, ['value'])
 
   return (
@@ -24,6 +23,6 @@ export const CheckboxGroupProvider = forwardRef<HTMLDivElement, CheckboxGroupPro
       <ark.div ref={ref} role="group" {...restProps} {...checkboxAnatomy.build().group.attrs} />
     </CheckboxGroupContextProvider>
   )
-})
+}
 
 CheckboxGroupProvider.displayName = 'CheckboxGroupProvider'

--- a/packages/react/src/components/checkbox/checkbox-group.tsx
+++ b/packages/react/src/components/checkbox/checkbox-group.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { forwardRef } from 'react'
 import type { Assign } from '../../types'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -13,7 +12,7 @@ export interface CheckboxGroupProps extends Assign<HTMLProps<'div'>, CheckboxGro
 
 const splitGroupProps = createSplitProps<UseCheckboxGroupProps>()
 
-export const CheckboxGroup = forwardRef<HTMLDivElement, CheckboxGroupProps>((props, ref) => {
+export const CheckboxGroup = ({ ref, ...props }: CheckboxGroupProps) => {
   const [checkboxGroupProps, localProps] = splitGroupProps(props, [
     'defaultValue',
     'value',
@@ -32,6 +31,6 @@ export const CheckboxGroup = forwardRef<HTMLDivElement, CheckboxGroupProps>((pro
       <ark.div ref={ref} role="group" {...localProps} {...checkboxAnatomy.build().group.attrs} />
     </CheckboxGroupContextProvider>
   )
-})
+}
 
 CheckboxGroup.displayName = 'CheckboxGroup'

--- a/packages/react/src/components/checkbox/checkbox-hidden-input.tsx
+++ b/packages/react/src/components/checkbox/checkbox-hidden-input.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useFieldContext } from '../field'
 import { useCheckboxContext } from './use-checkbox-context'
@@ -9,12 +8,12 @@ import { useCheckboxContext } from './use-checkbox-context'
 export interface CheckboxHiddenInputBaseProps extends PolymorphicProps {}
 export interface CheckboxHiddenInputProps extends HTMLProps<'input'>, CheckboxHiddenInputBaseProps {}
 
-export const CheckboxHiddenInput = forwardRef<HTMLInputElement, CheckboxHiddenInputProps>((props, ref) => {
+export const CheckboxHiddenInput = ({ ref, ...props }: CheckboxHiddenInputProps) => {
   const checkbox = useCheckboxContext()
   const mergedProps = mergeProps(checkbox.getHiddenInputProps(), props)
   const field = useFieldContext()
 
   return <ark.input aria-describedby={field?.ariaDescribedby} {...mergedProps} ref={ref} />
-})
+}
 
 CheckboxHiddenInput.displayName = 'CheckboxHiddenInput'

--- a/packages/react/src/components/checkbox/checkbox-indicator.tsx
+++ b/packages/react/src/components/checkbox/checkbox-indicator.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useCheckboxContext } from './use-checkbox-context'
 
@@ -10,13 +9,13 @@ export interface CheckboxIndicatorBaseProps extends PolymorphicProps {
 }
 export interface CheckboxIndicatorProps extends HTMLProps<'div'>, CheckboxIndicatorBaseProps {}
 
-export const CheckboxIndicator = forwardRef<HTMLDivElement, CheckboxIndicatorProps>((props, ref) => {
+export const CheckboxIndicator = ({ ref, ...props }: CheckboxIndicatorProps) => {
   const { indeterminate, ...rest } = props
   const checkbox = useCheckboxContext()
   const mergedProps = mergeProps(checkbox.getIndicatorProps(), rest)
   const isVisible = indeterminate ? checkbox.indeterminate : checkbox.checked
 
   return <ark.div {...mergedProps} hidden={!isVisible} ref={ref} />
-})
+}
 
 CheckboxIndicator.displayName = 'CheckboxIndicator'

--- a/packages/react/src/components/checkbox/checkbox-label.tsx
+++ b/packages/react/src/components/checkbox/checkbox-label.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useCheckboxContext } from './use-checkbox-context'
 
 export interface CheckboxLabelBaseProps extends PolymorphicProps {}
 export interface CheckboxLabelProps extends HTMLProps<'span'>, CheckboxLabelBaseProps {}
 
-export const CheckboxLabel = forwardRef<HTMLSpanElement, CheckboxLabelProps>((props, ref) => {
+export const CheckboxLabel = ({ ref, ...props }: CheckboxLabelProps) => {
   const checkbox = useCheckboxContext()
   const mergedProps = mergeProps(checkbox.getLabelProps(), props)
 
   return <ark.span {...mergedProps} ref={ref} />
-})
+}
 
 CheckboxLabel.displayName = 'CheckboxLabel'

--- a/packages/react/src/components/checkbox/checkbox-root-provider.tsx
+++ b/packages/react/src/components/checkbox/checkbox-root-provider.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import type { UseCheckboxReturn } from './use-checkbox'
@@ -16,7 +15,7 @@ export interface CheckboxRootProviderProps extends HTMLProps<'label'>, CheckboxR
 
 const splitRootProviderProps = createSplitProps<RootProviderProps>()
 
-export const CheckboxRootProvider = forwardRef<HTMLLabelElement, CheckboxRootProviderProps>((props, ref) => {
+export const CheckboxRootProvider = ({ ref, ...props }: CheckboxRootProviderProps) => {
   const [{ value: checkbox }, localProps] = splitRootProviderProps(props, ['value'])
   const mergedProps = mergeProps(checkbox.getRootProps(), localProps)
 
@@ -25,6 +24,6 @@ export const CheckboxRootProvider = forwardRef<HTMLLabelElement, CheckboxRootPro
       <ark.label {...mergedProps} ref={ref} />
     </CheckboxProvider>
   )
-})
+}
 
 CheckboxRootProvider.displayName = 'CheckboxRootProvider'

--- a/packages/react/src/components/checkbox/checkbox-root.tsx
+++ b/packages/react/src/components/checkbox/checkbox-root.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import type { Assign } from '../../types'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -13,7 +12,7 @@ export interface CheckboxRootProps extends Assign<HTMLProps<'label'>, CheckboxRo
 
 const splitRootProps = createSplitProps<UseCheckboxProps>()
 
-export const CheckboxRoot = forwardRef<HTMLLabelElement, CheckboxRootProps>((props, ref) => {
+export const CheckboxRoot = ({ ref, ...props }: CheckboxRootProps) => {
   const [useCheckboxProps, localProps] = splitRootProps(props, [
     'checked',
     'defaultChecked',
@@ -36,6 +35,6 @@ export const CheckboxRoot = forwardRef<HTMLLabelElement, CheckboxRootProps>((pro
       <ark.label {...mergedProps} ref={ref} />
     </CheckboxProvider>
   )
-})
+}
 
 CheckboxRoot.displayName = 'CheckboxRoot'

--- a/packages/react/src/components/clipboard/clipboard-control.tsx
+++ b/packages/react/src/components/clipboard/clipboard-control.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useClipboardContext } from './use-clipboard-context'
 
 export interface ClipboardControlBaseProps extends PolymorphicProps {}
 export interface ClipboardControlProps extends HTMLProps<'div'>, ClipboardControlBaseProps {}
 
-export const ClipboardControl = forwardRef<HTMLDivElement, ClipboardControlProps>((props, ref) => {
+export const ClipboardControl = ({ ref, ...props }: ClipboardControlProps) => {
   const clipboard = useClipboardContext()
   const mergedProps = mergeProps(clipboard.getControlProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 ClipboardControl.displayName = 'ClipboardControl'

--- a/packages/react/src/components/clipboard/clipboard-indicator.tsx
+++ b/packages/react/src/components/clipboard/clipboard-indicator.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { type ReactNode, forwardRef } from 'react'
+import type { ReactNode } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useClipboardContext } from './use-clipboard-context'
 
@@ -10,7 +10,7 @@ export interface ClipboardIndicatorBaseProps extends PolymorphicProps {
 }
 export interface ClipboardIndicatorProps extends HTMLProps<'div'>, ClipboardIndicatorBaseProps {}
 
-export const ClipboardIndicator = forwardRef<HTMLDivElement, ClipboardIndicatorProps>((props, ref) => {
+export const ClipboardIndicator = ({ ref, ...props }: ClipboardIndicatorProps) => {
   const { children, copied, ...localProps } = props
   const clipboard = useClipboardContext()
   const mergedProps = mergeProps(clipboard.getIndicatorProps({ copied: clipboard.copied }), localProps)
@@ -20,6 +20,6 @@ export const ClipboardIndicator = forwardRef<HTMLDivElement, ClipboardIndicatorP
       {clipboard.copied ? copied : children}
     </ark.div>
   )
-})
+}
 
 ClipboardIndicator.displayName = 'ClipboardIndicator'

--- a/packages/react/src/components/clipboard/clipboard-input.tsx
+++ b/packages/react/src/components/clipboard/clipboard-input.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useClipboardContext } from './use-clipboard-context'
 
 export interface ClipboardInputBaseProps extends PolymorphicProps {}
 export interface ClipboardInputProps extends HTMLProps<'input'>, ClipboardInputBaseProps {}
 
-export const ClipboardInput = forwardRef<HTMLInputElement, ClipboardInputProps>((props, ref) => {
+export const ClipboardInput = ({ ref, ...props }: ClipboardInputProps) => {
   const clipboard = useClipboardContext()
   const mergedProps = mergeProps(clipboard.getInputProps(), props)
 
   return <ark.input {...mergedProps} ref={ref} />
-})
+}
 
 ClipboardInput.displayName = 'ClipboardInput'

--- a/packages/react/src/components/clipboard/clipboard-label.tsx
+++ b/packages/react/src/components/clipboard/clipboard-label.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useClipboardContext } from './use-clipboard-context'
 
 export interface ClipboardLabelBaseProps extends PolymorphicProps {}
 export interface ClipboardLabelProps extends HTMLProps<'label'>, ClipboardLabelBaseProps {}
 
-export const ClipboardLabel = forwardRef<HTMLLabelElement, ClipboardLabelProps>((props, ref) => {
+export const ClipboardLabel = ({ ref, ...props }: ClipboardLabelProps) => {
   const clipboard = useClipboardContext()
   const mergedProps = mergeProps(clipboard.getLabelProps(), props)
 
   return <ark.label {...mergedProps} ref={ref} />
-})
+}
 
 ClipboardLabel.displayName = 'ClipboardLabel'

--- a/packages/react/src/components/clipboard/clipboard-root-provider.tsx
+++ b/packages/react/src/components/clipboard/clipboard-root-provider.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import type { UseClipboardReturn } from './use-clipboard'
@@ -16,7 +15,7 @@ export interface ClipboardRootProviderProps extends HTMLProps<'div'>, ClipboardR
 
 const splitRootProviderProps = createSplitProps<RootProviderProps>()
 
-export const ClipboardRootProvider = forwardRef<HTMLDivElement, ClipboardRootProviderProps>((props, ref) => {
+export const ClipboardRootProvider = ({ ref, ...props }: ClipboardRootProviderProps) => {
   const [{ value: clipboard }, localProps] = splitRootProviderProps(props, ['value'])
   const mergedProps = mergeProps(clipboard.getRootProps(), localProps)
 
@@ -25,6 +24,6 @@ export const ClipboardRootProvider = forwardRef<HTMLDivElement, ClipboardRootPro
       <ark.div ref={ref} {...mergedProps} />
     </ClipboardProvider>
   )
-})
+}
 
 ClipboardRootProvider.displayName = 'ClipboardRootProvider'

--- a/packages/react/src/components/clipboard/clipboard-root.tsx
+++ b/packages/react/src/components/clipboard/clipboard-root.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import type { Assign } from '../../types'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -13,7 +12,7 @@ export interface ClipboardRootProps extends Assign<HTMLProps<'div'>, ClipboardRo
 
 const splitRootProps = createSplitProps<UseClipboardProps>()
 
-export const ClipboardRoot = forwardRef<HTMLDivElement, ClipboardRootProps>((props, ref) => {
+export const ClipboardRoot = ({ ref, ...props }: ClipboardRootProps) => {
   const [useClipboardProps, localProps] = splitRootProps(props, [
     'defaultValue',
     'id',
@@ -32,6 +31,6 @@ export const ClipboardRoot = forwardRef<HTMLDivElement, ClipboardRootProps>((pro
       <ark.div ref={ref} {...mergedProps} />
     </ClipboardProvider>
   )
-})
+}
 
 ClipboardRoot.displayName = 'ClipboardRoot'

--- a/packages/react/src/components/clipboard/clipboard-trigger.tsx
+++ b/packages/react/src/components/clipboard/clipboard-trigger.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useClipboardContext } from './use-clipboard-context'
 
 export interface ClipboardTriggerBaseProps extends PolymorphicProps {}
 export interface ClipboardTriggerProps extends HTMLProps<'button'>, ClipboardTriggerBaseProps {}
 
-export const ClipboardTrigger = forwardRef<HTMLButtonElement, ClipboardTriggerProps>((props, ref) => {
+export const ClipboardTrigger = ({ ref, ...props }: ClipboardTriggerProps) => {
   const clipboard = useClipboardContext()
   const mergedProps = mergeProps(clipboard.getTriggerProps(), props)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 ClipboardTrigger.displayName = 'ClipboardTrigger'

--- a/packages/react/src/components/clipboard/clipboard-value-text.tsx
+++ b/packages/react/src/components/clipboard/clipboard-value-text.tsx
@@ -1,19 +1,18 @@
 'use client'
 
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useClipboardContext } from './use-clipboard-context'
 
 export interface ClipboardValueTextBaseProps extends PolymorphicProps {}
 export interface ClipboardValueTextProps extends HTMLProps<'span'>, ClipboardValueTextBaseProps {}
 
-export const ClipboardValueText = forwardRef<HTMLDivElement, ClipboardValueTextProps>((props, ref) => {
+export const ClipboardValueText = ({ ref, ...props }: ClipboardValueTextProps) => {
   const clipboard = useClipboardContext()
   return (
     <ark.span {...props} ref={ref}>
       {props.children || clipboard.value}
     </ark.span>
   )
-})
+}
 
 ClipboardValueText.displayName = 'ClipboardValueText'

--- a/packages/react/src/components/collapsible/collapsible-content.tsx
+++ b/packages/react/src/components/collapsible/collapsible-content.tsx
@@ -1,14 +1,13 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useCollapsibleContext } from './use-collapsible-context'
 
 export interface CollapsibleContentBaseProps extends PolymorphicProps {}
 export interface CollapsibleContentProps extends HTMLProps<'div'>, CollapsibleContentBaseProps {}
 
-export const CollapsibleContent = forwardRef<HTMLDivElement, CollapsibleContentProps>((props, ref) => {
+export const CollapsibleContent = ({ ref, ...props }: CollapsibleContentProps) => {
   const collapsible = useCollapsibleContext()
 
   if (collapsible.isUnmounted) {
@@ -17,6 +16,6 @@ export const CollapsibleContent = forwardRef<HTMLDivElement, CollapsibleContentP
 
   const mergedProps = mergeProps(collapsible.getContentProps(), props)
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 CollapsibleContent.displayName = 'CollapsibleContent'

--- a/packages/react/src/components/collapsible/collapsible-indicator.tsx
+++ b/packages/react/src/components/collapsible/collapsible-indicator.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useCollapsibleContext } from './use-collapsible-context'
 
 export interface CollapsibleIndicatorBaseProps extends PolymorphicProps {}
 export interface CollapsibleIndicatorProps extends HTMLProps<'div'>, CollapsibleIndicatorBaseProps {}
 
-export const CollapsibleIndicator = forwardRef<HTMLDivElement, CollapsibleIndicatorProps>((props, ref) => {
+export const CollapsibleIndicator = ({ ref, ...props }: CollapsibleIndicatorProps) => {
   const collapsible = useCollapsibleContext()
   const mergedProps = mergeProps(collapsible.getIndicatorProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 CollapsibleIndicator.displayName = 'CollapsibleIndicator'

--- a/packages/react/src/components/collapsible/collapsible-root-provider.tsx
+++ b/packages/react/src/components/collapsible/collapsible-root-provider.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import type { UseCollapsibleReturn } from './use-collapsible'
@@ -16,7 +15,7 @@ export interface CollapsibleRootProviderProps extends HTMLProps<'div'>, Collapsi
 
 const splitRootProviderProps = createSplitProps<RootProviderProps>()
 
-export const CollapsibleRootProvider = forwardRef<HTMLDivElement, CollapsibleRootProviderProps>((props, ref) => {
+export const CollapsibleRootProvider = ({ ref, ...props }: CollapsibleRootProviderProps) => {
   const [{ value: collapsible }, localProps] = splitRootProviderProps(props, ['value'])
   const mergedProps = mergeProps(collapsible.getRootProps(), localProps)
 
@@ -25,6 +24,6 @@ export const CollapsibleRootProvider = forwardRef<HTMLDivElement, CollapsibleRoo
       <ark.div {...mergedProps} ref={ref} />
     </CollapsibleProvider>
   )
-})
+}
 
 CollapsibleRootProvider.displayName = 'CollapsibleRootProvider'

--- a/packages/react/src/components/collapsible/collapsible-root.tsx
+++ b/packages/react/src/components/collapsible/collapsible-root.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { splitCollapsibleProps } from './split-collapsible-props'
 import { type UseCollapsibleProps, useCollapsible } from './use-collapsible'
@@ -10,7 +9,7 @@ import { CollapsibleProvider } from './use-collapsible-context'
 export interface CollapsibleRootBaseProps extends UseCollapsibleProps, PolymorphicProps {}
 export interface CollapsibleRootProps extends HTMLProps<'div'>, CollapsibleRootBaseProps {}
 
-export const CollapsibleRoot = forwardRef<HTMLDivElement, CollapsibleRootProps>((props, ref) => {
+export const CollapsibleRoot = ({ ref, ...props }: CollapsibleRootProps) => {
   const [useCollapsibleProps, localProps] = splitCollapsibleProps(props)
   const collapsible = useCollapsible(useCollapsibleProps)
   const mergedProps = mergeProps(collapsible.getRootProps(), localProps)
@@ -20,6 +19,6 @@ export const CollapsibleRoot = forwardRef<HTMLDivElement, CollapsibleRootProps>(
       <ark.div {...mergedProps} ref={ref} />
     </CollapsibleProvider>
   )
-})
+}
 
 CollapsibleRoot.displayName = 'CollapsibleRoot'

--- a/packages/react/src/components/collapsible/collapsible-trigger.tsx
+++ b/packages/react/src/components/collapsible/collapsible-trigger.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useCollapsibleContext } from './use-collapsible-context'
 
 export interface CollapsibleTriggerBaseProps extends PolymorphicProps {}
 export interface CollapsibleTriggerProps extends HTMLProps<'button'>, CollapsibleTriggerBaseProps {}
 
-export const CollapsibleTrigger = forwardRef<HTMLButtonElement, CollapsibleTriggerProps>((props, ref) => {
+export const CollapsibleTrigger = ({ ref, ...props }: CollapsibleTriggerProps) => {
   const collapsible = useCollapsibleContext()
   const mergedProps = mergeProps(collapsible.getTriggerProps(), props)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 CollapsibleTrigger.displayName = 'CollapsibleTrigger'

--- a/packages/react/src/components/color-picker/color-picker-area-background.tsx
+++ b/packages/react/src/components/color-picker/color-picker-area-background.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useColorPickerAreaPropsContext } from './use-color-picker-area-props-context'
 import { useColorPickerContext } from './use-color-picker-context'
@@ -9,12 +8,12 @@ import { useColorPickerContext } from './use-color-picker-context'
 export interface ColorPickerAreaBackgroundBaseProps extends PolymorphicProps {}
 export interface ColorPickerAreaBackgroundProps extends HTMLProps<'div'>, ColorPickerAreaBackgroundBaseProps {}
 
-export const ColorPickerAreaBackground = forwardRef<HTMLDivElement, ColorPickerAreaBackgroundProps>((props, ref) => {
+export const ColorPickerAreaBackground = ({ ref, ...props }: ColorPickerAreaBackgroundProps) => {
   const colorPicker = useColorPickerContext()
   const areaProps = useColorPickerAreaPropsContext()
   const mergedProps = mergeProps(colorPicker.getAreaBackgroundProps(areaProps), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 ColorPickerAreaBackground.displayName = 'ColorPickerAreaBackground'

--- a/packages/react/src/components/color-picker/color-picker-area-thumb.tsx
+++ b/packages/react/src/components/color-picker/color-picker-area-thumb.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useColorPickerAreaPropsContext } from './use-color-picker-area-props-context'
 import { useColorPickerContext } from './use-color-picker-context'
@@ -9,12 +8,12 @@ import { useColorPickerContext } from './use-color-picker-context'
 export interface ColorPickerAreaThumbBaseProps extends PolymorphicProps {}
 export interface ColorPickerAreaThumbProps extends HTMLProps<'div'>, ColorPickerAreaThumbBaseProps {}
 
-export const ColorPickerAreaThumb = forwardRef<HTMLDivElement, ColorPickerAreaThumbProps>((props, ref) => {
+export const ColorPickerAreaThumb = ({ ref, ...props }: ColorPickerAreaThumbProps) => {
   const colorPicker = useColorPickerContext()
   const areaProps = useColorPickerAreaPropsContext()
   const mergedProps = mergeProps(colorPicker.getAreaThumbProps(areaProps), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 ColorPickerAreaThumb.displayName = 'ColorPickerAreaThumb'

--- a/packages/react/src/components/color-picker/color-picker-area.tsx
+++ b/packages/react/src/components/color-picker/color-picker-area.tsx
@@ -2,7 +2,6 @@
 
 import type { AreaProps } from '@zag-js/color-picker'
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { ColorPickerAreaPropsProvider } from './use-color-picker-area-props-context'
@@ -13,7 +12,7 @@ export interface ColorPickerAreaProps extends HTMLProps<'div'>, ColorPickerAreaB
 
 const splitAreaProps = createSplitProps<AreaProps>()
 
-export const ColorPickerArea = forwardRef<HTMLDivElement, ColorPickerAreaProps>((props, ref) => {
+export const ColorPickerArea = ({ ref, ...props }: ColorPickerAreaProps) => {
   const [areaProps, localProps] = splitAreaProps(props, ['xChannel', 'yChannel'])
   const colorPicker = useColorPickerContext()
   const mergedProps = mergeProps(colorPicker.getAreaProps(areaProps), localProps)
@@ -23,6 +22,6 @@ export const ColorPickerArea = forwardRef<HTMLDivElement, ColorPickerAreaProps>(
       <ark.div {...mergedProps} ref={ref} />
     </ColorPickerAreaPropsProvider>
   )
-})
+}
 
 ColorPickerArea.displayName = 'ColorPickerArea'

--- a/packages/react/src/components/color-picker/color-picker-channel-input.tsx
+++ b/packages/react/src/components/color-picker/color-picker-channel-input.tsx
@@ -2,7 +2,6 @@
 
 import type { ChannelInputProps } from '@zag-js/color-picker'
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useColorPickerContext } from './use-color-picker-context'
@@ -12,12 +11,12 @@ export interface ColorPickerChannelInputProps extends HTMLProps<'input'>, ColorP
 
 const splitChannelInputProps = createSplitProps<ChannelInputProps>()
 
-export const ColorPickerChannelInput = forwardRef<HTMLInputElement, ColorPickerChannelInputProps>((props, ref) => {
+export const ColorPickerChannelInput = ({ ref, ...props }: ColorPickerChannelInputProps) => {
   const [channelProps, localProps] = splitChannelInputProps(props, ['channel', 'orientation'])
   const colorPicker = useColorPickerContext()
   const mergedProps = mergeProps(colorPicker.getChannelInputProps(channelProps), localProps)
 
   return <ark.input {...mergedProps} ref={ref} />
-})
+}
 
 ColorPickerChannelInput.displayName = 'ColorPickerChannelInput'

--- a/packages/react/src/components/color-picker/color-picker-channel-slider-label.tsx
+++ b/packages/react/src/components/color-picker/color-picker-channel-slider-label.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useColorPickerChannelPropsContext } from './use-color-picker-channel-props-context'
 import { useColorPickerContext } from './use-color-picker-context'
@@ -10,14 +9,12 @@ export interface ColorPickerChannelSliderLabelBaseProps extends PolymorphicProps
 export interface ColorPickerChannelSliderLabelProps
   extends HTMLProps<'label'>, ColorPickerChannelSliderLabelBaseProps {}
 
-export const ColorPickerChannelSliderLabel = forwardRef<HTMLLabelElement, ColorPickerChannelSliderLabelProps>(
-  (props, ref) => {
-    const colorPicker = useColorPickerContext()
-    const channelProps = useColorPickerChannelPropsContext()
-    const mergedProps = mergeProps(colorPicker.getChannelSliderLabelProps(channelProps), props)
+export const ColorPickerChannelSliderLabel = ({ ref, ...props }: ColorPickerChannelSliderLabelProps) => {
+  const colorPicker = useColorPickerContext()
+  const channelProps = useColorPickerChannelPropsContext()
+  const mergedProps = mergeProps(colorPicker.getChannelSliderLabelProps(channelProps), props)
 
-    return <ark.label {...mergedProps} ref={ref} />
-  },
-)
+  return <ark.label {...mergedProps} ref={ref} />
+}
 
 ColorPickerChannelSliderLabel.displayName = 'ColorPickerChannelSliderLabel'

--- a/packages/react/src/components/color-picker/color-picker-channel-slider-thumb.tsx
+++ b/packages/react/src/components/color-picker/color-picker-channel-slider-thumb.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useColorPickerChannelPropsContext } from './use-color-picker-channel-props-context'
 import { useColorPickerContext } from './use-color-picker-context'
@@ -10,18 +9,16 @@ import { useColorPickerFormatPropsContext } from './use-color-picker-format-cont
 export interface ColorPickerChannelSliderThumbBaseProps extends PolymorphicProps {}
 export interface ColorPickerChannelSliderThumbProps extends HTMLProps<'div'>, ColorPickerChannelSliderThumbBaseProps {}
 
-export const ColorPickerChannelSliderThumb = forwardRef<HTMLDivElement, ColorPickerChannelSliderThumbProps>(
-  (props, ref) => {
-    const colorPicker = useColorPickerContext()
+export const ColorPickerChannelSliderThumb = ({ ref, ...props }: ColorPickerChannelSliderThumbProps) => {
+  const colorPicker = useColorPickerContext()
 
-    const channelProps = useColorPickerChannelPropsContext()
-    const formatProps = useColorPickerFormatPropsContext()
-    const channelSliderProps = { ...channelProps, ...formatProps }
+  const channelProps = useColorPickerChannelPropsContext()
+  const formatProps = useColorPickerFormatPropsContext()
+  const channelSliderProps = { ...channelProps, ...formatProps }
 
-    const mergedProps = mergeProps(colorPicker.getChannelSliderThumbProps(channelSliderProps), props)
+  const mergedProps = mergeProps(colorPicker.getChannelSliderThumbProps(channelSliderProps), props)
 
-    return <ark.div {...mergedProps} ref={ref} />
-  },
-)
+  return <ark.div {...mergedProps} ref={ref} />
+}
 
 ColorPickerChannelSliderThumb.displayName = 'ColorPickerChannelSliderThumb'

--- a/packages/react/src/components/color-picker/color-picker-channel-slider-track.tsx
+++ b/packages/react/src/components/color-picker/color-picker-channel-slider-track.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useColorPickerChannelPropsContext } from './use-color-picker-channel-props-context'
 import { useColorPickerContext } from './use-color-picker-context'
@@ -10,18 +9,16 @@ import { useColorPickerFormatPropsContext } from './use-color-picker-format-cont
 export interface ColorPickerChannelSliderTrackBaseProps extends PolymorphicProps {}
 export interface ColorPickerChannelSliderTrackProps extends HTMLProps<'div'>, ColorPickerChannelSliderTrackBaseProps {}
 
-export const ColorPickerChannelSliderTrack = forwardRef<HTMLDivElement, ColorPickerChannelSliderTrackProps>(
-  (props, ref) => {
-    const colorPicker = useColorPickerContext()
+export const ColorPickerChannelSliderTrack = ({ ref, ...props }: ColorPickerChannelSliderTrackProps) => {
+  const colorPicker = useColorPickerContext()
 
-    const channelProps = useColorPickerChannelPropsContext()
-    const formatProps = useColorPickerFormatPropsContext()
-    const channelSliderProps = { ...channelProps, ...formatProps }
+  const channelProps = useColorPickerChannelPropsContext()
+  const formatProps = useColorPickerFormatPropsContext()
+  const channelSliderProps = { ...channelProps, ...formatProps }
 
-    const mergedProps = mergeProps(colorPicker.getChannelSliderTrackProps(channelSliderProps), props)
+  const mergedProps = mergeProps(colorPicker.getChannelSliderTrackProps(channelSliderProps), props)
 
-    return <ark.div {...mergedProps} ref={ref} />
-  },
-)
+  return <ark.div {...mergedProps} ref={ref} />
+}
 
 ColorPickerChannelSliderTrack.displayName = 'ColorPickerChannelSliderTrack'

--- a/packages/react/src/components/color-picker/color-picker-channel-slider-value-text.tsx
+++ b/packages/react/src/components/color-picker/color-picker-channel-slider-value-text.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { useLocaleContext } from '../../providers'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useColorPickerChannelPropsContext } from './use-color-picker-channel-props-context'
@@ -11,19 +10,17 @@ export interface ColorPickerChannelSliderValueTextBaseProps extends PolymorphicP
 export interface ColorPickerChannelSliderValueTextProps
   extends HTMLProps<'span'>, ColorPickerChannelSliderValueTextBaseProps {}
 
-export const ColorPickerChannelSliderValueText = forwardRef<HTMLSpanElement, ColorPickerChannelSliderValueTextProps>(
-  (props, ref) => {
-    const { locale } = useLocaleContext()
-    const colorPicker = useColorPickerContext()
-    const channelProps = useColorPickerChannelPropsContext()
-    const mergedProps = mergeProps(colorPicker.getChannelSliderValueTextProps(channelProps), props)
+export const ColorPickerChannelSliderValueText = ({ ref, ...props }: ColorPickerChannelSliderValueTextProps) => {
+  const { locale } = useLocaleContext()
+  const colorPicker = useColorPickerContext()
+  const channelProps = useColorPickerChannelPropsContext()
+  const mergedProps = mergeProps(colorPicker.getChannelSliderValueTextProps(channelProps), props)
 
-    return (
-      <ark.span {...mergedProps} ref={ref}>
-        {props.children || colorPicker.getChannelValueText(channelProps.channel, locale)}
-      </ark.span>
-    )
-  },
-)
+  return (
+    <ark.span {...mergedProps} ref={ref}>
+      {props.children || colorPicker.getChannelValueText(channelProps.channel, locale)}
+    </ark.span>
+  )
+}
 
 ColorPickerChannelSliderValueText.displayName = 'ColorPickerChannelSliderValueText'

--- a/packages/react/src/components/color-picker/color-picker-channel-slider.tsx
+++ b/packages/react/src/components/color-picker/color-picker-channel-slider.tsx
@@ -2,7 +2,6 @@
 
 import type { ChannelProps } from '@zag-js/color-picker'
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { ColorPickerChannelPropsProvider } from './use-color-picker-channel-props-context'
@@ -14,7 +13,7 @@ export interface ColorPickerChannelSliderProps extends HTMLProps<'div'>, ColorPi
 
 const splitChannelProps = createSplitProps<ChannelProps>()
 
-export const ColorPickerChannelSlider = forwardRef<HTMLDivElement, ColorPickerChannelSliderProps>((props, ref) => {
+export const ColorPickerChannelSlider = ({ ref, ...props }: ColorPickerChannelSliderProps) => {
   const [channelProps, localProps] = splitChannelProps(props, ['channel', 'orientation'])
 
   const colorPicker = useColorPickerContext()
@@ -29,6 +28,6 @@ export const ColorPickerChannelSlider = forwardRef<HTMLDivElement, ColorPickerCh
       <ark.div {...mergedProps} ref={ref} />
     </ColorPickerChannelPropsProvider>
   )
-})
+}
 
 ColorPickerChannelSlider.displayName = 'ColorPickerChannelSlider'

--- a/packages/react/src/components/color-picker/color-picker-content.tsx
+++ b/packages/react/src/components/color-picker/color-picker-content.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { composeRefs } from '../../utils/compose-refs'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { usePresenceContext } from '../presence'
@@ -10,7 +9,7 @@ import { useColorPickerContext } from './use-color-picker-context'
 export interface ColorPickerContentBaseProps extends PolymorphicProps {}
 export interface ColorPickerContentProps extends HTMLProps<'div'>, ColorPickerContentBaseProps {}
 
-export const ColorPickerContent = forwardRef<HTMLDivElement, ColorPickerContentProps>((props, ref) => {
+export const ColorPickerContent = ({ ref, ...props }: ColorPickerContentProps) => {
   const colorPicker = useColorPickerContext()
   const presence = usePresenceContext()
   const mergedProps = mergeProps(colorPicker.getContentProps(), presence.getPresenceProps(), props)
@@ -20,6 +19,6 @@ export const ColorPickerContent = forwardRef<HTMLDivElement, ColorPickerContentP
   }
 
   return <ark.div {...mergedProps} ref={composeRefs(presence.ref, ref)} />
-})
+}
 
 ColorPickerContent.displayName = 'ColorPickerContent'

--- a/packages/react/src/components/color-picker/color-picker-control.tsx
+++ b/packages/react/src/components/color-picker/color-picker-control.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useColorPickerContext } from './use-color-picker-context'
 
 export interface ColorPickerControlBaseProps extends PolymorphicProps {}
 export interface ColorPickerControlProps extends HTMLProps<'div'>, ColorPickerControlBaseProps {}
 
-export const ColorPickerControl = forwardRef<HTMLDivElement, ColorPickerControlProps>((props, ref) => {
+export const ColorPickerControl = ({ ref, ...props }: ColorPickerControlProps) => {
   const colorPicker = useColorPickerContext()
   const mergedProps = mergeProps(colorPicker.getControlProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 ColorPickerControl.displayName = 'ColorPickerControl'

--- a/packages/react/src/components/color-picker/color-picker-eye-dropper-trigger.tsx
+++ b/packages/react/src/components/color-picker/color-picker-eye-dropper-trigger.tsx
@@ -1,20 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useColorPickerContext } from './use-color-picker-context'
 
 export interface ColorPickerEyeDropperTriggerBaseProps extends PolymorphicProps {}
 export interface ColorPickerEyeDropperTriggerProps extends HTMLProps<'button'>, ColorPickerEyeDropperTriggerBaseProps {}
 
-export const ColorPickerEyeDropperTrigger = forwardRef<HTMLButtonElement, ColorPickerEyeDropperTriggerProps>(
-  (props, ref) => {
-    const colorPicker = useColorPickerContext()
-    const mergedProps = mergeProps(colorPicker.getEyeDropperTriggerProps(), props)
+export const ColorPickerEyeDropperTrigger = ({ ref, ...props }: ColorPickerEyeDropperTriggerProps) => {
+  const colorPicker = useColorPickerContext()
+  const mergedProps = mergeProps(colorPicker.getEyeDropperTriggerProps(), props)
 
-    return <ark.button {...mergedProps} ref={ref} />
-  },
-)
+  return <ark.button {...mergedProps} ref={ref} />
+}
 
 ColorPickerEyeDropperTrigger.displayName = 'ColorPickerEyeDropperTrigger'

--- a/packages/react/src/components/color-picker/color-picker-format-select.tsx
+++ b/packages/react/src/components/color-picker/color-picker-format-select.tsx
@@ -1,14 +1,13 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useColorPickerContext } from './use-color-picker-context'
 
 export interface ColorPickerFormatSelectBaseProps extends PolymorphicProps {}
 export interface ColorPickerFormatSelectProps extends HTMLProps<'select'>, ColorPickerFormatSelectBaseProps {}
 
-export const ColorPickerFormatSelect = forwardRef<HTMLSelectElement, ColorPickerFormatSelectProps>((props, ref) => {
+export const ColorPickerFormatSelect = ({ ref, ...props }: ColorPickerFormatSelectProps) => {
   const colorPicker = useColorPickerContext()
   const mergedProps = mergeProps(colorPicker.getFormatSelectProps(), props)
 
@@ -21,6 +20,6 @@ export const ColorPickerFormatSelect = forwardRef<HTMLSelectElement, ColorPicker
       ))}
     </ark.select>
   )
-})
+}
 
 ColorPickerFormatSelect.displayName = 'ColorPickerFormatSelect'

--- a/packages/react/src/components/color-picker/color-picker-format-trigger.tsx
+++ b/packages/react/src/components/color-picker/color-picker-format-trigger.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useColorPickerContext } from './use-color-picker-context'
 
 export interface ColorPickerFormatTriggerBaseProps extends PolymorphicProps {}
 export interface ColorPickerFormatTriggerProps extends HTMLProps<'button'>, ColorPickerFormatTriggerBaseProps {}
 
-export const ColorPickerFormatTrigger = forwardRef<HTMLButtonElement, ColorPickerFormatTriggerProps>((props, ref) => {
+export const ColorPickerFormatTrigger = ({ ref, ...props }: ColorPickerFormatTriggerProps) => {
   const colorPicker = useColorPickerContext()
   const mergedProps = mergeProps(colorPicker.getFormatTriggerProps(), props)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 ColorPickerFormatTrigger.displayName = 'ColorPickerFormatTrigger'

--- a/packages/react/src/components/color-picker/color-picker-hidden-input.tsx
+++ b/packages/react/src/components/color-picker/color-picker-hidden-input.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useFieldContext } from '../field'
 import { useColorPickerContext } from './use-color-picker-context'
@@ -9,12 +8,12 @@ import { useColorPickerContext } from './use-color-picker-context'
 export interface ColorPickerHiddenInputBaseProps extends PolymorphicProps {}
 export interface ColorPickerHiddenInputProps extends HTMLProps<'input'>, ColorPickerHiddenInputBaseProps {}
 
-export const ColorPickerHiddenInput = forwardRef<HTMLInputElement, ColorPickerHiddenInputProps>((props, ref) => {
+export const ColorPickerHiddenInput = ({ ref, ...props }: ColorPickerHiddenInputProps) => {
   const colorPicker = useColorPickerContext()
   const mergedProps = mergeProps(colorPicker.getHiddenInputProps(), props)
   const field = useFieldContext()
 
   return <ark.input aria-describedby={field?.ariaDescribedby} {...mergedProps} ref={ref} />
-})
+}
 
 ColorPickerHiddenInput.displayName = 'ColorPickerHiddenInput'

--- a/packages/react/src/components/color-picker/color-picker-label.tsx
+++ b/packages/react/src/components/color-picker/color-picker-label.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useColorPickerContext } from './use-color-picker-context'
 
 export interface ColorPickerLabelBaseProps extends PolymorphicProps {}
 export interface ColorPickerLabelProps extends HTMLProps<'label'>, ColorPickerLabelBaseProps {}
 
-export const ColorPickerLabel = forwardRef<HTMLLabelElement, ColorPickerLabelProps>((props, ref) => {
+export const ColorPickerLabel = ({ ref, ...props }: ColorPickerLabelProps) => {
   const colorPicker = useColorPickerContext()
   const mergedProps = mergeProps(colorPicker.getLabelProps(), props)
 
   return <ark.label {...mergedProps} ref={ref} />
-})
+}
 
 ColorPickerLabel.displayName = 'ColorPickerLabel'

--- a/packages/react/src/components/color-picker/color-picker-positioner.tsx
+++ b/packages/react/src/components/color-picker/color-picker-positioner.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { usePresenceContext } from '../presence'
 import { useColorPickerContext } from './use-color-picker-context'
@@ -9,7 +8,7 @@ import { useColorPickerContext } from './use-color-picker-context'
 export interface ColorPickerPositionerBaseProps extends PolymorphicProps {}
 export interface ColorPickerPositionerProps extends HTMLProps<'div'>, ColorPickerPositionerBaseProps {}
 
-export const ColorPickerPositioner = forwardRef<HTMLDivElement, ColorPickerPositionerProps>((props, ref) => {
+export const ColorPickerPositioner = ({ ref, ...props }: ColorPickerPositionerProps) => {
   const colorPicker = useColorPickerContext()
   const mergedProps = mergeProps(colorPicker.getPositionerProps(), props)
   const presence = usePresenceContext()
@@ -19,6 +18,6 @@ export const ColorPickerPositioner = forwardRef<HTMLDivElement, ColorPickerPosit
   }
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 ColorPickerPositioner.displayName = 'ColorPickerPositioner'

--- a/packages/react/src/components/color-picker/color-picker-root-provider.tsx
+++ b/packages/react/src/components/color-picker/color-picker-root-provider.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { PresenceProvider, type UsePresenceProps, splitPresenceProps, usePresence } from '../presence'
@@ -17,7 +16,7 @@ export interface ColorPickerRootProviderProps extends HTMLProps<'div'>, ColorPic
 
 const splitRootProviderProps = createSplitProps<RootProviderProps>()
 
-export const ColorPickerRootProvider = forwardRef<HTMLDivElement, ColorPickerRootProviderProps>((props, ref) => {
+export const ColorPickerRootProvider = ({ ref, ...props }: ColorPickerRootProviderProps) => {
   const [presenceProps, colorPickerProps] = splitPresenceProps(props)
   const [{ value: colorPicker }, localProps] = splitRootProviderProps(colorPickerProps, ['value'])
   const presence = usePresence(mergeProps({ present: colorPicker.open }, presenceProps))
@@ -30,6 +29,6 @@ export const ColorPickerRootProvider = forwardRef<HTMLDivElement, ColorPickerRoo
       </PresenceProvider>
     </ColorPickerProvider>
   )
-})
+}
 
 ColorPickerRootProvider.displayName = 'ColorPickerRootProvider'

--- a/packages/react/src/components/color-picker/color-picker-root.tsx
+++ b/packages/react/src/components/color-picker/color-picker-root.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import type { Assign } from '../../types'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -14,7 +13,7 @@ export interface ColorPickerRootProps extends Assign<HTMLProps<'div'>, ColorPick
 
 const splitRootProps = createSplitProps<UseColorPickerProps>()
 
-export const ColorPickerRoot = forwardRef<HTMLDivElement, ColorPickerRootProps>((props, ref) => {
+export const ColorPickerRoot = ({ ref, ...props }: ColorPickerRootProps) => {
   const [presenceProps, colorPickerProps] = splitPresenceProps(props)
   const [useColorPickerProps, localProps] = splitRootProps(colorPickerProps, [
     'closeOnSelect',
@@ -55,6 +54,6 @@ export const ColorPickerRoot = forwardRef<HTMLDivElement, ColorPickerRootProps>(
       </PresenceProvider>
     </ColorPickerProvider>
   )
-})
+}
 
 ColorPickerRoot.displayName = 'ColorPickerRoot'

--- a/packages/react/src/components/color-picker/color-picker-swatch-group.tsx
+++ b/packages/react/src/components/color-picker/color-picker-swatch-group.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useColorPickerContext } from './use-color-picker-context'
 
 export interface ColorPickerSwatchGroupBaseProps extends PolymorphicProps {}
 export interface ColorPickerSwatchGroupProps extends HTMLProps<'div'>, ColorPickerSwatchGroupBaseProps {}
 
-export const ColorPickerSwatchGroup = forwardRef<HTMLDivElement, ColorPickerSwatchGroupProps>((props, ref) => {
+export const ColorPickerSwatchGroup = ({ ref, ...props }: ColorPickerSwatchGroupProps) => {
   const colorPicker = useColorPickerContext()
   const mergedProps = mergeProps(colorPicker.getSwatchGroupProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 ColorPickerSwatchGroup.displayName = 'ColorPickerSwatchGroup'

--- a/packages/react/src/components/color-picker/color-picker-swatch-indicator.tsx
+++ b/packages/react/src/components/color-picker/color-picker-swatch-indicator.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useColorPickerContext } from './use-color-picker-context'
 import { useColorPickerSwatchPropsContext } from './use-color-picker-swatch-props-context'
@@ -9,12 +8,12 @@ import { useColorPickerSwatchPropsContext } from './use-color-picker-swatch-prop
 export interface ColorPickerSwatchIndicatorBaseProps extends PolymorphicProps {}
 export interface ColorPickerSwatchIndicatorProps extends HTMLProps<'div'>, ColorPickerSwatchIndicatorBaseProps {}
 
-export const ColorPickerSwatchIndicator = forwardRef<HTMLDivElement, ColorPickerSwatchIndicatorProps>((props, ref) => {
+export const ColorPickerSwatchIndicator = ({ ref, ...props }: ColorPickerSwatchIndicatorProps) => {
   const colorPicker = useColorPickerContext()
   const swatchProps = useColorPickerSwatchPropsContext()
   const mergedProps = mergeProps(colorPicker.getSwatchIndicatorProps(swatchProps), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 ColorPickerSwatchIndicator.displayName = 'ColorPickerSwatchIndicator'

--- a/packages/react/src/components/color-picker/color-picker-swatch-trigger.tsx
+++ b/packages/react/src/components/color-picker/color-picker-swatch-trigger.tsx
@@ -2,7 +2,6 @@
 
 import type { SwatchTriggerProps } from '@zag-js/color-picker'
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import type { Assign } from '../../types'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -13,12 +12,12 @@ export interface ColorPickerSwatchTriggerProps extends Assign<HTMLProps<'button'
 
 const splitSwatchTriggerProps = createSplitProps<SwatchTriggerProps>()
 
-export const ColorPickerSwatchTrigger = forwardRef<HTMLButtonElement, ColorPickerSwatchTriggerProps>((props, ref) => {
+export const ColorPickerSwatchTrigger = ({ ref, ...props }: ColorPickerSwatchTriggerProps) => {
   const [triggerProps, localProps] = splitSwatchTriggerProps(props, ['value', 'disabled'])
   const colorPicker = useColorPickerContext()
   const mergedProps = mergeProps(colorPicker.getSwatchTriggerProps(triggerProps), localProps)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 ColorPickerSwatchTrigger.displayName = 'ColorPickerSwatchTrigger'

--- a/packages/react/src/components/color-picker/color-picker-swatch.tsx
+++ b/packages/react/src/components/color-picker/color-picker-swatch.tsx
@@ -2,7 +2,6 @@
 
 import type { SwatchProps } from '@zag-js/color-picker'
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useColorPickerContext } from './use-color-picker-context'
@@ -13,7 +12,7 @@ export interface ColorPickerSwatchProps extends HTMLProps<'div'>, ColorPickerSwa
 
 const splitSwatchProps = createSplitProps<SwatchProps>()
 
-export const ColorPickerSwatch = forwardRef<HTMLDivElement, ColorPickerSwatchProps>((props, ref) => {
+export const ColorPickerSwatch = ({ ref, ...props }: ColorPickerSwatchProps) => {
   const [swatwchProps, localProps] = splitSwatchProps(props, ['respectAlpha', 'value'])
   const colorPicker = useColorPickerContext()
   const mergedProps = mergeProps(colorPicker.getSwatchProps(swatwchProps), localProps)
@@ -23,6 +22,6 @@ export const ColorPickerSwatch = forwardRef<HTMLDivElement, ColorPickerSwatchPro
       <ark.div {...mergedProps} ref={ref} />
     </ColorPickerSwatchPropsProvider>
   )
-})
+}
 
 ColorPickerSwatch.displayName = 'ColorPickerSwatch'

--- a/packages/react/src/components/color-picker/color-picker-transparency-grid.tsx
+++ b/packages/react/src/components/color-picker/color-picker-transparency-grid.tsx
@@ -2,7 +2,6 @@
 
 import type { TransparencyGridProps } from '@zag-js/color-picker'
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useColorPickerContext } from './use-color-picker-context'
@@ -12,14 +11,12 @@ export interface ColorPickerTransparencyGridProps extends HTMLProps<'div'>, Colo
 
 const splitTransparencyGridProps = createSplitProps<TransparencyGridProps>()
 
-export const ColorPickerTransparencyGrid = forwardRef<HTMLDivElement, ColorPickerTransparencyGridProps>(
-  (props, ref) => {
-    const [gridProps, localProps] = splitTransparencyGridProps(props, ['size'])
-    const colorPicker = useColorPickerContext()
-    const mergedProps = mergeProps(colorPicker.getTransparencyGridProps(gridProps), localProps)
+export const ColorPickerTransparencyGrid = ({ ref, ...props }: ColorPickerTransparencyGridProps) => {
+  const [gridProps, localProps] = splitTransparencyGridProps(props, ['size'])
+  const colorPicker = useColorPickerContext()
+  const mergedProps = mergeProps(colorPicker.getTransparencyGridProps(gridProps), localProps)
 
-    return <ark.div {...mergedProps} ref={ref} />
-  },
-)
+  return <ark.div {...mergedProps} ref={ref} />
+}
 
 ColorPickerTransparencyGrid.displayName = 'ColorPickerTransparencyGrid'

--- a/packages/react/src/components/color-picker/color-picker-trigger.tsx
+++ b/packages/react/src/components/color-picker/color-picker-trigger.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useColorPickerContext } from './use-color-picker-context'
 
 export interface ColorPickerTriggerBaseProps extends PolymorphicProps {}
 export interface ColorPickerTriggerProps extends HTMLProps<'button'>, ColorPickerTriggerBaseProps {}
 
-export const ColorPickerTrigger = forwardRef<HTMLButtonElement, ColorPickerTriggerProps>((props, ref) => {
+export const ColorPickerTrigger = ({ ref, ...props }: ColorPickerTriggerProps) => {
   const colorPicker = useColorPickerContext()
   const mergedProps = mergeProps(colorPicker.getTriggerProps(), props)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 ColorPickerTrigger.displayName = 'ColorPickerTrigger'

--- a/packages/react/src/components/color-picker/color-picker-value-swatch.tsx
+++ b/packages/react/src/components/color-picker/color-picker-value-swatch.tsx
@@ -2,7 +2,6 @@
 
 import type { SwatchProps } from '@zag-js/color-picker'
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useColorPickerContext } from './use-color-picker-context'
@@ -15,7 +14,7 @@ export interface ColorPickerValueSwatchProps extends HTMLProps<'div'>, ColorPick
 
 const splitValueSwatchProps = createSplitProps<ValueSwatchProps>()
 
-export const ColorPickerValueSwatch = forwardRef<HTMLDivElement, ColorPickerValueSwatchProps>((props, ref) => {
+export const ColorPickerValueSwatch = ({ ref, ...props }: ColorPickerValueSwatchProps) => {
   const [{ respectAlpha }, localProps] = splitValueSwatchProps(props, ['respectAlpha'])
   const colorPicker = useColorPickerContext()
   const swatchProps = {
@@ -29,6 +28,6 @@ export const ColorPickerValueSwatch = forwardRef<HTMLDivElement, ColorPickerValu
       <ark.div {...mergedProps} ref={ref} />
     </ColorPickerSwatchPropsProvider>
   )
-})
+}
 
 ColorPickerValueSwatch.displayName = 'ColorPickerValueSwatch'

--- a/packages/react/src/components/color-picker/color-picker-value-text.tsx
+++ b/packages/react/src/components/color-picker/color-picker-value-text.tsx
@@ -2,7 +2,6 @@
 
 import type { ColorStringFormat } from '@zag-js/color-utils'
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useColorPickerContext } from './use-color-picker-context'
 
@@ -11,7 +10,7 @@ export interface ColorPickerValueTextBaseProps extends PolymorphicProps {
 }
 export interface ColorPickerValueTextProps extends HTMLProps<'span'>, ColorPickerValueTextBaseProps {}
 
-export const ColorPickerValueText = forwardRef<HTMLDivElement, ColorPickerValueTextProps>((props, ref) => {
+export const ColorPickerValueText = ({ ref, ...props }: ColorPickerValueTextProps) => {
   const { children, format, ...localProps } = props
   const colorPicker = useColorPickerContext()
   const mergedProps = mergeProps(colorPicker.getValueTextProps(), localProps)
@@ -22,6 +21,6 @@ export const ColorPickerValueText = forwardRef<HTMLDivElement, ColorPickerValueT
       {children || valueAsString}
     </ark.span>
   )
-})
+}
 
 ColorPickerValueText.displayName = 'ColorPickerValueText'

--- a/packages/react/src/components/color-picker/color-picker-view.tsx
+++ b/packages/react/src/components/color-picker/color-picker-view.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import type { ColorFormat } from '@zag-js/color-picker'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { colorPickerAnatomy } from './color-picker.anatomy'
@@ -17,7 +16,7 @@ export interface ColorPickerViewProps extends HTMLProps<'div'>, ColorPickerViewB
 
 const splitFormatOptions = createSplitProps<FormatOptions>()
 
-export const ColorPickerView = forwardRef<HTMLDivElement, ColorPickerViewProps>((props, ref) => {
+export const ColorPickerView = ({ ref, ...props }: ColorPickerViewProps) => {
   const colorPicker = useColorPickerContext()
   const [formatProps, restProps] = splitFormatOptions(props, ['format'])
 
@@ -30,6 +29,6 @@ export const ColorPickerView = forwardRef<HTMLDivElement, ColorPickerViewProps>(
       <ark.div ref={ref} data-format={props.format} {...colorPickerAnatomy.build().view.attrs} {...restProps} />
     </ColorPickerFormatPropsProvider>
   )
-})
+}
 
 ColorPickerView.displayName = 'ColorPickerView'

--- a/packages/react/src/components/combobox/combobox-clear-trigger.tsx
+++ b/packages/react/src/components/combobox/combobox-clear-trigger.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useComboboxContext } from './use-combobox-context'
 
 export interface ComboboxClearTriggerBaseProps extends PolymorphicProps {}
 export interface ComboboxClearTriggerProps extends HTMLProps<'button'>, ComboboxClearTriggerBaseProps {}
 
-export const ComboboxClearTrigger = forwardRef<HTMLButtonElement, ComboboxClearTriggerProps>((props, ref) => {
+export const ComboboxClearTrigger = ({ ref, ...props }: ComboboxClearTriggerProps) => {
   const combobox = useComboboxContext()
   const mergedProps = mergeProps(combobox.getClearTriggerProps(), props)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 ComboboxClearTrigger.displayName = 'ComboboxClearTrigger'

--- a/packages/react/src/components/combobox/combobox-content.tsx
+++ b/packages/react/src/components/combobox/combobox-content.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { composeRefs } from '../../utils/compose-refs'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { usePresenceContext } from '../presence'
@@ -10,7 +9,7 @@ import { useComboboxContext } from './use-combobox-context'
 export interface ComboboxContentBaseProps extends PolymorphicProps {}
 export interface ComboboxContentProps extends HTMLProps<'div'>, ComboboxContentBaseProps {}
 
-export const ComboboxContent = forwardRef<HTMLDivElement, ComboboxContentProps>((props, ref) => {
+export const ComboboxContent = ({ ref, ...props }: ComboboxContentProps) => {
   const combobox = useComboboxContext()
   const presence = usePresenceContext()
   const mergedProps = mergeProps(combobox.getContentProps(), presence.getPresenceProps(), props)
@@ -20,6 +19,6 @@ export const ComboboxContent = forwardRef<HTMLDivElement, ComboboxContentProps>(
   }
 
   return <ark.div {...mergedProps} ref={composeRefs(presence.ref, ref)} />
-})
+}
 
 ComboboxContent.displayName = 'ComboboxContent'

--- a/packages/react/src/components/combobox/combobox-control.tsx
+++ b/packages/react/src/components/combobox/combobox-control.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useComboboxContext } from './use-combobox-context'
 
 export interface ComboboxControlBaseProps extends PolymorphicProps {}
 export interface ComboboxControlProps extends HTMLProps<'div'>, ComboboxControlBaseProps {}
 
-export const ComboboxControl = forwardRef<HTMLDivElement, ComboboxControlProps>((props, ref) => {
+export const ComboboxControl = ({ ref, ...props }: ComboboxControlProps) => {
   const combobox = useComboboxContext()
   const mergedProps = mergeProps(combobox.getControlProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 ComboboxControl.displayName = 'ComboboxControl'

--- a/packages/react/src/components/combobox/combobox-empty.tsx
+++ b/packages/react/src/components/combobox/combobox-empty.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { comboboxAnatomy } from './combobox.anatomy'
 import { useComboboxContext } from './use-combobox-context'
@@ -10,7 +9,7 @@ const parts = comboboxAnatomy.build()
 export interface ComboboxEmptyBaseProps extends PolymorphicProps {}
 export interface ComboboxEmptyProps extends HTMLProps<'div'>, ComboboxEmptyBaseProps {}
 
-export const ComboboxEmpty = forwardRef<HTMLDivElement, ComboboxEmptyProps>((props, ref) => {
+export const ComboboxEmpty = ({ ref, ...props }: ComboboxEmptyProps) => {
   const combobox = useComboboxContext()
 
   if (combobox.collection.size !== 0) {
@@ -18,6 +17,6 @@ export const ComboboxEmpty = forwardRef<HTMLDivElement, ComboboxEmptyProps>((pro
   }
 
   return <ark.div {...parts.empty.attrs} {...props} role="presentation" ref={ref} />
-})
+}
 
 ComboboxEmpty.displayName = 'ComboboxEmpty'

--- a/packages/react/src/components/combobox/combobox-input.tsx
+++ b/packages/react/src/components/combobox/combobox-input.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useFieldContext } from '../field'
 import { useComboboxContext } from './use-combobox-context'
@@ -9,12 +8,12 @@ import { useComboboxContext } from './use-combobox-context'
 export interface ComboboxInputBaseProps extends PolymorphicProps {}
 export interface ComboboxInputProps extends HTMLProps<'input'>, ComboboxInputBaseProps {}
 
-export const ComboboxInput = forwardRef<HTMLInputElement, ComboboxInputProps>((props, ref) => {
+export const ComboboxInput = ({ ref, ...props }: ComboboxInputProps) => {
   const combobox = useComboboxContext()
   const mergedProps = mergeProps(combobox.getInputProps(), props)
   const field = useFieldContext()
 
   return <ark.input aria-describedby={field?.ariaDescribedby} {...mergedProps} ref={ref} />
-})
+}
 
 ComboboxInput.displayName = 'ComboboxInput'

--- a/packages/react/src/components/combobox/combobox-item-group-label.tsx
+++ b/packages/react/src/components/combobox/combobox-item-group-label.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useComboboxContext } from './use-combobox-context'
 import { useComboboxItemGroupPropsContext } from './use-combobox-item-group-props-context'
@@ -9,12 +8,12 @@ import { useComboboxItemGroupPropsContext } from './use-combobox-item-group-prop
 export interface ComboboxItemGroupLabelBaseProps extends PolymorphicProps {}
 export interface ComboboxItemGroupLabelProps extends HTMLProps<'div'>, ComboboxItemGroupLabelBaseProps {}
 
-export const ComboboxItemGroupLabel = forwardRef<HTMLDivElement, ComboboxItemGroupLabelProps>((props, ref) => {
+export const ComboboxItemGroupLabel = ({ ref, ...props }: ComboboxItemGroupLabelProps) => {
   const combobox = useComboboxContext()
   const itemGroupProps = useComboboxItemGroupPropsContext()
   const mergedProps = mergeProps(combobox.getItemGroupLabelProps({ htmlFor: itemGroupProps.id }), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 ComboboxItemGroupLabel.displayName = 'ComboboxItemGroupLabel'

--- a/packages/react/src/components/combobox/combobox-item-group.tsx
+++ b/packages/react/src/components/combobox/combobox-item-group.tsx
@@ -2,7 +2,7 @@
 
 import type { ItemGroupProps } from '@zag-js/combobox'
 import { mergeProps } from '@zag-js/react'
-import { forwardRef, useId } from 'react'
+import { useId } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useComboboxContext } from './use-combobox-context'
@@ -13,7 +13,7 @@ export interface ComboboxItemGroupProps extends HTMLProps<'div'>, ComboboxItemGr
 
 const splitItemGroupProps = createSplitProps<Partial<ItemGroupProps>>()
 
-export const ComboboxItemGroup = forwardRef<HTMLDivElement, ComboboxItemGroupProps>((props, ref) => {
+export const ComboboxItemGroup = ({ ref, ...props }: ComboboxItemGroupProps) => {
   const id = useId()
   const [_itemGroupProps, localProps] = splitItemGroupProps(props, ['id'])
   const itemGroupProps = { id, ..._itemGroupProps }
@@ -26,6 +26,6 @@ export const ComboboxItemGroup = forwardRef<HTMLDivElement, ComboboxItemGroupPro
       <ark.div {...mergedProps} ref={ref} />
     </ComboboxItemGroupPropsProvider>
   )
-})
+}
 
 ComboboxItemGroup.displayName = 'ComboboxItemGroup'

--- a/packages/react/src/components/combobox/combobox-item-indicator.tsx
+++ b/packages/react/src/components/combobox/combobox-item-indicator.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useComboboxContext } from './use-combobox-context'
 import { useComboboxItemPropsContext } from './use-combobox-item-props-context'
@@ -9,12 +8,12 @@ import { useComboboxItemPropsContext } from './use-combobox-item-props-context'
 export interface ComboboxItemIndicatorBaseProps extends PolymorphicProps {}
 export interface ComboboxItemIndicatorProps extends HTMLProps<'div'>, ComboboxItemIndicatorBaseProps {}
 
-export const ComboboxItemIndicator = forwardRef<HTMLDivElement, ComboboxItemIndicatorProps>((props, ref) => {
+export const ComboboxItemIndicator = ({ ref, ...props }: ComboboxItemIndicatorProps) => {
   const combobox = useComboboxContext()
   const itemProps = useComboboxItemPropsContext()
   const mergedProps = mergeProps(combobox.getItemIndicatorProps(itemProps), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 ComboboxItemIndicator.displayName = 'ComboboxItemIndicator'

--- a/packages/react/src/components/combobox/combobox-item-text.tsx
+++ b/packages/react/src/components/combobox/combobox-item-text.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useComboboxContext } from './use-combobox-context'
 import { useComboboxItemPropsContext } from './use-combobox-item-props-context'
@@ -9,12 +8,12 @@ import { useComboboxItemPropsContext } from './use-combobox-item-props-context'
 export interface ComboboxItemTextBaseProps extends PolymorphicProps {}
 export interface ComboboxItemTextProps extends HTMLProps<'span'>, ComboboxItemTextBaseProps {}
 
-export const ComboboxItemText = forwardRef<HTMLDivElement, ComboboxItemTextProps>((props, ref) => {
+export const ComboboxItemText = ({ ref, ...props }: ComboboxItemTextProps) => {
   const combobox = useComboboxContext()
   const itemProps = useComboboxItemPropsContext()
   const mergedProps = mergeProps(combobox.getItemTextProps(itemProps), props)
 
   return <ark.span {...mergedProps} ref={ref} />
-})
+}
 
 ComboboxItemText.displayName = 'ComboboxItemText'

--- a/packages/react/src/components/combobox/combobox-item.tsx
+++ b/packages/react/src/components/combobox/combobox-item.tsx
@@ -2,7 +2,6 @@
 
 import type { ItemProps } from '@zag-js/combobox'
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useComboboxContext } from './use-combobox-context'
@@ -14,7 +13,7 @@ export interface ComboboxItemProps extends HTMLProps<'div'>, ComboboxItemBasePro
 
 const splitItemProps = createSplitProps<ItemProps>()
 
-export const ComboboxItem = forwardRef<HTMLDivElement, ComboboxItemProps>((props, ref) => {
+export const ComboboxItem = ({ ref, ...props }: ComboboxItemProps) => {
   const [itemProps, localProps] = splitItemProps(props, ['item', 'persistFocus'])
   const combobox = useComboboxContext()
   const mergedProps = mergeProps(combobox.getItemProps(itemProps), localProps)
@@ -27,6 +26,6 @@ export const ComboboxItem = forwardRef<HTMLDivElement, ComboboxItemProps>((props
       </ComboboxItemProvider>
     </ComboboxItemPropsProvider>
   )
-})
+}
 
 ComboboxItem.displayName = 'ComboboxItem'

--- a/packages/react/src/components/combobox/combobox-label.tsx
+++ b/packages/react/src/components/combobox/combobox-label.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useComboboxContext } from './use-combobox-context'
 
 export interface ComboboxLabelBaseProps extends PolymorphicProps {}
 export interface ComboboxLabelProps extends HTMLProps<'label'>, ComboboxLabelBaseProps {}
 
-export const ComboboxLabel = forwardRef<HTMLLabelElement, ComboboxLabelProps>((props, ref) => {
+export const ComboboxLabel = ({ ref, ...props }: ComboboxLabelProps) => {
   const combobox = useComboboxContext()
   const mergedProps = mergeProps(combobox.getLabelProps(), props)
 
   return <ark.label {...mergedProps} ref={ref} />
-})
+}
 
 ComboboxLabel.displayName = 'ComboboxLabel'

--- a/packages/react/src/components/combobox/combobox-list.tsx
+++ b/packages/react/src/components/combobox/combobox-list.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useComboboxContext } from './use-combobox-context'
 
 export interface ComboboxListBaseProps extends PolymorphicProps {}
 export interface ComboboxListProps extends HTMLProps<'div'>, ComboboxListBaseProps {}
 
-export const ComboboxList = forwardRef<HTMLDivElement, ComboboxListProps>((props, ref) => {
+export const ComboboxList = ({ ref, ...props }: ComboboxListProps) => {
   const combobox = useComboboxContext()
   const mergedProps = mergeProps(combobox.getListProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 ComboboxList.displayName = 'ComboboxList'

--- a/packages/react/src/components/combobox/combobox-positioner.tsx
+++ b/packages/react/src/components/combobox/combobox-positioner.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { usePresenceContext } from '../presence'
 import { useComboboxContext } from './use-combobox-context'
@@ -9,7 +8,7 @@ import { useComboboxContext } from './use-combobox-context'
 export interface ComboboxPositionerBaseProps extends PolymorphicProps {}
 export interface ComboboxPositionerProps extends HTMLProps<'div'>, ComboboxPositionerBaseProps {}
 
-export const ComboboxPositioner = forwardRef<HTMLDivElement, ComboboxPositionerProps>((props, ref) => {
+export const ComboboxPositioner = ({ ref, ...props }: ComboboxPositionerProps) => {
   const combobox = useComboboxContext()
   const presence = usePresenceContext()
   const mergedProps = mergeProps(combobox.getPositionerProps(), props)
@@ -19,6 +18,6 @@ export const ComboboxPositioner = forwardRef<HTMLDivElement, ComboboxPositionerP
   }
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 ComboboxPositioner.displayName = 'ComboboxPositioner'

--- a/packages/react/src/components/combobox/combobox-root-provider.tsx
+++ b/packages/react/src/components/combobox/combobox-root-provider.tsx
@@ -1,8 +1,7 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { type JSX, type Ref, type RefAttributes, forwardRef } from 'react'
-import type { Assign } from '../../types'
+import type { JSX } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import type { CollectionItem } from '../collection'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -13,12 +12,17 @@ import { ComboboxProvider } from './use-combobox-context'
 interface RootProviderProps<T extends CollectionItem> {
   value: UseComboboxReturn<T>
 }
+
 export interface ComboboxRootProviderBaseProps<T extends CollectionItem>
   extends RootProviderProps<T>, UsePresenceProps, PolymorphicProps {}
+
 export interface ComboboxRootProviderProps<T extends CollectionItem>
   extends HTMLProps<'div'>, ComboboxRootProviderBaseProps<T> {}
 
-const ComboboxImpl = <T extends CollectionItem>(props: ComboboxRootProviderProps<T>, ref: Ref<HTMLDivElement>) => {
+export const ComboboxRootProvider = <T extends CollectionItem>({
+  ref,
+  ...props
+}: ComboboxRootProviderProps<T>): JSX.Element => {
   const [presenceProps, comboboxProps] = splitPresenceProps(props)
   const [{ value: combobox }, localProps] = createSplitProps<RootProviderProps<T>>()(comboboxProps, ['value'])
   const presence = usePresence(mergeProps({ present: combobox.open }, presenceProps))
@@ -32,9 +36,3 @@ const ComboboxImpl = <T extends CollectionItem>(props: ComboboxRootProviderProps
     </ComboboxProvider>
   )
 }
-
-export type ComboboxRootProviderComponent<P = {}> = <T extends CollectionItem>(
-  props: Assign<ComboboxRootProviderProps<T>, P> & RefAttributes<HTMLDivElement>,
-) => JSX.Element
-
-export const ComboboxRootProvider = forwardRef(ComboboxImpl) as ComboboxRootProviderComponent

--- a/packages/react/src/components/combobox/combobox-root.tsx
+++ b/packages/react/src/components/combobox/combobox-root.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { type JSX, type Ref, type RefAttributes, forwardRef } from 'react'
+import type { JSX } from 'react'
 import type { Assign } from '../../types'
 import { createSplitProps } from '../../utils/create-split-props'
 import type { CollectionItem } from '../collection'
@@ -12,12 +12,13 @@ import { ComboboxProvider } from './use-combobox-context'
 
 export interface ComboboxRootBaseProps<T extends CollectionItem>
   extends UseComboboxProps<T>, UsePresenceProps, PolymorphicProps {}
+
 export interface ComboboxRootProps<T extends CollectionItem> extends Assign<
   HTMLProps<'div'>,
   ComboboxRootBaseProps<T>
 > {}
 
-const ComboboxImpl = <T extends CollectionItem>(props: ComboboxRootProps<T>, ref: Ref<HTMLDivElement>) => {
+export const ComboboxRoot = <T extends CollectionItem>({ ref, ...props }: ComboboxRootProps<T>): JSX.Element => {
   const [presenceProps, comboboxProps] = splitPresenceProps(props)
   const [useComboboxProps, localProps] = createSplitProps<UseComboboxProps<T>>()(comboboxProps, [
     'allowCustomValue',
@@ -76,15 +77,3 @@ const ComboboxImpl = <T extends CollectionItem>(props: ComboboxRootProps<T>, ref
     </ComboboxProvider>
   )
 }
-
-export type ComboboxRootComponentProps<T extends CollectionItem = CollectionItem, P = {}> = Assign<
-  ComboboxRootProps<T>,
-  P
-> &
-  RefAttributes<HTMLDivElement>
-
-export type ComboboxRootComponent<P = {}> = <T extends CollectionItem>(
-  props: ComboboxRootComponentProps<T, P>,
-) => JSX.Element
-
-export const ComboboxRoot = forwardRef(ComboboxImpl) as ComboboxRootComponent

--- a/packages/react/src/components/combobox/combobox-trigger.tsx
+++ b/packages/react/src/components/combobox/combobox-trigger.tsx
@@ -2,7 +2,6 @@
 
 import type { TriggerProps } from '@zag-js/combobox'
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useComboboxContext } from './use-combobox-context'
@@ -12,12 +11,12 @@ export interface ComboboxTriggerProps extends HTMLProps<'button'>, ComboboxTrigg
 
 const splitTriggerProps = createSplitProps<TriggerProps>()
 
-export const ComboboxTrigger = forwardRef<HTMLButtonElement, ComboboxTriggerProps>((props, ref) => {
+export const ComboboxTrigger = ({ ref, ...props }: ComboboxTriggerProps) => {
   const [triggerProps, localProps] = splitTriggerProps(props, ['focusable'])
   const combobox = useComboboxContext()
   const mergedProps = mergeProps(combobox.getTriggerProps(triggerProps), localProps)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 ComboboxTrigger.displayName = 'ComboboxTrigger'

--- a/packages/react/src/components/combobox/combobox.ts
+++ b/packages/react/src/components/combobox/combobox.ts
@@ -82,14 +82,11 @@ export {
 export {
   ComboboxRoot as Root,
   type ComboboxRootBaseProps as RootBaseProps,
-  type ComboboxRootComponent as RootComponent,
-  type ComboboxRootComponentProps as RootComponentProps,
   type ComboboxRootProps as RootProps,
 } from './combobox-root'
 export {
   ComboboxRootProvider as RootProvider,
   type ComboboxRootProviderBaseProps as RootProviderBaseProps,
-  type ComboboxRootProviderComponent as RootProviderComponent,
   type ComboboxRootProviderProps as RootProviderProps,
 } from './combobox-root-provider'
 export {

--- a/packages/react/src/components/combobox/index.ts
+++ b/packages/react/src/components/combobox/index.ts
@@ -46,18 +46,11 @@ export {
   type ComboboxPositionerBaseProps,
   type ComboboxPositionerProps,
 } from './combobox-positioner'
-export {
-  ComboboxRoot,
-  type ComboboxRootBaseProps,
-  type ComboboxRootProps,
-  type ComboboxRootComponent,
-  type ComboboxRootComponentProps,
-} from './combobox-root'
+export { ComboboxRoot, type ComboboxRootBaseProps, type ComboboxRootProps } from './combobox-root'
 export {
   ComboboxRootProvider,
   type ComboboxRootProviderBaseProps,
   type ComboboxRootProviderProps,
-  type ComboboxRootProviderComponent,
 } from './combobox-root-provider'
 export { ComboboxTrigger, type ComboboxTriggerBaseProps, type ComboboxTriggerProps } from './combobox-trigger'
 export { comboboxAnatomy } from './combobox.anatomy'

--- a/packages/react/src/components/date-input/date-input-control.tsx
+++ b/packages/react/src/components/date-input/date-input-control.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useDateInputContext } from './use-date-input-context'
 
 export interface DateInputControlBaseProps extends PolymorphicProps {}
 export interface DateInputControlProps extends HTMLProps<'div'>, DateInputControlBaseProps {}
 
-export const DateInputControl = forwardRef<HTMLDivElement, DateInputControlProps>((props, ref) => {
+export const DateInputControl = ({ ref, ...props }: DateInputControlProps) => {
   const dateInput = useDateInputContext()
   const mergedProps = mergeProps(dateInput.getControlProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 DateInputControl.displayName = 'DateInputControl'

--- a/packages/react/src/components/date-input/date-input-hidden-input.tsx
+++ b/packages/react/src/components/date-input/date-input-hidden-input.tsx
@@ -2,7 +2,6 @@
 
 import type { HiddenInputProps } from '@zag-js/date-input'
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useDateInputContext } from './use-date-input-context'
@@ -12,12 +11,12 @@ export interface DateInputHiddenInputProps extends HTMLProps<'input'>, DateInput
 
 const splitHiddenInputProps = createSplitProps<HiddenInputProps>()
 
-export const DateInputHiddenInput = forwardRef<HTMLInputElement, DateInputHiddenInputProps>((props, ref) => {
+export const DateInputHiddenInput = ({ ref, ...props }: DateInputHiddenInputProps) => {
   const [hiddenInputProps, localProps] = splitHiddenInputProps(props, ['index', 'name'])
   const dateInput = useDateInputContext()
   const mergedProps = mergeProps(dateInput.getHiddenInputProps(hiddenInputProps), localProps)
 
   return <ark.input {...mergedProps} ref={ref} />
-})
+}
 
 DateInputHiddenInput.displayName = 'DateInputHiddenInput'

--- a/packages/react/src/components/date-input/date-input-label.tsx
+++ b/packages/react/src/components/date-input/date-input-label.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useDateInputContext } from './use-date-input-context'
 
 export interface DateInputLabelBaseProps extends PolymorphicProps {}
 export interface DateInputLabelProps extends HTMLProps<'label'>, DateInputLabelBaseProps {}
 
-export const DateInputLabel = forwardRef<HTMLLabelElement, DateInputLabelProps>((props, ref) => {
+export const DateInputLabel = ({ ref, ...props }: DateInputLabelProps) => {
   const dateInput = useDateInputContext()
   const mergedProps = mergeProps(dateInput.getLabelProps(), props)
 
   return <ark.label {...mergedProps} ref={ref} />
-})
+}
 
 DateInputLabel.displayName = 'DateInputLabel'

--- a/packages/react/src/components/date-input/date-input-root-provider.tsx
+++ b/packages/react/src/components/date-input/date-input-root-provider.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import type { UseDateInputReturn } from './use-date-input'
@@ -16,7 +15,7 @@ export interface DateInputRootProviderProps extends HTMLProps<'div'>, DateInputR
 
 const splitRootProviderProps = createSplitProps<RootProviderProps>()
 
-export const DateInputRootProvider = forwardRef<HTMLDivElement, DateInputRootProviderProps>((props, ref) => {
+export const DateInputRootProvider = ({ ref, ...props }: DateInputRootProviderProps) => {
   const [{ value: dateInput }, localProps] = splitRootProviderProps(props, ['value'])
   const mergedProps = mergeProps(dateInput.getRootProps(), localProps)
 
@@ -25,6 +24,6 @@ export const DateInputRootProvider = forwardRef<HTMLDivElement, DateInputRootPro
       <ark.div {...mergedProps} ref={ref} />
     </DateInputProvider>
   )
-})
+}
 
 DateInputRootProvider.displayName = 'DateInputRootProvider'

--- a/packages/react/src/components/date-input/date-input-root.tsx
+++ b/packages/react/src/components/date-input/date-input-root.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { type UseDateInputProps, useDateInput } from './use-date-input'
@@ -13,7 +12,7 @@ export interface DateInputRootProps extends Assign<HTMLProps<'div'>, DateInputRo
 
 const splitRootProps = createSplitProps<UseDateInputProps>()
 
-export const DateInputRoot = forwardRef<HTMLDivElement, DateInputRootProps>((props, ref) => {
+export const DateInputRoot = ({ ref, ...props }: DateInputRootProps) => {
   const [useDateInputProps, localProps] = splitRootProps(props, [
     'dir',
     'disabled',
@@ -56,6 +55,6 @@ export const DateInputRoot = forwardRef<HTMLDivElement, DateInputRootProps>((pro
       <ark.div {...mergedProps} ref={ref} />
     </DateInputProvider>
   )
-})
+}
 
 DateInputRoot.displayName = 'DateInputRoot'

--- a/packages/react/src/components/date-input/date-input-segment-group.tsx
+++ b/packages/react/src/components/date-input/date-input-segment-group.tsx
@@ -2,7 +2,6 @@
 
 import type { SegmentGroupProps } from '@zag-js/date-input'
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useDateInputContext } from './use-date-input-context'
@@ -13,7 +12,7 @@ export interface DateInputSegmentGroupProps extends HTMLProps<'div'>, DateInputS
 
 const splitSegmentGroupProps = createSplitProps<SegmentGroupProps>()
 
-export const DateInputSegmentGroup = forwardRef<HTMLDivElement, DateInputSegmentGroupProps>((props, ref) => {
+export const DateInputSegmentGroup = ({ ref, ...props }: DateInputSegmentGroupProps) => {
   const [segmentGroupProps, localProps] = splitSegmentGroupProps(props, ['index'])
   const dateInput = useDateInputContext()
   const mergedProps = mergeProps(dateInput.getSegmentGroupProps(segmentGroupProps), localProps)
@@ -22,6 +21,6 @@ export const DateInputSegmentGroup = forwardRef<HTMLDivElement, DateInputSegment
       <ark.div {...mergedProps} ref={ref} />
     </DateInputSegmentGroupPropsProvider>
   )
-})
+}
 
 DateInputSegmentGroup.displayName = 'DateInputSegmentGroup'

--- a/packages/react/src/components/date-input/date-input-segment.tsx
+++ b/packages/react/src/components/date-input/date-input-segment.tsx
@@ -2,7 +2,6 @@
 
 import type { SegmentProps } from '@zag-js/date-input'
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useDateInputContext } from './use-date-input-context'
@@ -14,7 +13,7 @@ export interface DateInputSegmentProps extends HTMLProps<'span'>, DateInputSegme
 
 const splitSegmentProps = createSplitProps<Pick<SegmentProps, 'segment'>>()
 
-export const DateInputSegment = forwardRef<HTMLSpanElement, DateInputSegmentProps>((props, ref) => {
+export const DateInputSegment = ({ ref, ...props }: DateInputSegmentProps) => {
   const [segmentProps, localProps] = splitSegmentProps(props, ['segment'])
   const segmentGroupProps = useDateInputSegmentGroupPropsContext()
   const dateInput = useDateInputContext()
@@ -27,6 +26,6 @@ export const DateInputSegment = forwardRef<HTMLSpanElement, DateInputSegmentProp
       {segmentProps.segment.text}
     </ark.span>
   )
-})
+}
 
 DateInputSegment.displayName = 'DateInputSegment'

--- a/packages/react/src/components/date-picker/date-picker-clear-trigger.tsx
+++ b/packages/react/src/components/date-picker/date-picker-clear-trigger.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useDatePickerContext } from './use-date-picker-context'
 
 export interface DatePickerClearTriggerBaseProps extends PolymorphicProps {}
 export interface DatePickerClearTriggerProps extends HTMLProps<'button'>, DatePickerClearTriggerBaseProps {}
 
-export const DatePickerClearTrigger = forwardRef<HTMLButtonElement, DatePickerClearTriggerProps>((props, ref) => {
+export const DatePickerClearTrigger = ({ ref, ...props }: DatePickerClearTriggerProps) => {
   const datePicker = useDatePickerContext()
   const mergedProps = mergeProps(datePicker.getClearTriggerProps(), props)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 DatePickerClearTrigger.displayName = 'DatePickerClearTrigger'

--- a/packages/react/src/components/date-picker/date-picker-content.tsx
+++ b/packages/react/src/components/date-picker/date-picker-content.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { composeRefs } from '../../utils/compose-refs'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { usePresenceContext } from '../presence'
@@ -10,7 +9,7 @@ import { useDatePickerContext } from './use-date-picker-context'
 export interface DatePickerContentBaseProps extends PolymorphicProps {}
 export interface DatePickerContentProps extends HTMLProps<'div'>, DatePickerContentBaseProps {}
 
-export const DatePickerContent = forwardRef<HTMLDivElement, DatePickerContentProps>((props, ref) => {
+export const DatePickerContent = ({ ref, ...props }: DatePickerContentProps) => {
   const datePicker = useDatePickerContext()
   const presence = usePresenceContext()
   const mergedProps = mergeProps(datePicker.getContentProps(), presence.getPresenceProps(), props)
@@ -20,6 +19,6 @@ export const DatePickerContent = forwardRef<HTMLDivElement, DatePickerContentPro
   }
 
   return <ark.div {...mergedProps} ref={composeRefs(presence.ref, ref)} />
-})
+}
 
 DatePickerContent.displayName = 'DatePickerContent'

--- a/packages/react/src/components/date-picker/date-picker-control.tsx
+++ b/packages/react/src/components/date-picker/date-picker-control.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useDatePickerContext } from './use-date-picker-context'
 
 export interface DatePickerControlBaseProps extends PolymorphicProps {}
 export interface DatePickerControlProps extends HTMLProps<'div'>, DatePickerControlBaseProps {}
 
-export const DatePickerControl = forwardRef<HTMLDivElement, DatePickerControlProps>((props, ref) => {
+export const DatePickerControl = ({ ref, ...props }: DatePickerControlProps) => {
   const datePicker = useDatePickerContext()
   const mergedProps = mergeProps(datePicker.getControlProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 DatePickerControl.displayName = 'DatePickerControl'

--- a/packages/react/src/components/date-picker/date-picker-input.tsx
+++ b/packages/react/src/components/date-picker/date-picker-input.tsx
@@ -2,7 +2,6 @@
 
 import type { InputProps } from '@zag-js/date-picker'
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useDatePickerContext } from './use-date-picker-context'
@@ -12,12 +11,12 @@ export interface DatePickerInputProps extends HTMLProps<'input'>, DatePickerInpu
 
 const splitInputProps = createSplitProps<InputProps>()
 
-export const DatePickerInput = forwardRef<HTMLInputElement, DatePickerInputProps>((props, ref) => {
+export const DatePickerInput = ({ ref, ...props }: DatePickerInputProps) => {
   const [inputProps, localProps] = splitInputProps(props, ['index', 'fixOnBlur'])
   const datePicker = useDatePickerContext()
   const mergedProps = mergeProps(datePicker.getInputProps(inputProps), localProps)
 
   return <ark.input {...mergedProps} ref={ref} />
-})
+}
 
 DatePickerInput.displayName = 'DatePickerInput'

--- a/packages/react/src/components/date-picker/date-picker-label.tsx
+++ b/packages/react/src/components/date-picker/date-picker-label.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useDatePickerContext } from './use-date-picker-context'
 
 export interface DatePickerLabelBaseProps extends PolymorphicProps {}
 export interface DatePickerLabelProps extends HTMLProps<'label'>, DatePickerLabelBaseProps {}
 
-export const DatePickerLabel = forwardRef<HTMLLabelElement, DatePickerLabelProps>((props, ref) => {
+export const DatePickerLabel = ({ ref, ...props }: DatePickerLabelProps) => {
   const datePicker = useDatePickerContext()
   const mergedProps = mergeProps(datePicker.getLabelProps(), props)
 
   return <ark.label {...mergedProps} ref={ref} />
-})
+}
 
 DatePickerLabel.displayName = 'DatePickerLabel'

--- a/packages/react/src/components/date-picker/date-picker-month-select.tsx
+++ b/packages/react/src/components/date-picker/date-picker-month-select.tsx
@@ -1,14 +1,13 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useDatePickerContext } from './use-date-picker-context'
 
 export interface DatePickerMonthSelectBaseProps extends PolymorphicProps {}
 export interface DatePickerMonthSelectProps extends HTMLProps<'select'>, DatePickerMonthSelectBaseProps {}
 
-export const DatePickerMonthSelect = forwardRef<HTMLSelectElement, DatePickerMonthSelectProps>((props, ref) => {
+export const DatePickerMonthSelect = ({ ref, ...props }: DatePickerMonthSelectProps) => {
   const datePicker = useDatePickerContext()
   const mergedProps = mergeProps(datePicker.getMonthSelectProps(), props)
 
@@ -21,6 +20,6 @@ export const DatePickerMonthSelect = forwardRef<HTMLSelectElement, DatePickerMon
       ))}
     </ark.select>
   )
-})
+}
 
 DatePickerMonthSelect.displayName = 'DatePickerMonthSelect'

--- a/packages/react/src/components/date-picker/date-picker-next-trigger.tsx
+++ b/packages/react/src/components/date-picker/date-picker-next-trigger.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useDatePickerContext } from './use-date-picker-context'
 import { useDatePickerViewPropsContext } from './use-date-picker-view-props-context'
@@ -9,12 +8,12 @@ import { useDatePickerViewPropsContext } from './use-date-picker-view-props-cont
 export interface DatePickerNextTriggerBaseProps extends PolymorphicProps {}
 export interface DatePickerNextTriggerProps extends HTMLProps<'button'>, DatePickerNextTriggerBaseProps {}
 
-export const DatePickerNextTrigger = forwardRef<HTMLButtonElement, DatePickerNextTriggerProps>((props, ref) => {
+export const DatePickerNextTrigger = ({ ref, ...props }: DatePickerNextTriggerProps) => {
   const datePicker = useDatePickerContext()
   const viewProps = useDatePickerViewPropsContext()
   const mergedProps = mergeProps(datePicker.getNextTriggerProps(viewProps), props)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 DatePickerNextTrigger.displayName = 'DatePickerNextTrigger'

--- a/packages/react/src/components/date-picker/date-picker-positioner.tsx
+++ b/packages/react/src/components/date-picker/date-picker-positioner.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { usePresenceContext } from '../presence'
 import { useDatePickerContext } from './use-date-picker-context'
@@ -9,7 +8,7 @@ import { useDatePickerContext } from './use-date-picker-context'
 export interface DatePickerPositionerBaseProps extends PolymorphicProps {}
 export interface DatePickerPositionerProps extends HTMLProps<'div'>, DatePickerPositionerBaseProps {}
 
-export const DatePickerPositioner = forwardRef<HTMLDivElement, DatePickerPositionerProps>((props, ref) => {
+export const DatePickerPositioner = ({ ref, ...props }: DatePickerPositionerProps) => {
   const datePicker = useDatePickerContext()
   const mergedProps = mergeProps(datePicker.getPositionerProps(), props)
   const presence = usePresenceContext()
@@ -19,6 +18,6 @@ export const DatePickerPositioner = forwardRef<HTMLDivElement, DatePickerPositio
   }
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 DatePickerPositioner.displayName = 'DatePickerPositioner'

--- a/packages/react/src/components/date-picker/date-picker-preset-trigger.tsx
+++ b/packages/react/src/components/date-picker/date-picker-preset-trigger.tsx
@@ -2,7 +2,6 @@
 
 import type { PresetTriggerProps } from '@zag-js/date-picker'
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import type { Assign } from '../../types'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -13,12 +12,12 @@ export interface DatePickerPresetTriggerProps extends Assign<HTMLProps<'button'>
 
 const splitPresetTriggerProps = createSplitProps<PresetTriggerProps>()
 
-export const DatePickerPresetTrigger = forwardRef<HTMLButtonElement, DatePickerPresetTriggerProps>((props, ref) => {
+export const DatePickerPresetTrigger = ({ ref, ...props }: DatePickerPresetTriggerProps) => {
   const [presetTriggerProps, localProps] = splitPresetTriggerProps(props, ['value'])
   const datePicker = useDatePickerContext()
   const mergedProps = mergeProps(datePicker.getPresetTriggerProps(presetTriggerProps), localProps)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 DatePickerPresetTrigger.displayName = 'DatePickerPresetTrigger'

--- a/packages/react/src/components/date-picker/date-picker-prev-trigger.tsx
+++ b/packages/react/src/components/date-picker/date-picker-prev-trigger.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useDatePickerContext } from './use-date-picker-context'
 import { useDatePickerViewPropsContext } from './use-date-picker-view-props-context'
@@ -9,12 +8,12 @@ import { useDatePickerViewPropsContext } from './use-date-picker-view-props-cont
 export interface DatePickerPrevTriggerBaseProps extends PolymorphicProps {}
 export interface DatePickerPrevTriggerProps extends HTMLProps<'button'>, DatePickerPrevTriggerBaseProps {}
 
-export const DatePickerPrevTrigger = forwardRef<HTMLButtonElement, DatePickerPrevTriggerProps>((props, ref) => {
+export const DatePickerPrevTrigger = ({ ref, ...props }: DatePickerPrevTriggerProps) => {
   const datePicker = useDatePickerContext()
   const viewProps = useDatePickerViewPropsContext()
   const mergedProps = mergeProps(datePicker.getPrevTriggerProps(viewProps), props)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 DatePickerPrevTrigger.displayName = 'DatePickerPrevTrigger'

--- a/packages/react/src/components/date-picker/date-picker-range-text.tsx
+++ b/packages/react/src/components/date-picker/date-picker-range-text.tsx
@@ -2,14 +2,14 @@
 
 import { mergeProps } from '@zag-js/react'
 import { uniq } from '@zag-js/utils'
-import { forwardRef, useMemo } from 'react'
+import { useMemo } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useDatePickerContext } from './use-date-picker-context'
 
 export interface DatePickerRangeTextBaseProps extends PolymorphicProps {}
 export interface DatePickerRangeTextProps extends HTMLProps<'div'>, DatePickerRangeTextBaseProps {}
 
-export const DatePickerRangeText = forwardRef<HTMLDivElement, DatePickerRangeTextProps>((props, ref) => {
+export const DatePickerRangeText = ({ ref, ...props }: DatePickerRangeTextProps) => {
   const datePicker = useDatePickerContext()
   const mergedProps = mergeProps(datePicker.getRangeTextProps(), props)
   const visibleRangeText = useMemo(() => {
@@ -22,6 +22,6 @@ export const DatePickerRangeText = forwardRef<HTMLDivElement, DatePickerRangeTex
       {visibleRangeText}
     </ark.div>
   )
-})
+}
 
 DatePickerRangeText.displayName = 'DatePickerRangeText'

--- a/packages/react/src/components/date-picker/date-picker-root-provider.tsx
+++ b/packages/react/src/components/date-picker/date-picker-root-provider.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { PresenceProvider, type UsePresenceProps, splitPresenceProps, usePresence } from '../presence'
@@ -17,7 +16,7 @@ export interface DatePickerRootProviderProps extends HTMLProps<'div'>, DatePicke
 
 const splitRootProviderProps = createSplitProps<RootProviderProps>()
 
-export const DatePickerRootProvider = forwardRef<HTMLDivElement, DatePickerRootProviderProps>((props, ref) => {
+export const DatePickerRootProvider = ({ ref, ...props }: DatePickerRootProviderProps) => {
   const [presenceProps, datePickerProps] = splitPresenceProps(props)
   const [{ value: datePicker }, localProps] = splitRootProviderProps(datePickerProps, ['value'])
 
@@ -31,6 +30,6 @@ export const DatePickerRootProvider = forwardRef<HTMLDivElement, DatePickerRootP
       </PresenceProvider>
     </DatePickerProvider>
   )
-})
+}
 
 DatePickerRootProvider.displayName = 'DatePickerRootProvider'

--- a/packages/react/src/components/date-picker/date-picker-root.tsx
+++ b/packages/react/src/components/date-picker/date-picker-root.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import type { Assign } from '../../types'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -14,7 +13,7 @@ export interface DatePickerRootProps extends Assign<HTMLProps<'div'>, DatePicker
 
 const splitRootProps = createSplitProps<UseDatePickerProps>()
 
-export const DatePickerRoot = forwardRef<HTMLDivElement, DatePickerRootProps>((props, ref) => {
+export const DatePickerRoot = ({ ref, ...props }: DatePickerRootProps) => {
   const [presenceProps, datePickerProps] = splitPresenceProps(props)
   const [useDatePickerProps, localProps] = splitRootProps(datePickerProps, [
     'closeOnSelect',
@@ -72,6 +71,6 @@ export const DatePickerRoot = forwardRef<HTMLDivElement, DatePickerRootProps>((p
       </PresenceProvider>
     </DatePickerProvider>
   )
-})
+}
 
 DatePickerRoot.displayName = 'DatePickerRoot'

--- a/packages/react/src/components/date-picker/date-picker-table-body.tsx
+++ b/packages/react/src/components/date-picker/date-picker-table-body.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useDatePickerContext } from './use-date-picker-context'
 import { useDatePickerTablePropsContext } from './use-date-picker-table-props-context'
@@ -9,12 +8,12 @@ import { useDatePickerTablePropsContext } from './use-date-picker-table-props-co
 export interface DatePickerTableBodyBaseProps extends PolymorphicProps {}
 export interface DatePickerTableBodyProps extends HTMLProps<'tbody'>, DatePickerTableBodyBaseProps {}
 
-export const DatePickerTableBody = forwardRef<HTMLTableSectionElement, DatePickerTableBodyProps>((props, ref) => {
+export const DatePickerTableBody = ({ ref, ...props }: DatePickerTableBodyProps) => {
   const datePicker = useDatePickerContext()
   const tableProps = useDatePickerTablePropsContext()
   const mergedProps = mergeProps(datePicker.getTableBodyProps(tableProps), props)
 
   return <ark.tbody {...mergedProps} ref={ref} />
-})
+}
 
 DatePickerTableBody.displayName = 'DatePickerTableBody'

--- a/packages/react/src/components/date-picker/date-picker-table-cell-trigger.tsx
+++ b/packages/react/src/components/date-picker/date-picker-table-cell-trigger.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useDatePickerContext } from './use-date-picker-context'
 import { useDatePickerTableCellPropsContext } from './use-date-picker-table-cell-props-context'
@@ -10,7 +9,7 @@ import { useDatePickerViewPropsContext } from './use-date-picker-view-props-cont
 export interface DatePickerTableCellTriggerBaseProps extends PolymorphicProps {}
 export interface DatePickerTableCellTriggerProps extends HTMLProps<'div'>, DatePickerTableCellTriggerBaseProps {}
 
-export const DatePickerTableCellTrigger = forwardRef<HTMLDivElement, DatePickerTableCellTriggerProps>((props, ref) => {
+export const DatePickerTableCellTrigger = ({ ref, ...props }: DatePickerTableCellTriggerProps) => {
   const datePicker = useDatePickerContext()
   const tableCellProps = useDatePickerTableCellPropsContext()
   const viewProps = useDatePickerViewPropsContext()
@@ -29,6 +28,6 @@ export const DatePickerTableCellTrigger = forwardRef<HTMLDivElement, DatePickerT
   const mergedProps = mergeProps(triggerProps, props)
 
   return <ark.div ref={ref} {...mergedProps} />
-})
+}
 
 DatePickerTableCellTrigger.displayName = 'DatePickerTableCellTrigger'

--- a/packages/react/src/components/date-picker/date-picker-table-cell.tsx
+++ b/packages/react/src/components/date-picker/date-picker-table-cell.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useDatePickerContext } from './use-date-picker-context'
@@ -16,7 +15,7 @@ export interface DatePickerTableCellProps extends HTMLProps<'td'>, DatePickerTab
 
 const splitTableCellProps = createSplitProps<UseDatePickerTableCellPropsContext>()
 
-export const DatePickerTableCell = forwardRef<HTMLTableCellElement, DatePickerTableCellProps>((props, ref) => {
+export const DatePickerTableCell = ({ ref, ...props }: DatePickerTableCellProps) => {
   const [cellProps, localProps] = splitTableCellProps(props, ['disabled', 'value', 'visibleRange', 'columns'])
 
   const datePicker = useDatePickerContext()
@@ -35,6 +34,6 @@ export const DatePickerTableCell = forwardRef<HTMLTableCellElement, DatePickerTa
       <ark.td ref={ref} {...mergedProps} />
     </DatePickerTableCellPropsProvider>
   )
-})
+}
 
 DatePickerTableCell.displayName = 'DatePickerTableCell'

--- a/packages/react/src/components/date-picker/date-picker-table-head.tsx
+++ b/packages/react/src/components/date-picker/date-picker-table-head.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useDatePickerContext } from './use-date-picker-context'
 import { useDatePickerTablePropsContext } from './use-date-picker-table-props-context'
@@ -9,12 +8,12 @@ import { useDatePickerTablePropsContext } from './use-date-picker-table-props-co
 export interface DatePickerTableHeadBaseProps extends PolymorphicProps {}
 export interface DatePickerTableHeadProps extends HTMLProps<'thead'>, DatePickerTableHeadBaseProps {}
 
-export const DatePickerTableHead = forwardRef<HTMLTableSectionElement, DatePickerTableHeadProps>((props, ref) => {
+export const DatePickerTableHead = ({ ref, ...props }: DatePickerTableHeadProps) => {
   const datePicker = useDatePickerContext()
   const tableProps = useDatePickerTablePropsContext()
   const mergedProps = mergeProps(datePicker.getTableHeadProps(tableProps), props)
 
   return <ark.thead {...mergedProps} ref={ref} />
-})
+}
 
 DatePickerTableHead.displayName = 'DatePickerTableHead'

--- a/packages/react/src/components/date-picker/date-picker-table-header.tsx
+++ b/packages/react/src/components/date-picker/date-picker-table-header.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useDatePickerContext } from './use-date-picker-context'
 import { useDatePickerTablePropsContext } from './use-date-picker-table-props-context'
@@ -9,12 +8,12 @@ import { useDatePickerTablePropsContext } from './use-date-picker-table-props-co
 export interface DatePickerTableHeaderBaseProps extends PolymorphicProps {}
 export interface DatePickerTableHeaderProps extends HTMLProps<'th'>, DatePickerTableHeaderBaseProps {}
 
-export const DatePickerTableHeader = forwardRef<HTMLTableCellElement, DatePickerTableHeaderProps>((props, ref) => {
+export const DatePickerTableHeader = ({ ref, ...props }: DatePickerTableHeaderProps) => {
   const datePicker = useDatePickerContext()
   const tableProps = useDatePickerTablePropsContext()
   const mergedProps = mergeProps(datePicker.getTableHeaderProps(tableProps), props)
 
   return <ark.th {...mergedProps} ref={ref} />
-})
+}
 
 DatePickerTableHeader.displayName = 'DatePickerTableHeader'

--- a/packages/react/src/components/date-picker/date-picker-table-row.tsx
+++ b/packages/react/src/components/date-picker/date-picker-table-row.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useDatePickerContext } from './use-date-picker-context'
 import { useDatePickerTablePropsContext } from './use-date-picker-table-props-context'
@@ -9,12 +8,12 @@ import { useDatePickerTablePropsContext } from './use-date-picker-table-props-co
 export interface DatePickerTableRowBaseProps extends PolymorphicProps {}
 export interface DatePickerTableRowProps extends HTMLProps<'tr'>, DatePickerTableRowBaseProps {}
 
-export const DatePickerTableRow = forwardRef<HTMLTableRowElement, DatePickerTableRowProps>((props, ref) => {
+export const DatePickerTableRow = ({ ref, ...props }: DatePickerTableRowProps) => {
   const datePicker = useDatePickerContext()
   const tableProps = useDatePickerTablePropsContext()
   const mergedProps = mergeProps(datePicker.getTableRowProps(tableProps), props)
 
   return <ark.tr {...mergedProps} ref={ref} />
-})
+}
 
 DatePickerTableRow.displayName = 'DatePickerTableRow'

--- a/packages/react/src/components/date-picker/date-picker-table.tsx
+++ b/packages/react/src/components/date-picker/date-picker-table.tsx
@@ -2,7 +2,7 @@
 
 import type { TableProps } from '@zag-js/date-picker'
 import { mergeProps } from '@zag-js/react'
-import { forwardRef, useId } from 'react'
+import { useId } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useDatePickerContext } from './use-date-picker-context'
@@ -14,7 +14,7 @@ export interface DatePickerTableProps extends HTMLProps<'table'>, DatePickerTabl
 
 const splitTableProps = createSplitProps<Pick<TableProps, 'columns'>>()
 
-export const DatePickerTable = forwardRef<HTMLTableElement, DatePickerTableProps>((props, ref) => {
+export const DatePickerTable = ({ ref, ...props }: DatePickerTableProps) => {
   const [{ columns }, localProps] = splitTableProps(props, ['columns'])
   const datePicker = useDatePickerContext()
   const viewProps = useDatePickerViewPropsContext()
@@ -26,6 +26,6 @@ export const DatePickerTable = forwardRef<HTMLTableElement, DatePickerTableProps
       <ark.table {...mergedProps} ref={ref} />
     </DatePickerTablePropsProvider>
   )
-})
+}
 
 DatePickerTable.displayName = 'DatePickerTable'

--- a/packages/react/src/components/date-picker/date-picker-trigger.tsx
+++ b/packages/react/src/components/date-picker/date-picker-trigger.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useDatePickerContext } from './use-date-picker-context'
 
 export interface DatePickerTriggerBaseProps extends PolymorphicProps {}
 export interface DatePickerTriggerProps extends HTMLProps<'button'>, DatePickerTriggerBaseProps {}
 
-export const DatePickerTrigger = forwardRef<HTMLButtonElement, DatePickerTriggerProps>((props, ref) => {
+export const DatePickerTrigger = ({ ref, ...props }: DatePickerTriggerProps) => {
   const datePicker = useDatePickerContext()
   const mergedProps = mergeProps(datePicker.getTriggerProps(), props)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 DatePickerTrigger.displayName = 'DatePickerTrigger'

--- a/packages/react/src/components/date-picker/date-picker-value-text.tsx
+++ b/packages/react/src/components/date-picker/date-picker-value-text.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import type { DateValue } from '@zag-js/date-picker'
-import { Fragment, forwardRef } from 'react'
+import { Fragment } from 'react'
 import type { Assign } from '../../types'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { datePickerAnatomy } from './date-picker.anatomy'
@@ -33,7 +33,7 @@ export interface DatePickerValueTextBaseProps extends PolymorphicProps {
 
 export interface DatePickerValueTextProps extends Assign<HTMLProps<'span'>, DatePickerValueTextBaseProps> {}
 
-export const DatePickerValueText = forwardRef<HTMLSpanElement, DatePickerValueTextProps>((props, ref) => {
+export const DatePickerValueText = ({ ref, ...props }: DatePickerValueTextProps) => {
   const { children, placeholder, separator = ', ', ...localProps } = props
   const datePicker = useDatePickerContext()
 
@@ -65,6 +65,6 @@ export const DatePickerValueText = forwardRef<HTMLSpanElement, DatePickerValueTe
       {hasValue ? datePicker.valueAsString.join(separator) : placeholder}
     </ark.span>
   )
-})
+}
 
 DatePickerValueText.displayName = 'DatePickerValueText'

--- a/packages/react/src/components/date-picker/date-picker-view-control.tsx
+++ b/packages/react/src/components/date-picker/date-picker-view-control.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useDatePickerContext } from './use-date-picker-context'
 import { useDatePickerViewPropsContext } from './use-date-picker-view-props-context'
@@ -9,12 +8,12 @@ import { useDatePickerViewPropsContext } from './use-date-picker-view-props-cont
 export interface DatePickerViewControlBaseProps extends PolymorphicProps {}
 export interface DatePickerViewControlProps extends HTMLProps<'div'>, DatePickerViewControlBaseProps {}
 
-export const DatePickerViewControl = forwardRef<HTMLDivElement, DatePickerViewControlProps>((props, ref) => {
+export const DatePickerViewControl = ({ ref, ...props }: DatePickerViewControlProps) => {
   const datePicker = useDatePickerContext()
   const viewProps = useDatePickerViewPropsContext()
   const mergedProps = mergeProps(datePicker.getViewControlProps(viewProps), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 DatePickerViewControl.displayName = 'DatePickerViewControl'

--- a/packages/react/src/components/date-picker/date-picker-view-trigger.tsx
+++ b/packages/react/src/components/date-picker/date-picker-view-trigger.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useDatePickerContext } from './use-date-picker-context'
 import { useDatePickerViewPropsContext } from './use-date-picker-view-props-context'
@@ -9,12 +8,12 @@ import { useDatePickerViewPropsContext } from './use-date-picker-view-props-cont
 export interface DatePickerViewTriggerBaseProps extends PolymorphicProps {}
 export interface DatePickerViewTriggerProps extends HTMLProps<'button'>, DatePickerViewTriggerBaseProps {}
 
-export const DatePickerViewTrigger = forwardRef<HTMLButtonElement, DatePickerViewTriggerProps>((props, ref) => {
+export const DatePickerViewTrigger = ({ ref, ...props }: DatePickerViewTriggerProps) => {
   const datePicker = useDatePickerContext()
   const viewProps = useDatePickerViewPropsContext()
   const mergedProps = mergeProps(datePicker.getViewTriggerProps(viewProps), props)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 DatePickerViewTrigger.displayName = 'DatePickerViewTrigger'

--- a/packages/react/src/components/date-picker/date-picker-view.tsx
+++ b/packages/react/src/components/date-picker/date-picker-view.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import type { ViewProps } from '@zag-js/date-picker'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { datePickerAnatomy } from './date-picker.anatomy'
@@ -13,7 +12,7 @@ export interface DatePickerViewProps extends HTMLProps<'div'>, DatePickerViewBas
 
 const splitViewProps = createSplitProps<Required<ViewProps>>()
 
-export const DatePickerView = forwardRef<HTMLDivElement, DatePickerViewProps>((props, ref) => {
+export const DatePickerView = ({ ref, ...props }: DatePickerViewProps) => {
   const [viewProps, localProps] = splitViewProps(props, ['view'])
   const datePicker = useDatePickerContext()
 
@@ -27,6 +26,6 @@ export const DatePickerView = forwardRef<HTMLDivElement, DatePickerViewProps>((p
       />
     </DatePickerViewPropsProvider>
   )
-})
+}
 
 DatePickerView.displayName = 'DatePickerView'

--- a/packages/react/src/components/date-picker/date-picker-week-number-cell.tsx
+++ b/packages/react/src/components/date-picker/date-picker-week-number-cell.tsx
@@ -2,7 +2,6 @@
 
 import type { DateValue, WeekNumberCellProps } from '@zag-js/date-picker'
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useDatePickerContext } from './use-date-picker-context'
@@ -15,14 +14,12 @@ export interface DatePickerWeekNumberCellProps extends HTMLProps<'td'>, DatePick
 
 const splitWeekNumberCellProps = createSplitProps<WeekNumberCellProps>()
 
-export const DatePickerWeekNumberCell = forwardRef<HTMLTableCellElement, DatePickerWeekNumberCellProps>(
-  (props, ref) => {
-    const [cellProps, localProps] = splitWeekNumberCellProps(props, ['weekIndex', 'week'])
-    const datePicker = useDatePickerContext()
-    const mergedProps = mergeProps(datePicker.getWeekNumberCellProps(cellProps), localProps)
+export const DatePickerWeekNumberCell = ({ ref, ...props }: DatePickerWeekNumberCellProps) => {
+  const [cellProps, localProps] = splitWeekNumberCellProps(props, ['weekIndex', 'week'])
+  const datePicker = useDatePickerContext()
+  const mergedProps = mergeProps(datePicker.getWeekNumberCellProps(cellProps), localProps)
 
-    return <ark.td {...mergedProps} ref={ref} />
-  },
-)
+  return <ark.td {...mergedProps} ref={ref} />
+}
 
 DatePickerWeekNumberCell.displayName = 'DatePickerWeekNumberCell'

--- a/packages/react/src/components/date-picker/date-picker-week-number-header-cell.tsx
+++ b/packages/react/src/components/date-picker/date-picker-week-number-header-cell.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useDatePickerContext } from './use-date-picker-context'
 import { useDatePickerTablePropsContext } from './use-date-picker-table-props-context'
@@ -9,14 +8,12 @@ import { useDatePickerTablePropsContext } from './use-date-picker-table-props-co
 export interface DatePickerWeekNumberHeaderCellBaseProps extends PolymorphicProps {}
 export interface DatePickerWeekNumberHeaderCellProps extends HTMLProps<'th'>, DatePickerWeekNumberHeaderCellBaseProps {}
 
-export const DatePickerWeekNumberHeaderCell = forwardRef<HTMLTableCellElement, DatePickerWeekNumberHeaderCellProps>(
-  (props, ref) => {
-    const datePicker = useDatePickerContext()
-    const tableProps = useDatePickerTablePropsContext()
-    const mergedProps = mergeProps(datePicker.getWeekNumberHeaderCellProps(tableProps), props)
+export const DatePickerWeekNumberHeaderCell = ({ ref, ...props }: DatePickerWeekNumberHeaderCellProps) => {
+  const datePicker = useDatePickerContext()
+  const tableProps = useDatePickerTablePropsContext()
+  const mergedProps = mergeProps(datePicker.getWeekNumberHeaderCellProps(tableProps), props)
 
-    return <ark.th {...mergedProps} ref={ref} />
-  },
-)
+  return <ark.th {...mergedProps} ref={ref} />
+}
 
 DatePickerWeekNumberHeaderCell.displayName = 'DatePickerWeekNumberHeaderCell'

--- a/packages/react/src/components/date-picker/date-picker-year-select.tsx
+++ b/packages/react/src/components/date-picker/date-picker-year-select.tsx
@@ -1,14 +1,13 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useDatePickerContext } from './use-date-picker-context'
 
 export interface DatePickerYearSelectBaseProps extends PolymorphicProps {}
 export interface DatePickerYearSelectProps extends HTMLProps<'select'>, DatePickerYearSelectBaseProps {}
 
-export const DatePickerYearSelect = forwardRef<HTMLSelectElement, DatePickerYearSelectProps>((props, ref) => {
+export const DatePickerYearSelect = ({ ref, ...props }: DatePickerYearSelectProps) => {
   const datePicker = useDatePickerContext()
   const mergedProps = mergeProps(datePicker.getYearSelectProps(), props)
 
@@ -21,6 +20,6 @@ export const DatePickerYearSelect = forwardRef<HTMLSelectElement, DatePickerYear
       ))}
     </ark.select>
   )
-})
+}
 
 DatePickerYearSelect.displayName = 'DatePickerYearSelect'

--- a/packages/react/src/components/dialog/dialog-backdrop.tsx
+++ b/packages/react/src/components/dialog/dialog-backdrop.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { composeRefs } from '../../utils/compose-refs'
 import { useRenderStrategyPropsContext } from '../../utils/render-strategy'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -11,7 +10,7 @@ import { useDialogContext } from './use-dialog-context'
 export interface DialogBackdropBaseProps extends PolymorphicProps {}
 export interface DialogBackdropProps extends HTMLProps<'div'>, DialogBackdropBaseProps {}
 
-export const DialogBackdrop = forwardRef<HTMLDivElement, DialogBackdropProps>((props, ref) => {
+export const DialogBackdrop = ({ ref, ...props }: DialogBackdropProps) => {
   const dialog = useDialogContext()
   const renderStrategyProps = useRenderStrategyPropsContext()
   const presence = usePresence({ ...renderStrategyProps, present: dialog.open })
@@ -22,6 +21,6 @@ export const DialogBackdrop = forwardRef<HTMLDivElement, DialogBackdropProps>((p
   }
 
   return <ark.div {...mergedProps} ref={composeRefs(presence.ref, ref)} />
-})
+}
 
 DialogBackdrop.displayName = 'DialogBackdrop'

--- a/packages/react/src/components/dialog/dialog-close-trigger.tsx
+++ b/packages/react/src/components/dialog/dialog-close-trigger.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useDialogContext } from './use-dialog-context'
 
 export interface DialogCloseTriggerBaseProps extends PolymorphicProps {}
 export interface DialogCloseTriggerProps extends HTMLProps<'button'>, DialogCloseTriggerBaseProps {}
 
-export const DialogCloseTrigger = forwardRef<HTMLButtonElement, DialogCloseTriggerProps>((props, ref) => {
+export const DialogCloseTrigger = ({ ref, ...props }: DialogCloseTriggerProps) => {
   const dialog = useDialogContext()
   const mergedProps = mergeProps(dialog.getCloseTriggerProps(), props)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 DialogCloseTrigger.displayName = 'DialogCloseTrigger'

--- a/packages/react/src/components/dialog/dialog-content.tsx
+++ b/packages/react/src/components/dialog/dialog-content.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { composeRefs } from '../../utils/compose-refs'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { usePresenceContext } from '../presence'
@@ -10,7 +9,7 @@ import { useDialogContext } from './use-dialog-context'
 export interface DialogContentBaseProps extends PolymorphicProps {}
 export interface DialogContentProps extends HTMLProps<'div'>, DialogContentBaseProps {}
 
-export const DialogContent = forwardRef<HTMLDivElement, DialogContentProps>((props, ref) => {
+export const DialogContent = ({ ref, ...props }: DialogContentProps) => {
   const dialog = useDialogContext()
   const presence = usePresenceContext()
   const mergedProps = mergeProps(dialog.getContentProps(), presence.getPresenceProps(), props)
@@ -20,6 +19,6 @@ export const DialogContent = forwardRef<HTMLDivElement, DialogContentProps>((pro
   }
 
   return <ark.div {...mergedProps} ref={composeRefs(presence.ref, ref)} />
-})
+}
 
 DialogContent.displayName = 'DialogContent'

--- a/packages/react/src/components/dialog/dialog-description.tsx
+++ b/packages/react/src/components/dialog/dialog-description.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useDialogContext } from './use-dialog-context'
 
 export interface DialogDescriptionBaseProps extends PolymorphicProps {}
 export interface DialogDescriptionProps extends HTMLProps<'div'>, DialogDescriptionBaseProps {}
 
-export const DialogDescription = forwardRef<HTMLDivElement, DialogDescriptionProps>((props, ref) => {
+export const DialogDescription = ({ ref, ...props }: DialogDescriptionProps) => {
   const dialog = useDialogContext()
   const mergedProps = mergeProps(dialog.getDescriptionProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 DialogDescription.displayName = 'DialogDescription'

--- a/packages/react/src/components/dialog/dialog-positioner.tsx
+++ b/packages/react/src/components/dialog/dialog-positioner.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { usePresenceContext } from '../presence'
 import { useDialogContext } from './use-dialog-context'
@@ -9,7 +8,7 @@ import { useDialogContext } from './use-dialog-context'
 export interface DialogPositionerBaseProps extends PolymorphicProps {}
 export interface DialogPositionerProps extends HTMLProps<'div'>, DialogPositionerBaseProps {}
 
-export const DialogPositioner = forwardRef<HTMLDivElement, DialogPositionerProps>((props, ref) => {
+export const DialogPositioner = ({ ref, ...props }: DialogPositionerProps) => {
   const dialog = useDialogContext()
   const mergedProps = mergeProps(dialog.getPositionerProps(), props)
   const presence = usePresenceContext()
@@ -19,6 +18,6 @@ export const DialogPositioner = forwardRef<HTMLDivElement, DialogPositionerProps
   }
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 DialogPositioner.displayName = 'DialogPositioner'

--- a/packages/react/src/components/dialog/dialog-title.tsx
+++ b/packages/react/src/components/dialog/dialog-title.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useDialogContext } from './use-dialog-context'
 
 export interface DialogTitleBaseProps extends PolymorphicProps {}
 export interface DialogTitleProps extends HTMLProps<'h2'>, DialogTitleBaseProps {}
 
-export const DialogTitle = forwardRef<HTMLHeadingElement, DialogTitleProps>((props, ref) => {
+export const DialogTitle = ({ ref, ...props }: DialogTitleProps) => {
   const dialog = useDialogContext()
   const mergedProps = mergeProps(dialog.getTitleProps(), props)
 
   return <ark.h2 {...mergedProps} ref={ref} />
-})
+}
 
 DialogTitle.displayName = 'DialogTitle'

--- a/packages/react/src/components/dialog/dialog-trigger.tsx
+++ b/packages/react/src/components/dialog/dialog-trigger.tsx
@@ -2,7 +2,6 @@
 
 import { mergeProps } from '@zag-js/react'
 import type { TriggerProps } from '@zag-js/dialog'
-import { forwardRef } from 'react'
 import type { Assign } from '../../types'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -14,7 +13,7 @@ export interface DialogTriggerProps extends Assign<HTMLProps<'button'>, DialogTr
 
 const splitTriggerProps = createSplitProps<TriggerProps>()
 
-export const DialogTrigger = forwardRef<HTMLButtonElement, DialogTriggerProps>((props, ref) => {
+export const DialogTrigger = ({ ref, ...props }: DialogTriggerProps) => {
   const [triggerProps, localProps] = splitTriggerProps(props, ['value'])
   const dialog = useDialogContext()
   const presence = usePresenceContext()
@@ -29,6 +28,6 @@ export const DialogTrigger = forwardRef<HTMLButtonElement, DialogTriggerProps>((
   )
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 DialogTrigger.displayName = 'DialogTrigger'

--- a/packages/react/src/components/download-trigger/download-trigger.tsx
+++ b/packages/react/src/components/download-trigger/download-trigger.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { forwardRef } from 'react'
 import type { HTMLProps, PolymorphicProps } from '../factory'
 import { ark } from '../factory'
 import { type UseDownloadProps, useDownload } from './use-download'
@@ -9,7 +8,7 @@ export interface DownloadTriggerBaseProps extends PolymorphicProps, UseDownloadP
 
 export interface DownloadTriggerProps extends HTMLProps<'button'>, DownloadTriggerBaseProps {}
 
-export const DownloadTrigger = forwardRef<HTMLButtonElement, DownloadTriggerProps>((props, ref) => {
+export const DownloadTrigger = ({ ref, ...props }: DownloadTriggerProps) => {
   const { fileName, data, mimeType, ...rest } = props
   const { download } = useDownload({ fileName, mimeType, data })
   const onClick = (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -18,6 +17,6 @@ export const DownloadTrigger = forwardRef<HTMLButtonElement, DownloadTriggerProp
     download()
   }
   return <ark.button ref={ref} {...rest} type="button" onClick={onClick} />
-})
+}
 
 DownloadTrigger.displayName = 'DownloadTrigger'

--- a/packages/react/src/components/drawer/drawer-backdrop.tsx
+++ b/packages/react/src/components/drawer/drawer-backdrop.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { composeRefs } from '../../utils/compose-refs'
 import { useRenderStrategyPropsContext } from '../../utils/render-strategy'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -11,7 +10,7 @@ import { useDrawerContext } from './use-drawer-context'
 export interface DrawerBackdropBaseProps extends PolymorphicProps {}
 export interface DrawerBackdropProps extends HTMLProps<'div'>, DrawerBackdropBaseProps {}
 
-export const DrawerBackdrop = forwardRef<HTMLDivElement, DrawerBackdropProps>((props, ref) => {
+export const DrawerBackdrop = ({ ref, ...props }: DrawerBackdropProps) => {
   const drawer = useDrawerContext()
   const renderStrategyProps = useRenderStrategyPropsContext()
   const presence = usePresence({ ...renderStrategyProps, present: drawer.open })
@@ -22,6 +21,6 @@ export const DrawerBackdrop = forwardRef<HTMLDivElement, DrawerBackdropProps>((p
   }
 
   return <ark.div {...mergedProps} ref={composeRefs(presence.ref, ref)} />
-})
+}
 
 DrawerBackdrop.displayName = 'DrawerBackdrop'

--- a/packages/react/src/components/drawer/drawer-close-trigger.tsx
+++ b/packages/react/src/components/drawer/drawer-close-trigger.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useDrawerContext } from './use-drawer-context'
 
 export interface DrawerCloseTriggerBaseProps extends PolymorphicProps {}
 export interface DrawerCloseTriggerProps extends HTMLProps<'button'>, DrawerCloseTriggerBaseProps {}
 
-export const DrawerCloseTrigger = forwardRef<HTMLButtonElement, DrawerCloseTriggerProps>((props, ref) => {
+export const DrawerCloseTrigger = ({ ref, ...props }: DrawerCloseTriggerProps) => {
   const drawer = useDrawerContext()
   const mergedProps = mergeProps(drawer.getCloseTriggerProps(), props)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 DrawerCloseTrigger.displayName = 'DrawerCloseTrigger'

--- a/packages/react/src/components/drawer/drawer-content.tsx
+++ b/packages/react/src/components/drawer/drawer-content.tsx
@@ -2,7 +2,6 @@
 
 import { mergeProps } from '@zag-js/react'
 import type { ContentProps } from '@zag-js/drawer'
-import { forwardRef } from 'react'
 import { composeRefs } from '../../utils/compose-refs'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { usePresenceContext } from '../presence'
@@ -14,7 +13,7 @@ export interface DrawerContentProps extends Omit<HTMLProps<'div'>, 'draggable'>,
 
 const splitContentProps = createSplitProps<ContentProps>()
 
-export const DrawerContent = forwardRef<HTMLDivElement, DrawerContentProps>((props, ref) => {
+export const DrawerContent = ({ ref, ...props }: DrawerContentProps) => {
   const [contentProps, localProps] = splitContentProps(props, ['draggable'])
   const drawer = useDrawerContext()
   const presence = usePresenceContext()
@@ -29,6 +28,6 @@ export const DrawerContent = forwardRef<HTMLDivElement, DrawerContentProps>((pro
   }
 
   return <ark.div {...mergedProps} ref={composeRefs(presence.ref, ref)} />
-})
+}
 
 DrawerContent.displayName = 'DrawerContent'

--- a/packages/react/src/components/drawer/drawer-description.tsx
+++ b/packages/react/src/components/drawer/drawer-description.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useDrawerContext } from './use-drawer-context'
 
 export interface DrawerDescriptionBaseProps extends PolymorphicProps {}
 export interface DrawerDescriptionProps extends HTMLProps<'div'>, DrawerDescriptionBaseProps {}
 
-export const DrawerDescription = forwardRef<HTMLDivElement, DrawerDescriptionProps>((props, ref) => {
+export const DrawerDescription = ({ ref, ...props }: DrawerDescriptionProps) => {
   const drawer = useDrawerContext()
   const mergedProps = mergeProps(drawer.getDescriptionProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 DrawerDescription.displayName = 'DrawerDescription'

--- a/packages/react/src/components/drawer/drawer-grabber-indicator.tsx
+++ b/packages/react/src/components/drawer/drawer-grabber-indicator.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useDrawerContext } from './use-drawer-context'
 
 export interface DrawerGrabberIndicatorBaseProps extends PolymorphicProps {}
 export interface DrawerGrabberIndicatorProps extends HTMLProps<'div'>, DrawerGrabberIndicatorBaseProps {}
 
-export const DrawerGrabberIndicator = forwardRef<HTMLDivElement, DrawerGrabberIndicatorProps>((props, ref) => {
+export const DrawerGrabberIndicator = ({ ref, ...props }: DrawerGrabberIndicatorProps) => {
   const drawer = useDrawerContext()
   const mergedProps = mergeProps(drawer.getGrabberIndicatorProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 DrawerGrabberIndicator.displayName = 'DrawerGrabberIndicator'

--- a/packages/react/src/components/drawer/drawer-grabber.tsx
+++ b/packages/react/src/components/drawer/drawer-grabber.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useDrawerContext } from './use-drawer-context'
 
 export interface DrawerGrabberBaseProps extends PolymorphicProps {}
 export interface DrawerGrabberProps extends HTMLProps<'div'>, DrawerGrabberBaseProps {}
 
-export const DrawerGrabber = forwardRef<HTMLDivElement, DrawerGrabberProps>((props, ref) => {
+export const DrawerGrabber = ({ ref, ...props }: DrawerGrabberProps) => {
   const drawer = useDrawerContext()
   const mergedProps = mergeProps(drawer.getGrabberProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 DrawerGrabber.displayName = 'DrawerGrabber'

--- a/packages/react/src/components/drawer/drawer-indent-background.tsx
+++ b/packages/react/src/components/drawer/drawer-indent-background.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useDrawerStackContext } from './use-drawer-stack-context'
 
 export interface DrawerIndentBackgroundBaseProps extends PolymorphicProps {}
 export interface DrawerIndentBackgroundProps extends HTMLProps<'div'>, DrawerIndentBackgroundBaseProps {}
 
-export const DrawerIndentBackground = forwardRef<HTMLDivElement, DrawerIndentBackgroundProps>((props, ref) => {
+export const DrawerIndentBackground = ({ ref, ...props }: DrawerIndentBackgroundProps) => {
   const stackApi = useDrawerStackContext()
   const mergedProps = mergeProps(stackApi.getIndentBackgroundProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 DrawerIndentBackground.displayName = 'DrawerIndentBackground'

--- a/packages/react/src/components/drawer/drawer-indent.tsx
+++ b/packages/react/src/components/drawer/drawer-indent.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useDrawerStackContext } from './use-drawer-stack-context'
 
 export interface DrawerIndentBaseProps extends PolymorphicProps {}
 export interface DrawerIndentProps extends HTMLProps<'div'>, DrawerIndentBaseProps {}
 
-export const DrawerIndent = forwardRef<HTMLDivElement, DrawerIndentProps>((props, ref) => {
+export const DrawerIndent = ({ ref, ...props }: DrawerIndentProps) => {
   const stackApi = useDrawerStackContext()
   const mergedProps = mergeProps(stackApi.getIndentProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 DrawerIndent.displayName = 'DrawerIndent'

--- a/packages/react/src/components/drawer/drawer-positioner.tsx
+++ b/packages/react/src/components/drawer/drawer-positioner.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { usePresenceContext } from '../presence'
 import { useDrawerContext } from './use-drawer-context'
@@ -9,7 +8,7 @@ import { useDrawerContext } from './use-drawer-context'
 export interface DrawerPositionerBaseProps extends PolymorphicProps {}
 export interface DrawerPositionerProps extends HTMLProps<'div'>, DrawerPositionerBaseProps {}
 
-export const DrawerPositioner = forwardRef<HTMLDivElement, DrawerPositionerProps>((props, ref) => {
+export const DrawerPositioner = ({ ref, ...props }: DrawerPositionerProps) => {
   const drawer = useDrawerContext()
   const presence = usePresenceContext()
   const mergedProps = mergeProps(drawer.getPositionerProps(), props)
@@ -19,6 +18,6 @@ export const DrawerPositioner = forwardRef<HTMLDivElement, DrawerPositionerProps
   }
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 DrawerPositioner.displayName = 'DrawerPositioner'

--- a/packages/react/src/components/drawer/drawer-swipe-area.tsx
+++ b/packages/react/src/components/drawer/drawer-swipe-area.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useDrawerContext } from './use-drawer-context'
 
 export interface DrawerSwipeAreaBaseProps extends PolymorphicProps {}
 export interface DrawerSwipeAreaProps extends HTMLProps<'div'>, DrawerSwipeAreaBaseProps {}
 
-export const DrawerSwipeArea = forwardRef<HTMLDivElement, DrawerSwipeAreaProps>((props, ref) => {
+export const DrawerSwipeArea = ({ ref, ...props }: DrawerSwipeAreaProps) => {
   const drawer = useDrawerContext()
   const mergedProps = mergeProps(drawer.getSwipeAreaProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 DrawerSwipeArea.displayName = 'DrawerSwipeArea'

--- a/packages/react/src/components/drawer/drawer-title.tsx
+++ b/packages/react/src/components/drawer/drawer-title.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useDrawerContext } from './use-drawer-context'
 
 export interface DrawerTitleBaseProps extends PolymorphicProps {}
 export interface DrawerTitleProps extends HTMLProps<'h2'>, DrawerTitleBaseProps {}
 
-export const DrawerTitle = forwardRef<HTMLHeadingElement, DrawerTitleProps>((props, ref) => {
+export const DrawerTitle = ({ ref, ...props }: DrawerTitleProps) => {
   const drawer = useDrawerContext()
   const mergedProps = mergeProps(drawer.getTitleProps(), props)
 
   return <ark.h2 {...mergedProps} ref={ref} />
-})
+}
 
 DrawerTitle.displayName = 'DrawerTitle'

--- a/packages/react/src/components/drawer/drawer-trigger.tsx
+++ b/packages/react/src/components/drawer/drawer-trigger.tsx
@@ -2,7 +2,6 @@
 
 import { mergeProps } from '@zag-js/react'
 import type { TriggerProps } from '@zag-js/drawer'
-import { forwardRef } from 'react'
 import type { Assign } from '../../types'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -14,7 +13,7 @@ export interface DrawerTriggerProps extends Assign<HTMLProps<'button'>, DrawerTr
 
 const splitTriggerProps = createSplitProps<TriggerProps>()
 
-export const DrawerTrigger = forwardRef<HTMLButtonElement, DrawerTriggerProps>((props, ref) => {
+export const DrawerTrigger = ({ ref, ...props }: DrawerTriggerProps) => {
   const [triggerProps, localProps] = splitTriggerProps(props, ['value'])
   const drawer = useDrawerContext()
   const presence = usePresenceContext()
@@ -28,6 +27,6 @@ export const DrawerTrigger = forwardRef<HTMLButtonElement, DrawerTriggerProps>((
   )
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 DrawerTrigger.displayName = 'DrawerTrigger'

--- a/packages/react/src/components/editable/editable-area.tsx
+++ b/packages/react/src/components/editable/editable-area.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useEditableContext } from './use-editable-context'
 
 export interface EditableAreaBaseProps extends PolymorphicProps {}
 export interface EditableAreaProps extends HTMLProps<'div'>, EditableAreaBaseProps {}
 
-export const EditableArea = forwardRef<HTMLDivElement, EditableAreaProps>((props, ref) => {
+export const EditableArea = ({ ref, ...props }: EditableAreaProps) => {
   const editable = useEditableContext()
   const mergedProps = mergeProps(editable.getAreaProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 EditableArea.displayName = 'EditableArea'

--- a/packages/react/src/components/editable/editable-cancel-trigger.tsx
+++ b/packages/react/src/components/editable/editable-cancel-trigger.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useEditableContext } from './use-editable-context'
 
 export interface EditableCancelTriggerBaseProps extends PolymorphicProps {}
 export interface EditableCancelTriggerProps extends HTMLProps<'button'>, EditableCancelTriggerBaseProps {}
 
-export const EditableCancelTrigger = forwardRef<HTMLButtonElement, EditableCancelTriggerProps>((props, ref) => {
+export const EditableCancelTrigger = ({ ref, ...props }: EditableCancelTriggerProps) => {
   const editable = useEditableContext()
   const mergedProps = mergeProps(editable.getCancelTriggerProps(), props)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 EditableCancelTrigger.displayName = 'EditableCancelTrigger'

--- a/packages/react/src/components/editable/editable-control.tsx
+++ b/packages/react/src/components/editable/editable-control.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useEditableContext } from './use-editable-context'
 
 export interface EditableControlBaseProps extends PolymorphicProps {}
 export interface EditableControlProps extends HTMLProps<'div'>, EditableControlBaseProps {}
 
-export const EditableControl = forwardRef<HTMLDivElement, EditableControlProps>((props, ref) => {
+export const EditableControl = ({ ref, ...props }: EditableControlProps) => {
   const editable = useEditableContext()
   const mergedProps = mergeProps(editable.getControlProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 EditableControl.displayName = 'EditableControl'

--- a/packages/react/src/components/editable/editable-edit-trigger.tsx
+++ b/packages/react/src/components/editable/editable-edit-trigger.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useEditableContext } from './use-editable-context'
 
 export interface EditableEditTriggerBaseProps extends PolymorphicProps {}
 export interface EditableEditTriggerProps extends HTMLProps<'button'>, EditableEditTriggerBaseProps {}
 
-export const EditableEditTrigger = forwardRef<HTMLButtonElement, EditableEditTriggerProps>((props, ref) => {
+export const EditableEditTrigger = ({ ref, ...props }: EditableEditTriggerProps) => {
   const editable = useEditableContext()
   const mergedProps = mergeProps(editable.getEditTriggerProps(), props)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 EditableEditTrigger.displayName = 'EditableEditTrigger'

--- a/packages/react/src/components/editable/editable-input.tsx
+++ b/packages/react/src/components/editable/editable-input.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useFieldContext } from '../field'
 import { useEditableContext } from './use-editable-context'
@@ -9,12 +8,12 @@ import { useEditableContext } from './use-editable-context'
 export interface EditableInputBaseProps extends PolymorphicProps {}
 export interface EditableInputProps extends HTMLProps<'input'>, EditableInputBaseProps {}
 
-export const EditableInput = forwardRef<HTMLInputElement, EditableInputProps>((props, ref) => {
+export const EditableInput = ({ ref, ...props }: EditableInputProps) => {
   const editable = useEditableContext()
   const mergedProps = mergeProps(editable.getInputProps(), props)
   const field = useFieldContext()
 
   return <ark.input aria-describedby={field?.ariaDescribedby} {...mergedProps} ref={ref} />
-})
+}
 
 EditableInput.displayName = 'EditableInput'

--- a/packages/react/src/components/editable/editable-label.tsx
+++ b/packages/react/src/components/editable/editable-label.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useEditableContext } from './use-editable-context'
 
 export interface EditableLabelBaseProps extends PolymorphicProps {}
 export interface EditableLabelProps extends HTMLProps<'label'>, EditableLabelBaseProps {}
 
-export const EditableLabel = forwardRef<HTMLLabelElement, EditableLabelProps>((props, ref) => {
+export const EditableLabel = ({ ref, ...props }: EditableLabelProps) => {
   const editable = useEditableContext()
   const mergedProps = mergeProps(editable.getLabelProps(), props)
 
   return <ark.label {...mergedProps} ref={ref} />
-})
+}
 
 EditableLabel.displayName = 'EditableLabel'

--- a/packages/react/src/components/editable/editable-preview.tsx
+++ b/packages/react/src/components/editable/editable-preview.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useEditableContext } from './use-editable-context'
 
 export interface EditablePreviewBaseProps extends PolymorphicProps {}
 export interface EditablePreviewProps extends HTMLProps<'span'>, EditablePreviewBaseProps {}
 
-export const EditablePreview = forwardRef<HTMLSpanElement, EditablePreviewProps>((props, ref) => {
+export const EditablePreview = ({ ref, ...props }: EditablePreviewProps) => {
   const editable = useEditableContext()
   const mergedProps = mergeProps(editable.getPreviewProps(), props)
 
   return <ark.span {...mergedProps} ref={ref} />
-})
+}
 
 EditablePreview.displayName = 'EditablePreview'

--- a/packages/react/src/components/editable/editable-root-provider.tsx
+++ b/packages/react/src/components/editable/editable-root-provider.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import type { UseEditableReturn } from './use-editable'
@@ -16,7 +15,7 @@ export interface EditableRootProviderProps extends HTMLProps<'div'>, EditableRoo
 
 const splitRootProviderProps = createSplitProps<RootProviderProps>()
 
-export const EditableRootProvider = forwardRef<HTMLDivElement, EditableRootProviderProps>((props, ref) => {
+export const EditableRootProvider = ({ ref, ...props }: EditableRootProviderProps) => {
   const [{ value: editable }, localProps] = splitRootProviderProps(props, ['value'])
   const mergedProps = mergeProps(editable.getRootProps(), localProps)
 
@@ -25,6 +24,6 @@ export const EditableRootProvider = forwardRef<HTMLDivElement, EditableRootProvi
       <ark.div {...mergedProps} ref={ref} />
     </EditableProvider>
   )
-})
+}
 
 EditableRootProvider.displayName = 'EditableRootProvider'

--- a/packages/react/src/components/editable/editable-root.tsx
+++ b/packages/react/src/components/editable/editable-root.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import type { Assign } from '../../types'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -13,7 +12,7 @@ export interface EditableRootProps extends Assign<HTMLProps<'div'>, EditableRoot
 
 const splitRootProps = createSplitProps<UseEditableProps>()
 
-export const EditableRoot = forwardRef<HTMLDivElement, EditableRootProps>((props, ref) => {
+export const EditableRoot = ({ ref, ...props }: EditableRootProps) => {
   const [useEditableProps, localProps] = splitRootProps(props, [
     'activationMode',
     'autoResize',
@@ -51,6 +50,6 @@ export const EditableRoot = forwardRef<HTMLDivElement, EditableRootProps>((props
       <ark.div {...mergedProps} ref={ref} />
     </EditableProvider>
   )
-})
+}
 
 EditableRoot.displayName = 'EditableRoot'

--- a/packages/react/src/components/editable/editable-submit-trigger.tsx
+++ b/packages/react/src/components/editable/editable-submit-trigger.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useEditableContext } from './use-editable-context'
 
 export interface EditableSubmitTriggerBaseProps extends PolymorphicProps {}
 export interface EditableSubmitTriggerProps extends HTMLProps<'button'>, EditableSubmitTriggerBaseProps {}
 
-export const EditableSubmitTrigger = forwardRef<HTMLButtonElement, EditableSubmitTriggerProps>((props, ref) => {
+export const EditableSubmitTrigger = ({ ref, ...props }: EditableSubmitTriggerProps) => {
   const editable = useEditableContext()
   const mergedProps = mergeProps(editable.getSubmitTriggerProps(), props)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 EditableSubmitTrigger.displayName = 'EditableSubmitTrigger'

--- a/packages/react/src/components/factory.ts
+++ b/packages/react/src/components/factory.ts
@@ -3,7 +3,7 @@ import { mergeProps } from '@zag-js/core'
 import type React from 'react'
 import {
   Children,
-  type ComponentPropsWithoutRef,
+  type ComponentPropsWithRef,
   type JSX,
   cloneElement,
   createElement,
@@ -73,7 +73,7 @@ const withAsChild = (Component: React.ElementType) => {
   return Comp
 }
 
-export type HTMLProps<T extends keyof JSX.IntrinsicElements> = ComponentPropsWithoutRef<T>
+export type HTMLProps<T extends keyof JSX.IntrinsicElements> = ComponentPropsWithRef<T>
 export type HTMLArkProps<T extends keyof JSX.IntrinsicElements> = HTMLProps<T> & PolymorphicProps
 
 export const jsxFactory = () => {

--- a/packages/react/src/components/field/field-error-text.tsx
+++ b/packages/react/src/components/field/field-error-text.tsx
@@ -1,14 +1,13 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useFieldContext } from './use-field-context'
 
 export interface FieldErrorTextBaseProps extends PolymorphicProps {}
 export interface FieldErrorTextProps extends HTMLProps<'span'>, FieldErrorTextBaseProps {}
 
-export const FieldErrorText = forwardRef<HTMLSpanElement, FieldErrorTextProps>((props, ref) => {
+export const FieldErrorText = ({ ref, ...props }: FieldErrorTextProps) => {
   const field = useFieldContext()
   const mergedProps = mergeProps(field.getErrorTextProps(), props)
 
@@ -16,6 +15,6 @@ export const FieldErrorText = forwardRef<HTMLSpanElement, FieldErrorTextProps>((
     return <ark.span {...mergedProps} ref={ref} />
   }
   return null
-})
+}
 
 FieldErrorText.displayName = 'FieldErrorText'

--- a/packages/react/src/components/field/field-helper-text.tsx
+++ b/packages/react/src/components/field/field-helper-text.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useFieldContext } from './use-field-context'
 
 export interface FieldHelperTextBaseProps extends PolymorphicProps {}
 export interface FieldHelperTextProps extends HTMLProps<'span'>, FieldHelperTextBaseProps {}
 
-export const FieldHelperText = forwardRef<HTMLSpanElement, FieldHelperTextProps>((props, ref) => {
+export const FieldHelperText = ({ ref, ...props }: FieldHelperTextProps) => {
   const field = useFieldContext()
   const mergedProps = mergeProps<HTMLProps<'span'>>(field?.getHelperTextProps(), props)
 
   return <ark.span {...mergedProps} ref={ref} />
-})
+}
 
 FieldHelperText.displayName = 'FieldHelperText'

--- a/packages/react/src/components/field/field-input.tsx
+++ b/packages/react/src/components/field/field-input.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useFieldContext } from './use-field-context'
 
 export interface FieldInputBaseProps extends PolymorphicProps {}
 export interface FieldInputProps extends HTMLProps<'input'>, FieldInputBaseProps {}
 
-export const FieldInput = forwardRef<HTMLInputElement, FieldInputProps>((props, ref) => {
+export const FieldInput = ({ ref, ...props }: FieldInputProps) => {
   const field = useFieldContext()
   const mergedProps = mergeProps<HTMLProps<'input'>>(field?.getInputProps(), props)
 
   return <ark.input {...mergedProps} ref={ref} />
-})
+}
 
 FieldInput.displayName = 'FieldInput'

--- a/packages/react/src/components/field/field-label.tsx
+++ b/packages/react/src/components/field/field-label.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useFieldContext } from './use-field-context'
 
 export interface FieldLabelBaseProps extends PolymorphicProps {}
 export interface FieldLabelProps extends HTMLProps<'label'>, FieldLabelBaseProps {}
 
-export const FieldLabel = forwardRef<HTMLLabelElement, FieldLabelProps>((props, ref) => {
+export const FieldLabel = ({ ref, ...props }: FieldLabelProps) => {
   const field = useFieldContext()
   const mergedProps = mergeProps<HTMLProps<'label'>>(field?.getLabelProps(), props)
 
   return <ark.label {...mergedProps} ref={ref} />
-})
+}
 
 FieldLabel.displayName = 'FieldLabel'

--- a/packages/react/src/components/field/field-required-indicator.tsx
+++ b/packages/react/src/components/field/field-required-indicator.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/core'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useFieldContext } from './use-field-context'
 
@@ -10,21 +9,25 @@ export interface FieldRequiredIndicatorBaseProps extends PolymorphicProps {
 }
 export interface FieldRequiredIndicatorProps extends HTMLProps<'span'>, FieldRequiredIndicatorBaseProps {}
 
-export const FieldRequiredIndicator = forwardRef<HTMLSpanElement, FieldRequiredIndicatorProps>(
-  ({ fallback, ...props }, ref) => {
-    const field = useFieldContext()
+export const FieldRequiredIndicator = ({
+  ref,
+  fallback,
+  ...props
+}: FieldRequiredIndicatorProps & {
+  ref: React.RefObject<HTMLSpanElement>
+}) => {
+  const field = useFieldContext()
 
-    if (!field.required) {
-      return fallback
-    }
+  if (!field.required) {
+    return fallback
+  }
 
-    const mergedProps = mergeProps(field.getRequiredIndicatorProps(), props)
-    return (
-      <ark.span {...mergedProps} ref={ref}>
-        {props.children ?? '*'}
-      </ark.span>
-    )
-  },
-)
+  const mergedProps = mergeProps(field.getRequiredIndicatorProps(), props)
+  return (
+    <ark.span {...mergedProps} ref={ref}>
+      {props.children ?? '*'}
+    </ark.span>
+  )
+}
 
 FieldRequiredIndicator.displayName = 'FieldRequiredIndicator'

--- a/packages/react/src/components/field/field-root-provider.tsx
+++ b/packages/react/src/components/field/field-root-provider.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import type { UseFieldReturn } from './use-field'
@@ -16,7 +15,7 @@ export interface FieldRootProviderProps extends HTMLProps<'div'>, FieldRootProvi
 
 const splitRootProviderProps = createSplitProps<RootProviderProps>()
 
-export const FieldRootProvider = forwardRef<HTMLDivElement, FieldRootProviderProps>((props, ref) => {
+export const FieldRootProvider = ({ ref, ...props }: FieldRootProviderProps) => {
   const [{ value: field }, localProps] = splitRootProviderProps(props, ['value'])
   const mergedProps = mergeProps<HTMLProps<'div'>>(field.getRootProps(), localProps)
 
@@ -25,6 +24,6 @@ export const FieldRootProvider = forwardRef<HTMLDivElement, FieldRootProviderPro
       <ark.div {...mergedProps} ref={ref} />
     </FieldProvider>
   )
-})
+}
 
 FieldRootProvider.displayName = 'FieldRootProvider'

--- a/packages/react/src/components/field/field-root.tsx
+++ b/packages/react/src/components/field/field-root.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { composeRefs } from '../../utils/compose-refs'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -13,7 +12,7 @@ export interface FieldRootProps extends HTMLProps<'div'>, FieldRootBaseProps {}
 
 const splitRootProps = createSplitProps<UseFieldProps>()
 
-export const FieldRoot = forwardRef<HTMLDivElement, FieldRootProps>((props, ref) => {
+export const FieldRoot = ({ ref, ...props }: FieldRootProps) => {
   const [useFieldProps, localProps] = splitRootProps(props, [
     'id',
     'ids',
@@ -32,6 +31,6 @@ export const FieldRoot = forwardRef<HTMLDivElement, FieldRootProps>((props, ref)
       <ark.div {...mergedProps} ref={composeRefs(ref, field.refs.rootRef)} />
     </FieldProvider>
   )
-})
+}
 
 FieldRoot.displayName = 'FieldRoot'

--- a/packages/react/src/components/field/field-select.tsx
+++ b/packages/react/src/components/field/field-select.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useFieldContext } from './use-field-context'
 
 export interface FieldSelectBaseProps extends PolymorphicProps {}
 export interface FieldSelectProps extends HTMLProps<'select'>, FieldSelectBaseProps {}
 
-export const FieldSelect = forwardRef<HTMLSelectElement, FieldSelectProps>((props, ref) => {
+export const FieldSelect = ({ ref, ...props }: FieldSelectProps) => {
   const field = useFieldContext()
   const mergedProps = mergeProps<HTMLProps<'select'>>(field?.getSelectProps(), props)
 
   return <ark.select {...mergedProps} ref={ref} />
-})
+}
 
 FieldSelect.displayName = 'FieldSelect'

--- a/packages/react/src/components/field/field-textarea.tsx
+++ b/packages/react/src/components/field/field-textarea.tsx
@@ -2,7 +2,7 @@
 
 import { autoresizeTextarea } from '@zag-js/auto-resize'
 import { mergeProps } from '@zag-js/react'
-import { forwardRef, useEffect, useRef } from 'react'
+import { useEffect, useRef } from 'react'
 import { composeRefs } from '../../utils/compose-refs'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useFieldContext } from './use-field-context'
@@ -16,7 +16,7 @@ export interface FieldTextareaBaseProps extends PolymorphicProps {
 }
 export interface FieldTextareaProps extends HTMLProps<'textarea'>, FieldTextareaBaseProps {}
 
-export const FieldTextarea = forwardRef<HTMLTextAreaElement, FieldTextareaProps>((props, ref) => {
+export const FieldTextarea = ({ ref, ...props }: FieldTextareaProps) => {
   const { autoresize, ...textareaProps } = props
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const field = useFieldContext()
@@ -32,6 +32,6 @@ export const FieldTextarea = forwardRef<HTMLTextAreaElement, FieldTextareaProps>
   }, [autoresize])
 
   return <ark.textarea {...mergedProps} ref={composeRefs(ref, textareaRef)} />
-})
+}
 
 FieldTextarea.displayName = 'FieldTextarea'

--- a/packages/react/src/components/fieldset/fieldset-error-text.tsx
+++ b/packages/react/src/components/fieldset/fieldset-error-text.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useFieldsetContext } from './use-fieldset-context'
 
 export interface FieldsetErrorTextBaseProps extends PolymorphicProps {}
 export interface FieldsetErrorTextProps extends HTMLProps<'span'>, FieldsetErrorTextBaseProps {}
 
-export const FieldsetErrorText = forwardRef<HTMLSpanElement, FieldsetErrorTextProps>((props, ref) => {
+export const FieldsetErrorText = ({ ref, ...props }: FieldsetErrorTextProps) => {
   const fieldset = useFieldsetContext()
   const mergedProps = mergeProps(fieldset.getErrorTextProps(), props)
 
   return fieldset.invalid ? <ark.span {...mergedProps} ref={ref} /> : null
-})
+}
 
 FieldsetErrorText.displayName = 'FieldsetErrorText'

--- a/packages/react/src/components/fieldset/fieldset-helper-text.tsx
+++ b/packages/react/src/components/fieldset/fieldset-helper-text.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useFieldsetContext } from './use-fieldset-context'
 
 export interface FieldsetHelperTextBaseProps extends PolymorphicProps {}
 export interface FieldsetHelperTextProps extends HTMLProps<'span'>, FieldsetHelperTextBaseProps {}
 
-export const FieldsetHelperText = forwardRef<HTMLSpanElement, FieldsetHelperTextProps>((props, ref) => {
+export const FieldsetHelperText = ({ ref, ...props }: FieldsetHelperTextProps) => {
   const fieldset = useFieldsetContext()
   const mergedProps = mergeProps(fieldset.getHelperTextProps(), props)
 
   return <ark.span {...mergedProps} ref={ref} />
-})
+}
 
 FieldsetHelperText.displayName = 'FieldsetHelperText'

--- a/packages/react/src/components/fieldset/fieldset-legend.tsx
+++ b/packages/react/src/components/fieldset/fieldset-legend.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useFieldsetContext } from './use-fieldset-context'
 
 export interface FieldsetLegendBaseProps extends PolymorphicProps {}
 export interface FieldsetLegendProps extends HTMLProps<'legend'>, FieldsetLegendBaseProps {}
 
-export const FieldsetLegend = forwardRef<HTMLLegendElement, FieldsetLegendProps>((props, ref) => {
+export const FieldsetLegend = ({ ref, ...props }: FieldsetLegendProps) => {
   const fieldset = useFieldsetContext()
   const mergedProps = mergeProps(fieldset.getLegendProps(), props)
 
   return <ark.legend {...mergedProps} ref={ref} />
-})
+}
 
 FieldsetLegend.displayName = 'FieldsetLegend'

--- a/packages/react/src/components/fieldset/fieldset-root-provider.tsx
+++ b/packages/react/src/components/fieldset/fieldset-root-provider.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import type { UseFieldsetReturn } from './use-fieldset'
@@ -16,7 +15,7 @@ export interface FieldsetRootProviderProps extends HTMLProps<'fieldset'>, Fields
 
 const splitRootProviderProps = createSplitProps<RootProviderProps>()
 
-export const FieldsetRootProvider = forwardRef<HTMLFieldSetElement, FieldsetRootProviderProps>((props, ref) => {
+export const FieldsetRootProvider = ({ ref, ...props }: FieldsetRootProviderProps) => {
   const [{ value: fieldset }, localProps] = splitRootProviderProps(props, ['value'])
   const mergedProps = mergeProps(fieldset.getRootProps(), localProps)
 
@@ -25,6 +24,6 @@ export const FieldsetRootProvider = forwardRef<HTMLFieldSetElement, FieldsetRoot
       <ark.fieldset {...mergedProps} ref={ref} />
     </FieldsetProvider>
   )
-})
+}
 
 FieldsetRootProvider.displayName = 'FieldsetRootProvider'

--- a/packages/react/src/components/fieldset/fieldset-root.tsx
+++ b/packages/react/src/components/fieldset/fieldset-root.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { composeRefs } from '../../utils/compose-refs'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -13,7 +12,7 @@ export interface FieldsetRootProps extends HTMLProps<'fieldset'>, FieldsetRootBa
 
 const splitRootProps = createSplitProps<UseFieldsetProps>()
 
-export const FieldsetRoot = forwardRef<HTMLFieldSetElement, FieldsetRootProps>((props, ref) => {
+export const FieldsetRoot = ({ ref, ...props }: FieldsetRootProps) => {
   const [useFieldsetProps, localProps] = splitRootProps(props, ['id', 'disabled', 'invalid'])
   const fieldset = useFieldset(useFieldsetProps)
   const mergedProps = mergeProps<HTMLProps<'fieldset'>>(fieldset.getRootProps(), localProps)
@@ -23,6 +22,6 @@ export const FieldsetRoot = forwardRef<HTMLFieldSetElement, FieldsetRootProps>((
       <ark.fieldset {...mergedProps} ref={composeRefs(ref, fieldset.refs.rootRef)} />
     </FieldsetProvider>
   )
-})
+}
 
 FieldsetRoot.displayName = 'FieldsetRoot'

--- a/packages/react/src/components/file-upload/file-upload-clear-trigger.tsx
+++ b/packages/react/src/components/file-upload/file-upload-clear-trigger.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useFileUploadContext } from './use-file-upload-context'
 
 export interface FileUploadClearTriggerBaseProps extends PolymorphicProps {}
 export interface FileUploadClearTriggerProps extends HTMLProps<'button'>, FileUploadClearTriggerBaseProps {}
 
-export const FileUploadClearTrigger = forwardRef<HTMLButtonElement, FileUploadClearTriggerProps>((props, ref) => {
+export const FileUploadClearTrigger = ({ ref, ...props }: FileUploadClearTriggerProps) => {
   const fileUpload = useFileUploadContext()
   const mergedProps = mergeProps(fileUpload.getClearTriggerProps(), props)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 FileUploadClearTrigger.displayName = 'FileUploadClearTrigger'

--- a/packages/react/src/components/file-upload/file-upload-dropzone.tsx
+++ b/packages/react/src/components/file-upload/file-upload-dropzone.tsx
@@ -2,7 +2,6 @@
 
 import type { DropzoneProps } from '@zag-js/file-upload'
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useFileUploadContext } from './use-file-upload-context'
@@ -12,12 +11,12 @@ export interface FileUploadDropzoneProps extends HTMLProps<'div'>, FileUploadDro
 
 const splitDropzoneProps = createSplitProps<DropzoneProps>()
 
-export const FileUploadDropzone = forwardRef<HTMLDivElement, FileUploadDropzoneProps>((props, ref) => {
+export const FileUploadDropzone = ({ ref, ...props }: FileUploadDropzoneProps) => {
   const [dropzoneProps, localProps] = splitDropzoneProps(props, ['disableClick'])
   const fileUpload = useFileUploadContext()
   const mergedProps = mergeProps(fileUpload.getDropzoneProps(dropzoneProps), localProps)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 FileUploadDropzone.displayName = 'FileUploadDropzone'

--- a/packages/react/src/components/file-upload/file-upload-hidden-input.tsx
+++ b/packages/react/src/components/file-upload/file-upload-hidden-input.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useFieldContext } from '../field'
 import { useFileUploadContext } from './use-file-upload-context'
@@ -9,12 +8,12 @@ import { useFileUploadContext } from './use-file-upload-context'
 export interface FileUploadHiddenInputBaseProps extends PolymorphicProps {}
 export interface FileUploadHiddenInputProps extends HTMLProps<'input'>, FileUploadHiddenInputBaseProps {}
 
-export const FileUploadHiddenInput = forwardRef<HTMLInputElement, FileUploadHiddenInputProps>((props, ref) => {
+export const FileUploadHiddenInput = ({ ref, ...props }: FileUploadHiddenInputProps) => {
   const fileUpload = useFileUploadContext()
   const mergedProps = mergeProps(fileUpload.getHiddenInputProps(), props)
   const field = useFieldContext()
 
   return <ark.input aria-describedby={field?.ariaDescribedby} {...mergedProps} ref={ref} />
-})
+}
 
 FileUploadHiddenInput.displayName = 'FileUploadHiddenInput'

--- a/packages/react/src/components/file-upload/file-upload-item-delete-trigger.tsx
+++ b/packages/react/src/components/file-upload/file-upload-item-delete-trigger.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useFileUploadContext } from './use-file-upload-context'
 import { useFileUploadItemPropsContext } from './use-file-upload-item-props-context'
@@ -9,14 +8,12 @@ import { useFileUploadItemPropsContext } from './use-file-upload-item-props-cont
 export interface FileUploadItemDeleteTriggerBaseProps extends PolymorphicProps {}
 export interface FileUploadItemDeleteTriggerProps extends HTMLProps<'button'>, FileUploadItemDeleteTriggerBaseProps {}
 
-export const FileUploadItemDeleteTrigger = forwardRef<HTMLButtonElement, FileUploadItemDeleteTriggerProps>(
-  (props, ref) => {
-    const fileUpload = useFileUploadContext()
-    const itemProps = useFileUploadItemPropsContext()
-    const mergedProps = mergeProps(fileUpload.getItemDeleteTriggerProps(itemProps), props)
+export const FileUploadItemDeleteTrigger = ({ ref, ...props }: FileUploadItemDeleteTriggerProps) => {
+  const fileUpload = useFileUploadContext()
+  const itemProps = useFileUploadItemPropsContext()
+  const mergedProps = mergeProps(fileUpload.getItemDeleteTriggerProps(itemProps), props)
 
-    return <ark.button {...mergedProps} ref={ref} />
-  },
-)
+  return <ark.button {...mergedProps} ref={ref} />
+}
 
 FileUploadItemDeleteTrigger.displayName = 'FileUploadItemDeleteTrigger'

--- a/packages/react/src/components/file-upload/file-upload-item-group.tsx
+++ b/packages/react/src/components/file-upload/file-upload-item-group.tsx
@@ -2,7 +2,6 @@
 
 import { mergeProps } from '@zag-js/react'
 import type { ItemGroupProps } from '@zag-js/file-upload'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useFileUploadContext } from './use-file-upload-context'
@@ -13,7 +12,7 @@ export interface FileUploadItemGroupProps extends HTMLProps<'ul'>, FileUploadIte
 
 const splitItemGroupProps = createSplitProps<ItemGroupProps>()
 
-export const FileUploadItemGroup = forwardRef<HTMLUListElement, FileUploadItemGroupProps>((props, ref) => {
+export const FileUploadItemGroup = ({ ref, ...props }: FileUploadItemGroupProps) => {
   const [itemGroupProps, localProps] = splitItemGroupProps(props, ['type'])
   const fileUpload = useFileUploadContext()
   const mergedProps = mergeProps(fileUpload.getItemGroupProps(itemGroupProps), localProps)
@@ -23,6 +22,6 @@ export const FileUploadItemGroup = forwardRef<HTMLUListElement, FileUploadItemGr
       <ark.ul {...mergedProps} ref={ref} />
     </FileUploadItemGroupPropsProvider>
   )
-})
+}
 
 FileUploadItemGroup.displayName = 'FileUploadItemGroup'

--- a/packages/react/src/components/file-upload/file-upload-item-name.tsx
+++ b/packages/react/src/components/file-upload/file-upload-item-name.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useFileUploadContext } from './use-file-upload-context'
 import { useFileUploadItemPropsContext } from './use-file-upload-item-props-context'
@@ -9,7 +8,7 @@ import { useFileUploadItemPropsContext } from './use-file-upload-item-props-cont
 export interface FileUploadItemNameBaseProps extends PolymorphicProps {}
 export interface FileUploadItemNameProps extends HTMLProps<'div'>, FileUploadItemNameBaseProps {}
 
-export const FileUploadItemName = forwardRef<HTMLDivElement, FileUploadItemNameProps>((props, ref) => {
+export const FileUploadItemName = ({ ref, ...props }: FileUploadItemNameProps) => {
   const { children, ...rest } = props
   const fileUpload = useFileUploadContext()
   const itemProps = useFileUploadItemPropsContext()
@@ -20,6 +19,6 @@ export const FileUploadItemName = forwardRef<HTMLDivElement, FileUploadItemNameP
       {children || itemProps.file.name}
     </ark.div>
   )
-})
+}
 
 FileUploadItemName.displayName = 'FileUploadItemName'

--- a/packages/react/src/components/file-upload/file-upload-item-preview-image.tsx
+++ b/packages/react/src/components/file-upload/file-upload-item-preview-image.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useFileUploadContext } from './use-file-upload-context'
 import { useFileUploadItemPropsContext } from './use-file-upload-item-props-context'
@@ -9,21 +9,19 @@ import { useFileUploadItemPropsContext } from './use-file-upload-item-props-cont
 export interface FileUploadItemPreviewImageBaseProps extends PolymorphicProps {}
 export interface FileUploadItemPreviewImageProps extends HTMLProps<'img'>, FileUploadItemPreviewImageBaseProps {}
 
-export const FileUploadItemPreviewImage = forwardRef<HTMLImageElement, FileUploadItemPreviewImageProps>(
-  (props, ref) => {
-    const [url, setUrl] = useState<string>('')
-    const fileUpload = useFileUploadContext()
-    const itemProps = useFileUploadItemPropsContext()
-    const mergedProps = mergeProps(fileUpload.getItemPreviewImageProps({ ...itemProps, url }), props)
+export const FileUploadItemPreviewImage = ({ ref, ...props }: FileUploadItemPreviewImageProps) => {
+  const [url, setUrl] = useState<string>('')
+  const fileUpload = useFileUploadContext()
+  const itemProps = useFileUploadItemPropsContext()
+  const mergedProps = mergeProps(fileUpload.getItemPreviewImageProps({ ...itemProps, url }), props)
 
-    useEffect(() => {
-      return fileUpload.createFileUrl(itemProps.file, (url) => setUrl(url))
-    }, [itemProps, fileUpload])
+  useEffect(() => {
+    return fileUpload.createFileUrl(itemProps.file, (url) => setUrl(url))
+  }, [itemProps, fileUpload])
 
-    if (!url) return null
+  if (!url) return null
 
-    return <ark.img {...mergedProps} ref={ref} />
-  },
-)
+  return <ark.img {...mergedProps} ref={ref} />
+}
 
 FileUploadItemPreviewImage.displayName = 'FileUploadItemPreviewImage'

--- a/packages/react/src/components/file-upload/file-upload-item-preview.tsx
+++ b/packages/react/src/components/file-upload/file-upload-item-preview.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useFileUploadContext } from './use-file-upload-context'
 import { useFileUploadItemPropsContext } from './use-file-upload-item-props-context'
@@ -15,7 +14,7 @@ export interface FileUploadItemPreviewBaseProps extends PolymorphicProps {
 }
 export interface FileUploadItemPreviewProps extends HTMLProps<'div'>, FileUploadItemPreviewBaseProps {}
 
-export const FileUploadItemPreview = forwardRef<HTMLImageElement, FileUploadItemPreviewProps>((props, ref) => {
+export const FileUploadItemPreview = ({ ref, ...props }: FileUploadItemPreviewProps) => {
   const fileUpload = useFileUploadContext()
   const itemProps = useFileUploadItemPropsContext()
   const mergedProps = mergeProps(fileUpload.getItemPreviewProps(itemProps), props)
@@ -23,6 +22,6 @@ export const FileUploadItemPreview = forwardRef<HTMLImageElement, FileUploadItem
   if (!itemProps.file.type.match(props.type ?? '.*')) return null
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 FileUploadItemPreview.displayName = 'FileUploadItemPreview'

--- a/packages/react/src/components/file-upload/file-upload-item-size-text.tsx
+++ b/packages/react/src/components/file-upload/file-upload-item-size-text.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useFileUploadContext } from './use-file-upload-context'
 import { useFileUploadItemPropsContext } from './use-file-upload-item-props-context'
@@ -9,7 +8,7 @@ import { useFileUploadItemPropsContext } from './use-file-upload-item-props-cont
 export interface FileUploadItemSizeTextBaseProps extends PolymorphicProps {}
 export interface FileUploadItemSizeTextProps extends HTMLProps<'div'>, FileUploadItemSizeTextBaseProps {}
 
-export const FileUploadItemSizeText = forwardRef<HTMLDivElement, FileUploadItemSizeTextProps>((props, ref) => {
+export const FileUploadItemSizeText = ({ ref, ...props }: FileUploadItemSizeTextProps) => {
   const { children, ...rest } = props
   const fileUpload = useFileUploadContext()
   const itemProps = useFileUploadItemPropsContext()
@@ -20,6 +19,6 @@ export const FileUploadItemSizeText = forwardRef<HTMLDivElement, FileUploadItemS
       {children || fileUpload.getFileSize(itemProps.file)}
     </ark.div>
   )
-})
+}
 
 FileUploadItemSizeText.displayName = 'FileUploadItemSizeText'

--- a/packages/react/src/components/file-upload/file-upload-item.tsx
+++ b/packages/react/src/components/file-upload/file-upload-item.tsx
@@ -2,7 +2,6 @@
 
 import type { ItemProps } from '@zag-js/file-upload'
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useFileUploadContext } from './use-file-upload-context'
@@ -16,7 +15,7 @@ export interface FileUploadItemProps extends HTMLProps<'li'>, FileUploadItemBase
 
 const splitItemBaseProps = createSplitProps<ItemBaseProps>()
 
-export const FileUploadItem = forwardRef<HTMLLIElement, FileUploadItemProps>((props, ref) => {
+export const FileUploadItem = ({ ref, ...props }: FileUploadItemProps) => {
   const [itemProps, localProps] = splitItemBaseProps(props, ['file'])
   const fileUpload = useFileUploadContext()
 
@@ -30,6 +29,6 @@ export const FileUploadItem = forwardRef<HTMLLIElement, FileUploadItemProps>((pr
       <ark.li {...mergedProps} ref={ref} />
     </FileUploadItemPropsProvider>
   )
-})
+}
 
 FileUploadItem.displayName = 'FileUploadItem'

--- a/packages/react/src/components/file-upload/file-upload-label.tsx
+++ b/packages/react/src/components/file-upload/file-upload-label.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useFileUploadContext } from './use-file-upload-context'
 
 export interface FileUploadLabelBaseProps extends PolymorphicProps {}
 export interface FileUploadLabelProps extends HTMLProps<'label'>, FileUploadLabelBaseProps {}
 
-export const FileUploadLabel = forwardRef<HTMLLabelElement, FileUploadLabelProps>((props, ref) => {
+export const FileUploadLabel = ({ ref, ...props }: FileUploadLabelProps) => {
   const fileUpload = useFileUploadContext()
   const mergedProps = mergeProps(fileUpload.getLabelProps(), props)
 
   return <ark.label {...mergedProps} ref={ref} />
-})
+}
 
 FileUploadLabel.displayName = 'FileUploadLabel'

--- a/packages/react/src/components/file-upload/file-upload-root-provider.tsx
+++ b/packages/react/src/components/file-upload/file-upload-root-provider.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import type { UseFileUploadReturn } from './use-file-upload'
@@ -16,7 +15,7 @@ export interface FileUploadRootProviderProps extends HTMLProps<'div'>, FileUploa
 
 const splitRootProviderProps = createSplitProps<RootProviderProps>()
 
-export const FileUploadRootProvider = forwardRef<HTMLDivElement, FileUploadRootProviderProps>((props, ref) => {
+export const FileUploadRootProvider = ({ ref, ...props }: FileUploadRootProviderProps) => {
   const [{ value: fileUpload }, localProps] = splitRootProviderProps(props, ['value'])
   const mergedProps = mergeProps(fileUpload.getRootProps(), localProps)
 
@@ -25,6 +24,6 @@ export const FileUploadRootProvider = forwardRef<HTMLDivElement, FileUploadRootP
       <ark.div {...mergedProps} ref={ref} />
     </FileUploadProvider>
   )
-})
+}
 
 FileUploadRootProvider.displayName = 'FileUploadRootProvider'

--- a/packages/react/src/components/file-upload/file-upload-root.tsx
+++ b/packages/react/src/components/file-upload/file-upload-root.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { type UseFileUploadProps, useFileUpload } from './use-file-upload'
@@ -12,7 +11,7 @@ export interface FileUploadRootProps extends HTMLProps<'div'>, FileUploadRootBas
 
 const splitRootProps = createSplitProps<UseFileUploadProps>()
 
-export const FileUploadRoot = forwardRef<HTMLDivElement, FileUploadRootProps>((props, ref) => {
+export const FileUploadRoot = ({ ref, ...props }: FileUploadRootProps) => {
   const [useFileUploadProps, localProps] = splitRootProps(props, [
     'accept',
     'acceptedFiles',
@@ -47,6 +46,6 @@ export const FileUploadRoot = forwardRef<HTMLDivElement, FileUploadRootProps>((p
       <ark.div {...mergedProps} ref={ref} />
     </FileUploadProvider>
   )
-})
+}
 
 FileUploadRoot.displayName = 'FileUploadRoot'

--- a/packages/react/src/components/file-upload/file-upload-trigger.tsx
+++ b/packages/react/src/components/file-upload/file-upload-trigger.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useFileUploadContext } from './use-file-upload-context'
 
 export interface FileUploadTriggerBaseProps extends PolymorphicProps {}
 export interface FileUploadTriggerProps extends HTMLProps<'button'>, FileUploadTriggerBaseProps {}
 
-export const FileUploadTrigger = forwardRef<HTMLButtonElement, FileUploadTriggerProps>((props, ref) => {
+export const FileUploadTrigger = ({ ref, ...props }: FileUploadTriggerProps) => {
   const fileUpload = useFileUploadContext()
   const mergedProps = mergeProps(fileUpload.getTriggerProps(), props)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 FileUploadTrigger.displayName = 'FileUploadTrigger'

--- a/packages/react/src/components/floating-panel/floating-panel-body.tsx
+++ b/packages/react/src/components/floating-panel/floating-panel-body.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useFloatingPanelContext } from './use-floating-panel-context'
 
 export interface FloatingPanelBodyBaseProps extends PolymorphicProps {}
 export interface FloatingPanelBodyProps extends HTMLProps<'div'>, FloatingPanelBodyBaseProps {}
 
-export const FloatingPanelBody = forwardRef<HTMLDivElement, FloatingPanelBodyProps>((props, ref) => {
+export const FloatingPanelBody = ({ ref, ...props }: FloatingPanelBodyProps) => {
   const floatingPanel = useFloatingPanelContext()
   const mergedProps = mergeProps(floatingPanel.getBodyProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 FloatingPanelBody.displayName = 'FloatingPanelBody'

--- a/packages/react/src/components/floating-panel/floating-panel-close-trigger.tsx
+++ b/packages/react/src/components/floating-panel/floating-panel-close-trigger.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useFloatingPanelContext } from './use-floating-panel-context'
 
 export interface FloatingPanelCloseTriggerBaseProps extends PolymorphicProps {}
 export interface FloatingPanelCloseTriggerProps extends HTMLProps<'button'>, FloatingPanelCloseTriggerBaseProps {}
 
-export const FloatingPanelCloseTrigger = forwardRef<HTMLButtonElement, FloatingPanelCloseTriggerProps>((props, ref) => {
+export const FloatingPanelCloseTrigger = ({ ref, ...props }: FloatingPanelCloseTriggerProps) => {
   const floatingPanel = useFloatingPanelContext()
   const mergedProps = mergeProps(floatingPanel.getCloseTriggerProps(), props)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 FloatingPanelCloseTrigger.displayName = 'FloatingPanelCloseTrigger'

--- a/packages/react/src/components/floating-panel/floating-panel-content.tsx
+++ b/packages/react/src/components/floating-panel/floating-panel-content.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { composeRefs } from '../../utils/compose-refs'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { usePresenceContext } from '../presence'
@@ -10,7 +9,7 @@ import { useFloatingPanelContext } from './use-floating-panel-context'
 export interface FloatingPanelContentBaseProps extends PolymorphicProps {}
 export interface FloatingPanelContentProps extends HTMLProps<'div'>, FloatingPanelContentBaseProps {}
 
-export const FloatingPanelContent = forwardRef<HTMLDivElement, FloatingPanelContentProps>((props, ref) => {
+export const FloatingPanelContent = ({ ref, ...props }: FloatingPanelContentProps) => {
   const floatingPanel = useFloatingPanelContext()
   const presence = usePresenceContext()
   const mergedProps = mergeProps(floatingPanel.getContentProps(), presence.getPresenceProps(), props)
@@ -20,6 +19,6 @@ export const FloatingPanelContent = forwardRef<HTMLDivElement, FloatingPanelCont
   }
 
   return <ark.div {...mergedProps} ref={composeRefs(presence.ref, ref)} />
-})
+}
 
 FloatingPanelContent.displayName = 'FloatingPanelContent'

--- a/packages/react/src/components/floating-panel/floating-panel-control.tsx
+++ b/packages/react/src/components/floating-panel/floating-panel-control.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useFloatingPanelContext } from './use-floating-panel-context'
 
 export interface FloatingPanelControlBaseProps extends PolymorphicProps {}
 export interface FloatingPanelControlProps extends HTMLProps<'div'>, FloatingPanelControlBaseProps {}
 
-export const FloatingPanelControl = forwardRef<HTMLDivElement, FloatingPanelControlProps>((props, ref) => {
+export const FloatingPanelControl = ({ ref, ...props }: FloatingPanelControlProps) => {
   const floatingPanel = useFloatingPanelContext()
   const mergedProps = mergeProps(floatingPanel.getControlProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 FloatingPanelControl.displayName = 'FloatingPanelControl'

--- a/packages/react/src/components/floating-panel/floating-panel-drag-trigger.tsx
+++ b/packages/react/src/components/floating-panel/floating-panel-drag-trigger.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useFloatingPanelContext } from './use-floating-panel-context'
 
 export interface FloatingPanelDragTriggerBaseProps extends PolymorphicProps {}
 export interface FloatingPanelDragTriggerProps extends HTMLProps<'div'>, FloatingPanelDragTriggerBaseProps {}
 
-export const FloatingPanelDragTrigger = forwardRef<HTMLDivElement, FloatingPanelDragTriggerProps>((props, ref) => {
+export const FloatingPanelDragTrigger = ({ ref, ...props }: FloatingPanelDragTriggerProps) => {
   const floatingPanel = useFloatingPanelContext()
   const mergedProps = mergeProps(floatingPanel.getDragTriggerProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 FloatingPanelDragTrigger.displayName = 'FloatingPanelDragTrigger'

--- a/packages/react/src/components/floating-panel/floating-panel-header.tsx
+++ b/packages/react/src/components/floating-panel/floating-panel-header.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useFloatingPanelContext } from './use-floating-panel-context'
 
 export interface FloatingPanelHeaderBaseProps extends PolymorphicProps {}
 export interface FloatingPanelHeaderProps extends HTMLProps<'div'>, FloatingPanelHeaderBaseProps {}
 
-export const FloatingPanelHeader = forwardRef<HTMLDivElement, FloatingPanelHeaderProps>((props, ref) => {
+export const FloatingPanelHeader = ({ ref, ...props }: FloatingPanelHeaderProps) => {
   const floatingPanel = useFloatingPanelContext()
   const mergedProps = mergeProps(floatingPanel.getHeaderProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 FloatingPanelHeader.displayName = 'FloatingPanelHeader'

--- a/packages/react/src/components/floating-panel/floating-panel-positioner.tsx
+++ b/packages/react/src/components/floating-panel/floating-panel-positioner.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { usePresenceContext } from '../presence'
 import { useFloatingPanelContext } from './use-floating-panel-context'
@@ -9,7 +8,7 @@ import { useFloatingPanelContext } from './use-floating-panel-context'
 export interface FloatingPanelPositionerBaseProps extends PolymorphicProps {}
 export interface FloatingPanelPositionerProps extends HTMLProps<'div'>, FloatingPanelPositionerBaseProps {}
 
-export const FloatingPanelPositioner = forwardRef<HTMLDivElement, FloatingPanelPositionerProps>((props, ref) => {
+export const FloatingPanelPositioner = ({ ref, ...props }: FloatingPanelPositionerProps) => {
   const floatingPanel = useFloatingPanelContext()
   const mergedProps = mergeProps(floatingPanel.getPositionerProps(), props)
   const presence = usePresenceContext()
@@ -19,6 +18,6 @@ export const FloatingPanelPositioner = forwardRef<HTMLDivElement, FloatingPanelP
   }
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 FloatingPanelPositioner.displayName = 'FloatingPanelPositioner'

--- a/packages/react/src/components/floating-panel/floating-panel-resize-trigger.tsx
+++ b/packages/react/src/components/floating-panel/floating-panel-resize-trigger.tsx
@@ -2,7 +2,6 @@
 
 import type { ResizeTriggerProps } from '@zag-js/floating-panel'
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useFloatingPanelContext } from './use-floating-panel-context'
@@ -12,12 +11,12 @@ export interface FloatingPanelResizeTriggerProps extends HTMLProps<'div'>, Float
 
 const splitResizeTriggerProps = createSplitProps<ResizeTriggerProps>()
 
-export const FloatingPanelResizeTrigger = forwardRef<HTMLDivElement, FloatingPanelResizeTriggerProps>((props, ref) => {
+export const FloatingPanelResizeTrigger = ({ ref, ...props }: FloatingPanelResizeTriggerProps) => {
   const [resizeProps, localProps] = splitResizeTriggerProps(props, ['axis'])
   const floatingPanel = useFloatingPanelContext()
   const mergedProps = mergeProps(floatingPanel.getResizeTriggerProps(resizeProps), localProps)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 FloatingPanelResizeTrigger.displayName = 'FloatingPanelResizeTrigger'

--- a/packages/react/src/components/floating-panel/floating-panel-stage-trigger.tsx
+++ b/packages/react/src/components/floating-panel/floating-panel-stage-trigger.tsx
@@ -2,7 +2,6 @@
 
 import type { StageTriggerProps } from '@zag-js/floating-panel'
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useFloatingPanelContext } from './use-floating-panel-context'
@@ -12,12 +11,12 @@ export interface FloatingPanelStageTriggerProps extends HTMLProps<'button'>, Flo
 
 const splitStageTriggerProps = createSplitProps<StageTriggerProps>()
 
-export const FloatingPanelStageTrigger = forwardRef<HTMLButtonElement, FloatingPanelStageTriggerProps>((props, ref) => {
+export const FloatingPanelStageTrigger = ({ ref, ...props }: FloatingPanelStageTriggerProps) => {
   const [stage, localProps] = splitStageTriggerProps(props, ['stage'])
   const floatingPanel = useFloatingPanelContext()
   const mergedProps = mergeProps(floatingPanel.getStageTriggerProps(stage), localProps)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 FloatingPanelStageTrigger.displayName = 'FloatingPanelStageTrigger'

--- a/packages/react/src/components/floating-panel/floating-panel-title.tsx
+++ b/packages/react/src/components/floating-panel/floating-panel-title.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useFloatingPanelContext } from './use-floating-panel-context'
 
 export interface FloatingPanelTitleBaseProps extends PolymorphicProps {}
 export interface FloatingPanelTitleProps extends HTMLProps<'h2'>, FloatingPanelTitleBaseProps {}
 
-export const FloatingPanelTitle = forwardRef<HTMLDivElement, FloatingPanelTitleProps>((props, ref) => {
+export const FloatingPanelTitle = ({ ref, ...props }: FloatingPanelTitleProps) => {
   const floatingPanel = useFloatingPanelContext()
   const mergedProps = mergeProps(floatingPanel.getTitleProps(), props)
 
   return <ark.h2 {...mergedProps} ref={ref} />
-})
+}
 
 FloatingPanelTitle.displayName = 'FloatingPanelTitle'

--- a/packages/react/src/components/floating-panel/floating-panel-trigger.tsx
+++ b/packages/react/src/components/floating-panel/floating-panel-trigger.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { usePresenceContext } from '../presence'
 import { useFloatingPanelContext } from './use-floating-panel-context'
@@ -9,7 +8,7 @@ import { useFloatingPanelContext } from './use-floating-panel-context'
 export interface FloatingPanelTriggerBaseProps extends PolymorphicProps {}
 export interface FloatingPanelTriggerProps extends HTMLProps<'button'>, FloatingPanelTriggerBaseProps {}
 
-export const FloatingPanelTrigger = forwardRef<HTMLButtonElement, FloatingPanelTriggerProps>((props, ref) => {
+export const FloatingPanelTrigger = ({ ref, ...props }: FloatingPanelTriggerProps) => {
   const floatingPanel = useFloatingPanelContext()
   const presence = usePresenceContext()
 
@@ -23,6 +22,6 @@ export const FloatingPanelTrigger = forwardRef<HTMLButtonElement, FloatingPanelT
   )
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 FloatingPanelTrigger.displayName = 'FloatingPanelTrigger'

--- a/packages/react/src/components/focus-trap/focus-trap.tsx
+++ b/packages/react/src/components/focus-trap/focus-trap.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { type FocusTrapOptions, trapFocus } from '@zag-js/focus-trap'
-import { forwardRef, useRef } from 'react'
+import { useRef } from 'react'
 import type { Assign } from '../../types'
 import { composeRefs } from '../../utils/compose-refs'
 import { createSplitProps } from '../../utils/create-split-props'
@@ -24,7 +24,7 @@ export interface FocusTrapProps extends Assign<HTMLProps<'div'>, FocusTrapBasePr
 
 const splitTrapProps = createSplitProps<TrapOptions>()
 
-export const FocusTrap = forwardRef<HTMLDivElement, FocusTrapProps>((props, ref) => {
+export const FocusTrap = ({ ref, ...props }: FocusTrapProps) => {
   const localRef = useRef<HTMLDivElement | null>(null)
   const [trapProps, localProps] = splitTrapProps(props, [
     'disabled',
@@ -43,6 +43,6 @@ export const FocusTrap = forwardRef<HTMLDivElement, FocusTrapProps>((props, ref)
   }, [ref, trapProps])
 
   return <ark.div ref={composeRefs(localRef, ref)} {...localProps} />
-})
+}
 
 FocusTrap.displayName = 'FocusTrap'

--- a/packages/react/src/components/frame/frame.tsx
+++ b/packages/react/src/components/frame/frame.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { forwardRef, useEffect, useId, useState } from 'react'
+import { useEffect, useId, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { EnvironmentProvider } from '../../providers'
 import type { Assign } from '../../types'
@@ -30,7 +30,7 @@ function getMountNode(frame: HTMLIFrameElement) {
   return mountNode
 }
 
-export const Frame = forwardRef<HTMLIFrameElement, FrameProps>((props, ref) => {
+export const Frame = ({ ref, ...props }: FrameProps) => {
   const { children, head, onMount, onUnmount, srcDoc = initialSrcDoc, ...rest } = props
 
   const [frameRef, setFrameRef] = useState<HTMLIFrameElement | null>(null)
@@ -95,4 +95,4 @@ export const Frame = forwardRef<HTMLIFrameElement, FrameProps>((props, ref) => {
       </iframe>
     </EnvironmentProvider>
   )
-})
+}

--- a/packages/react/src/components/hover-card/hover-card-arrow-tip.tsx
+++ b/packages/react/src/components/hover-card/hover-card-arrow-tip.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useHoverCardContext } from './use-hover-card-context'
 
 export interface HoverCardArrowTipBaseProps extends PolymorphicProps {}
 export interface HoverCardArrowTipProps extends HTMLProps<'div'>, HoverCardArrowTipBaseProps {}
 
-export const HoverCardArrowTip = forwardRef<HTMLDivElement, HoverCardArrowTipProps>((props, ref) => {
+export const HoverCardArrowTip = ({ ref, ...props }: HoverCardArrowTipProps) => {
   const hoverCard = useHoverCardContext()
   const mergedProps = mergeProps(hoverCard.getArrowTipProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 HoverCardArrowTip.displayName = 'HoverCardArrowTip'

--- a/packages/react/src/components/hover-card/hover-card-arrow.tsx
+++ b/packages/react/src/components/hover-card/hover-card-arrow.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useHoverCardContext } from './use-hover-card-context'
 
 export interface HoverCardArrowBaseProps extends PolymorphicProps {}
 export interface HoverCardArrowProps extends HTMLProps<'div'>, HoverCardArrowBaseProps {}
 
-export const HoverCardArrow = forwardRef<HTMLDivElement, HoverCardArrowProps>((props, ref) => {
+export const HoverCardArrow = ({ ref, ...props }: HoverCardArrowProps) => {
   const hoverCard = useHoverCardContext()
   const mergedProps = mergeProps(hoverCard.getArrowProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 HoverCardArrow.displayName = 'HoverCardArrow'

--- a/packages/react/src/components/hover-card/hover-card-content.tsx
+++ b/packages/react/src/components/hover-card/hover-card-content.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { composeRefs } from '../../utils/compose-refs'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { usePresenceContext } from '../presence'
@@ -10,7 +9,7 @@ import { useHoverCardContext } from './use-hover-card-context'
 export interface HoverCardContentBaseProps extends PolymorphicProps {}
 export interface HoverCardContentProps extends HTMLProps<'div'>, HoverCardContentBaseProps {}
 
-export const HoverCardContent = forwardRef<HTMLDivElement, HoverCardContentProps>((props, ref) => {
+export const HoverCardContent = ({ ref, ...props }: HoverCardContentProps) => {
   const hoverCard = useHoverCardContext()
   const presence = usePresenceContext()
   const mergedProps = mergeProps(hoverCard.getContentProps(), presence.getPresenceProps(), props)
@@ -20,6 +19,6 @@ export const HoverCardContent = forwardRef<HTMLDivElement, HoverCardContentProps
   }
 
   return <ark.div {...mergedProps} ref={composeRefs(presence.ref, ref)} />
-})
+}
 
 HoverCardContent.displayName = 'HoverCardContent'

--- a/packages/react/src/components/hover-card/hover-card-positioner.tsx
+++ b/packages/react/src/components/hover-card/hover-card-positioner.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { usePresenceContext } from '../presence'
 import { useHoverCardContext } from './use-hover-card-context'
@@ -9,7 +8,7 @@ import { useHoverCardContext } from './use-hover-card-context'
 export interface HoverCardPositionerBaseProps extends PolymorphicProps {}
 export interface HoverCardPositionerProps extends HTMLProps<'div'>, HoverCardPositionerBaseProps {}
 
-export const HoverCardPositioner = forwardRef<HTMLDivElement, HoverCardPositionerProps>((props, ref) => {
+export const HoverCardPositioner = ({ ref, ...props }: HoverCardPositionerProps) => {
   const hoverCard = useHoverCardContext()
   const mergedProps = mergeProps(hoverCard.getPositionerProps(), props)
   const presence = usePresenceContext()
@@ -19,6 +18,6 @@ export const HoverCardPositioner = forwardRef<HTMLDivElement, HoverCardPositione
   }
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 HoverCardPositioner.displayName = 'HoverCardPositioner'

--- a/packages/react/src/components/hover-card/hover-card-trigger.tsx
+++ b/packages/react/src/components/hover-card/hover-card-trigger.tsx
@@ -2,7 +2,6 @@
 
 import { mergeProps } from '@zag-js/react'
 import type { TriggerProps } from '@zag-js/hover-card'
-import { forwardRef } from 'react'
 import type { Assign } from '../../types'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -13,12 +12,12 @@ export interface HoverCardTriggerProps extends Assign<HTMLProps<'button'>, Hover
 
 const splitTriggerProps = createSplitProps<TriggerProps>()
 
-export const HoverCardTrigger = forwardRef<HTMLButtonElement, HoverCardTriggerProps>((props, ref) => {
+export const HoverCardTrigger = ({ ref, ...props }: HoverCardTriggerProps) => {
   const [triggerProps, localProps] = splitTriggerProps(props, ['value'])
   const hoverCard = useHoverCardContext()
   const mergedProps = mergeProps(hoverCard.getTriggerProps(triggerProps), localProps)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 HoverCardTrigger.displayName = 'HoverCardTrigger'

--- a/packages/react/src/components/image-cropper/image-cropper-grid.tsx
+++ b/packages/react/src/components/image-cropper/image-cropper-grid.tsx
@@ -2,19 +2,18 @@
 
 import type { GridProps } from '@zag-js/image-cropper'
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useImageCropperContext } from './use-image-cropper-context'
 
 export interface ImageCropperGridBaseProps extends PolymorphicProps, GridProps {}
 export interface ImageCropperGridProps extends HTMLProps<'div'>, ImageCropperGridBaseProps {}
 
-export const ImageCropperGrid = forwardRef<HTMLDivElement, ImageCropperGridProps>((props, ref) => {
+export const ImageCropperGrid = ({ ref, ...props }: ImageCropperGridProps) => {
   const { axis, ...localProps } = props
   const imageCropper = useImageCropperContext()
   const mergedProps = mergeProps(imageCropper.getGridProps({ axis }), localProps)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 ImageCropperGrid.displayName = 'ImageCropperGrid'

--- a/packages/react/src/components/image-cropper/image-cropper-handle.tsx
+++ b/packages/react/src/components/image-cropper/image-cropper-handle.tsx
@@ -2,19 +2,18 @@
 
 import type { HandleProps } from '@zag-js/image-cropper'
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useImageCropperContext } from './use-image-cropper-context'
 
 export interface ImageCropperHandleBaseProps extends PolymorphicProps, HandleProps {}
 export interface ImageCropperHandleProps extends HTMLProps<'div'>, ImageCropperHandleBaseProps {}
 
-export const ImageCropperHandle = forwardRef<HTMLDivElement, ImageCropperHandleProps>((props, ref) => {
+export const ImageCropperHandle = ({ ref, ...props }: ImageCropperHandleProps) => {
   const { position, ...localProps } = props
   const imageCropper = useImageCropperContext()
   const mergedProps = mergeProps(imageCropper.getHandleProps({ position }), localProps)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 ImageCropperHandle.displayName = 'ImageCropperHandle'

--- a/packages/react/src/components/image-cropper/image-cropper-image.tsx
+++ b/packages/react/src/components/image-cropper/image-cropper-image.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useImageCropperContext } from './use-image-cropper-context'
 
 export interface ImageCropperImageBaseProps extends PolymorphicProps {}
 export interface ImageCropperImageProps extends HTMLProps<'img'>, ImageCropperImageBaseProps {}
 
-export const ImageCropperImage = forwardRef<HTMLImageElement, ImageCropperImageProps>((props, ref) => {
+export const ImageCropperImage = ({ ref, ...props }: ImageCropperImageProps) => {
   const imageCropper = useImageCropperContext()
   const mergedProps = mergeProps(imageCropper.getImageProps(), props)
 
   return <ark.img {...mergedProps} ref={ref} />
-})
+}
 
 ImageCropperImage.displayName = 'ImageCropperImage'

--- a/packages/react/src/components/image-cropper/image-cropper-root-provider.tsx
+++ b/packages/react/src/components/image-cropper/image-cropper-root-provider.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import type { UseImageCropperReturn } from './use-image-cropper'
@@ -16,7 +15,7 @@ export interface ImageCropperRootProviderProps extends HTMLProps<'div'>, ImageCr
 
 const splitRootProviderProps = createSplitProps<RootProviderProps>()
 
-export const ImageCropperRootProvider = forwardRef<HTMLDivElement, ImageCropperRootProviderProps>((props, ref) => {
+export const ImageCropperRootProvider = ({ ref, ...props }: ImageCropperRootProviderProps) => {
   const [{ value: imageCropper }, localProps] = splitRootProviderProps(props, ['value'])
   const mergedProps = mergeProps(imageCropper.getRootProps(), localProps)
 
@@ -25,6 +24,6 @@ export const ImageCropperRootProvider = forwardRef<HTMLDivElement, ImageCropperR
       <ark.div {...mergedProps} ref={ref} />
     </ImageCropperProvider>
   )
-})
+}
 
 ImageCropperRootProvider.displayName = 'ImageCropperRootProvider'

--- a/packages/react/src/components/image-cropper/image-cropper-root.tsx
+++ b/packages/react/src/components/image-cropper/image-cropper-root.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { type UseImageCropperProps, useImageCropper } from './use-image-cropper'
@@ -12,7 +11,7 @@ export interface ImageCropperRootProps extends HTMLProps<'div'>, ImageCropperRoo
 
 const splitRootProps = createSplitProps<UseImageCropperProps>()
 
-export const ImageCropperRoot = forwardRef<HTMLDivElement, ImageCropperRootProps>((props, ref) => {
+export const ImageCropperRoot = ({ ref, ...props }: ImageCropperRootProps) => {
   const [useImageCropperProps, localProps] = splitRootProps(props, [
     'aspectRatio',
     'cropShape',
@@ -51,6 +50,6 @@ export const ImageCropperRoot = forwardRef<HTMLDivElement, ImageCropperRootProps
       <ark.div {...mergedProps} ref={ref} />
     </ImageCropperProvider>
   )
-})
+}
 
 ImageCropperRoot.displayName = 'ImageCropperRoot'

--- a/packages/react/src/components/image-cropper/image-cropper-selection.tsx
+++ b/packages/react/src/components/image-cropper/image-cropper-selection.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useImageCropperContext } from './use-image-cropper-context'
 
 export interface ImageCropperSelectionBaseProps extends PolymorphicProps {}
 export interface ImageCropperSelectionProps extends HTMLProps<'div'>, ImageCropperSelectionBaseProps {}
 
-export const ImageCropperSelection = forwardRef<HTMLDivElement, ImageCropperSelectionProps>((props, ref) => {
+export const ImageCropperSelection = ({ ref, ...props }: ImageCropperSelectionProps) => {
   const imageCropper = useImageCropperContext()
   const mergedProps = mergeProps(imageCropper.getSelectionProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 ImageCropperSelection.displayName = 'ImageCropperSelection'

--- a/packages/react/src/components/image-cropper/image-cropper-viewport.tsx
+++ b/packages/react/src/components/image-cropper/image-cropper-viewport.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useImageCropperContext } from './use-image-cropper-context'
 
 export interface ImageCropperViewportBaseProps extends PolymorphicProps {}
 export interface ImageCropperViewportProps extends HTMLProps<'div'>, ImageCropperViewportBaseProps {}
 
-export const ImageCropperViewport = forwardRef<HTMLDivElement, ImageCropperViewportProps>((props, ref) => {
+export const ImageCropperViewport = ({ ref, ...props }: ImageCropperViewportProps) => {
   const imageCropper = useImageCropperContext()
   const mergedProps = mergeProps(imageCropper.getViewportProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 ImageCropperViewport.displayName = 'ImageCropperViewport'

--- a/packages/react/src/components/json-tree-view/json-tree-view-root-provider.tsx
+++ b/packages/react/src/components/json-tree-view/json-tree-view-root-provider.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import type { JsonNode } from '@zag-js/json-tree-utils'
-import { forwardRef } from 'react'
 import { TreeView } from '../tree-view'
 import { JsonTreeViewPropsProvider } from './json-tree-view-props-context'
 import type { UseJsonTreeViewReturn } from './use-json-tree-view'
@@ -10,7 +9,7 @@ export interface JsonTreeViewRootProviderProps extends Omit<TreeView.RootProvide
   value: UseJsonTreeViewReturn
 }
 
-export const JsonTreeViewRootProvider = forwardRef<HTMLDivElement, JsonTreeViewRootProviderProps>((props, ref) => {
+export const JsonTreeViewRootProvider = ({ ref, ...props }: JsonTreeViewRootProviderProps) => {
   const { value, ...restProps } = props
   const { options, ...treeView } = value
 
@@ -19,6 +18,6 @@ export const JsonTreeViewRootProvider = forwardRef<HTMLDivElement, JsonTreeViewR
       <TreeView.RootProvider data-scope="json-tree-view" value={treeView} {...restProps} ref={ref} />
     </JsonTreeViewPropsProvider>
   )
-})
+}
 
 JsonTreeViewRootProvider.displayName = 'JsonTreeViewRootProvider'

--- a/packages/react/src/components/json-tree-view/json-tree-view-root.tsx
+++ b/packages/react/src/components/json-tree-view/json-tree-view-root.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { type JsonNode, getRootNode, nodeToString, nodeToValue } from '@zag-js/json-tree-utils'
-import { forwardRef, useMemo } from 'react'
+import { useMemo } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { TreeView, createTreeCollection } from '../tree-view'
 import { getBranchValues } from './get-branch-value'
@@ -20,7 +20,7 @@ export interface JsonTreeViewRootProps extends Omit<TreeView.RootProps<JsonNode>
 
 const splitJsonTreeViewProps = createSplitProps<JsonTreeViewOptions>()
 
-export const JsonTreeViewRoot = forwardRef<HTMLDivElement, JsonTreeViewRootProps>((props, ref) => {
+export const JsonTreeViewRoot = ({ ref, ...props }: JsonTreeViewRootProps) => {
   const [jsonTreeProps, localProps] = splitJsonTreeViewProps(props, [
     'maxPreviewItems',
     'collapseStringsAfterLength',
@@ -54,6 +54,6 @@ export const JsonTreeViewRoot = forwardRef<HTMLDivElement, JsonTreeViewRootProps
       />
     </JsonTreeViewPropsProvider>
   )
-})
+}
 
 JsonTreeViewRoot.displayName = 'JsonTreeViewRoot'

--- a/packages/react/src/components/json-tree-view/json-tree-view-tree.tsx
+++ b/packages/react/src/components/json-tree-view/json-tree-view-tree.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { TreeView, useTreeViewContext } from '../tree-view'
 import { JsonTreeViewNode, type JsonTreeViewNodeBaseProps } from './json-tree-view-node'
@@ -9,7 +8,7 @@ export interface JsonTreeViewTreeProps extends TreeView.TreeProps, JsonTreeViewN
 
 const splitTreeNodeProps = createSplitProps<JsonTreeViewNodeBaseProps>()
 
-export const JsonTreeViewTree = forwardRef<HTMLDivElement, JsonTreeViewTreeProps>((props, ref) => {
+export const JsonTreeViewTree = ({ ref, ...props }: JsonTreeViewTreeProps) => {
   const [nodeProps, treeProps] = splitTreeNodeProps(props, ['arrow', 'indentGuide', 'renderValue'])
   const tree = useTreeViewContext()
   const children = tree.collection.getNodeChildren(tree.collection.rootNode)
@@ -20,6 +19,6 @@ export const JsonTreeViewTree = forwardRef<HTMLDivElement, JsonTreeViewTreeProps
       ))}
     </TreeView.Tree>
   )
-})
+}
 
 JsonTreeViewTree.displayName = 'JsonTreeViewTree'

--- a/packages/react/src/components/listbox/index.ts
+++ b/packages/react/src/components/listbox/index.ts
@@ -25,18 +25,11 @@ export {
 } from './listbox-item-indicator'
 export { ListboxItemText, type ListboxItemTextBaseProps, type ListboxItemTextProps } from './listbox-item-text'
 export { ListboxLabel, type ListboxLabelBaseProps, type ListboxLabelProps } from './listbox-label'
-export {
-  ListboxRoot,
-  type ListboxRootBaseProps,
-  type ListboxRootProps,
-  type ListboxRootComponent,
-  type ListboxRootComponentProps,
-} from './listbox-root'
+export { ListboxRoot, type ListboxRootBaseProps, type ListboxRootProps } from './listbox-root'
 export {
   ListboxRootProvider,
   type ListboxRootProviderBaseProps,
   type ListboxRootProviderProps,
-  type ListboxRootProviderComponent,
 } from './listbox-root-provider'
 export { ListboxValueText, type ListboxValueTextBaseProps, type ListboxValueTextProps } from './listbox-value-text'
 export { listboxAnatomy } from './listbox.anatomy'

--- a/packages/react/src/components/listbox/listbox-content.tsx
+++ b/packages/react/src/components/listbox/listbox-content.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useListboxContext } from './use-listbox-context'
 
 export interface ListboxContentBaseProps extends PolymorphicProps {}
 export interface ListboxContentProps extends HTMLProps<'div'>, ListboxContentBaseProps {}
 
-export const ListboxContent = forwardRef<HTMLDivElement, ListboxContentProps>((props, ref) => {
+export const ListboxContent = ({ ref, ...props }: ListboxContentProps) => {
   const listbox = useListboxContext()
   const mergedProps = mergeProps(listbox.getContentProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 ListboxContent.displayName = 'ListboxContent'

--- a/packages/react/src/components/listbox/listbox-empty.tsx
+++ b/packages/react/src/components/listbox/listbox-empty.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { listboxAnatomy } from './listbox.anatomy'
 import { useListboxContext } from './use-listbox-context'
@@ -10,7 +9,7 @@ const parts = listboxAnatomy.build()
 export interface ListboxEmptyBaseProps extends PolymorphicProps {}
 export interface ListboxEmptyProps extends HTMLProps<'div'>, ListboxEmptyBaseProps {}
 
-export const ListboxEmpty = forwardRef<HTMLDivElement, ListboxEmptyProps>((props, ref) => {
+export const ListboxEmpty = ({ ref, ...props }: ListboxEmptyProps) => {
   const listbox = useListboxContext()
 
   if (listbox.collection.size !== 0) {
@@ -18,6 +17,6 @@ export const ListboxEmpty = forwardRef<HTMLDivElement, ListboxEmptyProps>((props
   }
 
   return <ark.div {...parts.empty.attrs} {...props} role="presentation" ref={ref} />
-})
+}
 
 ListboxEmpty.displayName = 'ListboxEmpty'

--- a/packages/react/src/components/listbox/listbox-input.tsx
+++ b/packages/react/src/components/listbox/listbox-input.tsx
@@ -2,7 +2,6 @@
 
 import type { InputProps } from '@zag-js/listbox'
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useListboxContext } from './use-listbox-context'
@@ -12,12 +11,12 @@ export interface ListboxInputProps extends HTMLProps<'input'>, ListboxInputBaseP
 
 const splitInputProps = createSplitProps<InputProps>()
 
-export const ListboxInput = forwardRef<HTMLInputElement, ListboxInputProps>((props, ref) => {
+export const ListboxInput = ({ ref, ...props }: ListboxInputProps) => {
   const [inputProps, localProps] = splitInputProps(props, ['autoHighlight', 'keyboardPriority'])
   const listbox = useListboxContext()
   const mergedProps = mergeProps(listbox.getInputProps(inputProps), localProps)
 
   return <ark.input {...mergedProps} ref={ref} />
-})
+}
 
 ListboxInput.displayName = 'ListboxInput'

--- a/packages/react/src/components/listbox/listbox-item-group-label.tsx
+++ b/packages/react/src/components/listbox/listbox-item-group-label.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useListboxContext } from './use-listbox-context'
 import { useListboxItemGroupPropsContext } from './use-listbox-item-group-props'
@@ -9,12 +8,12 @@ import { useListboxItemGroupPropsContext } from './use-listbox-item-group-props'
 export interface ListboxItemGroupLabelBaseProps extends PolymorphicProps {}
 export interface ListboxItemGroupLabelProps extends HTMLProps<'div'>, ListboxItemGroupLabelBaseProps {}
 
-export const ListboxItemGroupLabel = forwardRef<HTMLDivElement, ListboxItemGroupLabelProps>((props, ref) => {
+export const ListboxItemGroupLabel = ({ ref, ...props }: ListboxItemGroupLabelProps) => {
   const listbox = useListboxContext()
   const itemGroupProps = useListboxItemGroupPropsContext()
   const mergedProps = mergeProps(listbox.getItemGroupLabelProps({ htmlFor: itemGroupProps.id }), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 ListboxItemGroupLabel.displayName = 'ListboxItemGroupLabel'

--- a/packages/react/src/components/listbox/listbox-item-group.tsx
+++ b/packages/react/src/components/listbox/listbox-item-group.tsx
@@ -2,7 +2,7 @@
 
 import type { ItemGroupProps } from '@zag-js/listbox'
 import { mergeProps } from '@zag-js/react'
-import { forwardRef, useId } from 'react'
+import { useId } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useListboxContext } from './use-listbox-context'
@@ -13,7 +13,7 @@ export interface ListboxItemGroupProps extends HTMLProps<'div'>, ListboxItemGrou
 
 const splitItemGroupProps = createSplitProps<Partial<ItemGroupProps>>()
 
-export const ListboxItemGroup = forwardRef<HTMLDivElement, ListboxItemGroupProps>((props, ref) => {
+export const ListboxItemGroup = ({ ref, ...props }: ListboxItemGroupProps) => {
   const id = useId()
   const [_itemGroupProps, localProps] = splitItemGroupProps(props, ['id'])
   const itemGroupProps = { id, ..._itemGroupProps }
@@ -26,6 +26,6 @@ export const ListboxItemGroup = forwardRef<HTMLDivElement, ListboxItemGroupProps
       <ark.div {...mergedProps} ref={ref} />
     </ListboxItemGroupPropsProvider>
   )
-})
+}
 
 ListboxItemGroup.displayName = 'ListboxItemGroup'

--- a/packages/react/src/components/listbox/listbox-item-indicator.tsx
+++ b/packages/react/src/components/listbox/listbox-item-indicator.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useListboxContext } from './use-listbox-context'
 import { useListboxItemPropsContext } from './use-listbox-item-props-context'
@@ -9,12 +8,12 @@ import { useListboxItemPropsContext } from './use-listbox-item-props-context'
 export interface ListboxItemIndicatorBaseProps extends PolymorphicProps {}
 export interface ListboxItemIndicatorProps extends HTMLProps<'div'>, ListboxItemIndicatorBaseProps {}
 
-export const ListboxItemIndicator = forwardRef<HTMLDivElement, ListboxItemIndicatorProps>((props, ref) => {
+export const ListboxItemIndicator = ({ ref, ...props }: ListboxItemIndicatorProps) => {
   const listbox = useListboxContext()
   const itemProps = useListboxItemPropsContext()
   const mergedProps = mergeProps(listbox.getItemIndicatorProps(itemProps), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 ListboxItemIndicator.displayName = 'ListboxItemIndicator'

--- a/packages/react/src/components/listbox/listbox-item-text.tsx
+++ b/packages/react/src/components/listbox/listbox-item-text.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useListboxContext } from './use-listbox-context'
 import { useListboxItemPropsContext } from './use-listbox-item-props-context'
@@ -9,12 +8,12 @@ import { useListboxItemPropsContext } from './use-listbox-item-props-context'
 export interface ListboxItemTextBaseProps extends PolymorphicProps {}
 export interface ListboxItemTextProps extends HTMLProps<'div'>, ListboxItemTextBaseProps {}
 
-export const ListboxItemText = forwardRef<HTMLDivElement, ListboxItemTextProps>((props, ref) => {
+export const ListboxItemText = ({ ref, ...props }: ListboxItemTextProps) => {
   const listbox = useListboxContext()
   const itemProps = useListboxItemPropsContext()
   const mergedProps = mergeProps(listbox.getItemTextProps(itemProps), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 ListboxItemText.displayName = 'ListboxItemText'

--- a/packages/react/src/components/listbox/listbox-item.tsx
+++ b/packages/react/src/components/listbox/listbox-item.tsx
@@ -2,7 +2,6 @@
 
 import type { ItemProps } from '@zag-js/listbox'
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useListboxContext } from './use-listbox-context'
@@ -14,7 +13,7 @@ export interface ListboxItemProps extends HTMLProps<'div'>, ListboxItemBaseProps
 
 const splitItemProps = createSplitProps<ItemProps>()
 
-export const ListboxItem = forwardRef<HTMLDivElement, ListboxItemProps>((props, ref) => {
+export const ListboxItem = ({ ref, ...props }: ListboxItemProps) => {
   const [itemProps, localProps] = splitItemProps(props, ['item', 'highlightOnHover'])
   const listbox = useListboxContext()
   const mergedProps = mergeProps(listbox.getItemProps(itemProps), localProps)
@@ -27,6 +26,6 @@ export const ListboxItem = forwardRef<HTMLDivElement, ListboxItemProps>((props, 
       </ListboxItemProvider>
     </ListboxItemPropsProvider>
   )
-})
+}
 
 ListboxItem.displayName = 'ListboxItem'

--- a/packages/react/src/components/listbox/listbox-label.tsx
+++ b/packages/react/src/components/listbox/listbox-label.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useListboxContext } from './use-listbox-context'
 
 export interface ListboxLabelBaseProps extends PolymorphicProps {}
 export interface ListboxLabelProps extends HTMLProps<'span'>, ListboxLabelBaseProps {}
 
-export const ListboxLabel = forwardRef<HTMLSpanElement, ListboxLabelProps>((props, ref) => {
+export const ListboxLabel = ({ ref, ...props }: ListboxLabelProps) => {
   const listbox = useListboxContext()
   const mergedProps = mergeProps(listbox.getLabelProps(), props)
 
   return <ark.span {...mergedProps} ref={ref} />
-})
+}
 
 ListboxLabel.displayName = 'ListboxLabel'

--- a/packages/react/src/components/listbox/listbox-root-provider.tsx
+++ b/packages/react/src/components/listbox/listbox-root-provider.tsx
@@ -1,8 +1,7 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { type JSX, forwardRef } from 'react'
-import type { Assign } from '../../types'
+import type { JSX } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import type { CollectionItem } from '../collection'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -12,12 +11,17 @@ import { ListboxProvider } from './use-listbox-context'
 interface RootProviderProps<T extends CollectionItem> {
   value: UseListboxReturn<T>
 }
+
 export interface ListboxRootProviderBaseProps<T extends CollectionItem>
   extends RootProviderProps<T>, PolymorphicProps {}
+
 export interface ListboxRootProviderProps<T extends CollectionItem>
   extends HTMLProps<'div'>, ListboxRootProviderBaseProps<T> {}
 
-const ListboxImpl = <T extends CollectionItem>(props: ListboxRootProviderProps<T>, ref: React.Ref<HTMLDivElement>) => {
+export const ListboxRootProvider = <T extends CollectionItem>({
+  ref,
+  ...props
+}: ListboxRootProviderProps<T>): JSX.Element => {
   const [{ value: listbox }, localProps] = createSplitProps<RootProviderProps<T>>()(props, ['value'])
   const mergedProps = mergeProps(listbox.getRootProps(), localProps)
 
@@ -27,9 +31,3 @@ const ListboxImpl = <T extends CollectionItem>(props: ListboxRootProviderProps<T
     </ListboxProvider>
   )
 }
-
-export type ListboxRootProviderComponent<P = {}> = <T extends CollectionItem>(
-  props: Assign<ListboxRootProviderProps<T>, P> & React.RefAttributes<HTMLDivElement>,
-) => JSX.Element
-
-export const ListboxRootProvider = forwardRef(ListboxImpl) as ListboxRootProviderComponent

--- a/packages/react/src/components/listbox/listbox-root.tsx
+++ b/packages/react/src/components/listbox/listbox-root.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { type JSX, forwardRef } from 'react'
+import type { JSX } from 'react'
 import type { Assign } from '../../types'
 import { createSplitProps } from '../../utils/create-split-props'
 import type { CollectionItem } from '../collection'
@@ -12,7 +12,7 @@ import { ListboxProvider } from './use-listbox-context'
 export interface ListboxRootBaseProps<T extends CollectionItem> extends UseListboxProps<T>, PolymorphicProps {}
 export interface ListboxRootProps<T extends CollectionItem> extends Assign<HTMLProps<'div'>, ListboxRootBaseProps<T>> {}
 
-const ListboxImpl = <T extends CollectionItem>(props: ListboxRootProps<T>, ref: React.Ref<HTMLDivElement>) => {
+export const ListboxRoot = <T extends CollectionItem>({ ref, ...props }: ListboxRootProps<T>): JSX.Element => {
   const [useListboxProps, localProps] = createSplitProps<UseListboxProps<T>>()(props, [
     'collection',
     'defaultHighlightedValue',
@@ -43,15 +43,3 @@ const ListboxImpl = <T extends CollectionItem>(props: ListboxRootProps<T>, ref: 
     </ListboxProvider>
   )
 }
-
-export type ListboxRootComponentProps<T extends CollectionItem = CollectionItem, P = {}> = Assign<
-  ListboxRootProps<T>,
-  P
-> &
-  React.RefAttributes<HTMLDivElement>
-
-export type ListboxRootComponent<P = {}> = <T extends CollectionItem>(
-  props: ListboxRootComponentProps<T, P>,
-) => JSX.Element
-
-export const ListboxRoot = forwardRef(ListboxImpl) as ListboxRootComponent

--- a/packages/react/src/components/listbox/listbox-value-text.tsx
+++ b/packages/react/src/components/listbox/listbox-value-text.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useListboxContext } from './use-listbox-context'
 
@@ -13,7 +12,7 @@ export interface ListboxValueTextBaseProps extends PolymorphicProps {
 }
 export interface ListboxValueTextProps extends HTMLProps<'span'>, ListboxValueTextBaseProps {}
 
-export const ListboxValueText = forwardRef<HTMLSpanElement, ListboxValueTextProps>((props, ref) => {
+export const ListboxValueText = ({ ref, ...props }: ListboxValueTextProps) => {
   const { children, placeholder, ...localprops } = props
   const listbox = useListboxContext()
   const mergedProps = mergeProps(listbox.getValueTextProps(), localprops)
@@ -23,6 +22,6 @@ export const ListboxValueText = forwardRef<HTMLSpanElement, ListboxValueTextProp
       {children || listbox.valueAsString || placeholder}
     </ark.span>
   )
-})
+}
 
 ListboxValueText.displayName = 'ListboxValueText'

--- a/packages/react/src/components/listbox/listbox.ts
+++ b/packages/react/src/components/listbox/listbox.ts
@@ -59,14 +59,11 @@ export {
   ListboxRoot as Root,
   type ListboxRootBaseProps as RootBaseProps,
   type ListboxRootProps as RootProps,
-  type ListboxRootComponent as RootComponent,
-  type ListboxRootComponentProps as RootComponentProps,
 } from './listbox-root'
 export {
   ListboxRootProvider as RootProvider,
   type ListboxRootProviderBaseProps as RootProviderBaseProps,
   type ListboxRootProviderProps as RootProviderProps,
-  type ListboxRootProviderComponent as RootProviderComponent,
 } from './listbox-root-provider'
 export {
   ListboxValueText as ValueText,

--- a/packages/react/src/components/marquee/marquee-content.tsx
+++ b/packages/react/src/components/marquee/marquee-content.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { type ReactNode, forwardRef } from 'react'
+import type { ReactNode } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useMarqueeContext } from './use-marquee-context'
 
@@ -10,7 +10,7 @@ export interface MarqueeContentBaseProps extends PolymorphicProps {
 }
 export interface MarqueeContentProps extends Omit<HTMLProps<'div'>, 'children'>, MarqueeContentBaseProps {}
 
-export const MarqueeContent = forwardRef<HTMLDivElement, MarqueeContentProps>((props, ref) => {
+export const MarqueeContent = ({ ref, ...props }: MarqueeContentProps) => {
   const { children, ...localProps } = props
   const marquee = useMarqueeContext()
 
@@ -26,6 +26,6 @@ export const MarqueeContent = forwardRef<HTMLDivElement, MarqueeContentProps>((p
       })}
     </>
   )
-})
+}
 
 MarqueeContent.displayName = 'MarqueeContent'

--- a/packages/react/src/components/marquee/marquee-edge.tsx
+++ b/packages/react/src/components/marquee/marquee-edge.tsx
@@ -2,7 +2,6 @@
 
 import type { EdgeProps } from '@zag-js/marquee'
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useMarqueeContext } from './use-marquee-context'
@@ -12,12 +11,12 @@ export interface MarqueeEdgeProps extends HTMLProps<'div'>, MarqueeEdgeBaseProps
 
 const splitEdgeProps = createSplitProps<EdgeProps>()
 
-export const MarqueeEdge = forwardRef<HTMLDivElement, MarqueeEdgeProps>((props, ref) => {
+export const MarqueeEdge = ({ ref, ...props }: MarqueeEdgeProps) => {
   const [edgeProps, localProps] = splitEdgeProps(props, ['side'])
   const marquee = useMarqueeContext()
   const mergedProps = mergeProps(marquee.getEdgeProps(edgeProps), localProps)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 MarqueeEdge.displayName = 'MarqueeEdge'

--- a/packages/react/src/components/marquee/marquee-item.tsx
+++ b/packages/react/src/components/marquee/marquee-item.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useMarqueeContext } from './use-marquee-context'
 
 export interface MarqueeItemBaseProps extends PolymorphicProps {}
 export interface MarqueeItemProps extends HTMLProps<'div'>, MarqueeItemBaseProps {}
 
-export const MarqueeItem = forwardRef<HTMLDivElement, MarqueeItemProps>((props, ref) => {
+export const MarqueeItem = ({ ref, ...props }: MarqueeItemProps) => {
   const marquee = useMarqueeContext()
   const mergedProps = mergeProps(marquee.getItemProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 MarqueeItem.displayName = 'MarqueeItem'

--- a/packages/react/src/components/marquee/marquee-root-provider.tsx
+++ b/packages/react/src/components/marquee/marquee-root-provider.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import type { UseMarqueeReturn } from './use-marquee'
@@ -16,7 +15,7 @@ export interface MarqueeRootProviderProps extends HTMLProps<'div'>, MarqueeRootP
 
 const splitRootProviderProps = createSplitProps<RootProviderProps>()
 
-export const MarqueeRootProvider = forwardRef<HTMLDivElement, MarqueeRootProviderProps>((props, ref) => {
+export const MarqueeRootProvider = ({ ref, ...props }: MarqueeRootProviderProps) => {
   const [{ value: marquee }, localProps] = splitRootProviderProps(props, ['value'])
   const mergedProps = mergeProps(marquee.getRootProps(), localProps)
 
@@ -25,6 +24,6 @@ export const MarqueeRootProvider = forwardRef<HTMLDivElement, MarqueeRootProvide
       <ark.div {...mergedProps} ref={ref} />
     </MarqueeProvider>
   )
-})
+}
 
 MarqueeRootProvider.displayName = 'MarqueeRootProvider'

--- a/packages/react/src/components/marquee/marquee-root.tsx
+++ b/packages/react/src/components/marquee/marquee-root.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { type UseMarqueeProps, useMarquee } from './use-marquee'
@@ -12,7 +11,7 @@ export interface MarqueeRootProps extends HTMLProps<'div'>, MarqueeRootBaseProps
 
 const splitRootProps = createSplitProps<UseMarqueeProps>()
 
-export const MarqueeRoot = forwardRef<HTMLDivElement, MarqueeRootProps>((props, ref) => {
+export const MarqueeRoot = ({ ref, ...props }: MarqueeRootProps) => {
   const [useMarqueeProps, localProps] = splitRootProps(props, [
     'autoFill',
     'defaultPaused',
@@ -39,6 +38,6 @@ export const MarqueeRoot = forwardRef<HTMLDivElement, MarqueeRootProps>((props, 
       <ark.div {...mergedProps} ref={ref} />
     </MarqueeProvider>
   )
-})
+}
 
 MarqueeRoot.displayName = 'MarqueeRoot'

--- a/packages/react/src/components/marquee/marquee-viewport.tsx
+++ b/packages/react/src/components/marquee/marquee-viewport.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useMarqueeContext } from './use-marquee-context'
 
 export interface MarqueeViewportBaseProps extends PolymorphicProps {}
 export interface MarqueeViewportProps extends HTMLProps<'div'>, MarqueeViewportBaseProps {}
 
-export const MarqueeViewport = forwardRef<HTMLDivElement, MarqueeViewportProps>((props, ref) => {
+export const MarqueeViewport = ({ ref, ...props }: MarqueeViewportProps) => {
   const marquee = useMarqueeContext()
   const mergedProps = mergeProps(marquee.getViewportProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 MarqueeViewport.displayName = 'MarqueeViewport'

--- a/packages/react/src/components/menu/menu-arrow-tip.tsx
+++ b/packages/react/src/components/menu/menu-arrow-tip.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useMenuContext } from './use-menu-context'
 
 export interface MenuArrowTipBaseProps extends PolymorphicProps {}
 export interface MenuArrowTipProps extends HTMLProps<'div'>, MenuArrowTipBaseProps {}
 
-export const MenuArrowTip = forwardRef<HTMLDivElement, MenuArrowTipProps>((props, ref) => {
+export const MenuArrowTip = ({ ref, ...props }: MenuArrowTipProps) => {
   const menu = useMenuContext()
   const mergedProps = mergeProps(menu.getArrowTipProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 MenuArrowTip.displayName = 'MenuArrowTip'

--- a/packages/react/src/components/menu/menu-arrow.tsx
+++ b/packages/react/src/components/menu/menu-arrow.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useMenuContext } from './use-menu-context'
 
 export interface MenuArrowBaseProps extends PolymorphicProps {}
 export interface MenuArrowProps extends HTMLProps<'div'>, MenuArrowBaseProps {}
 
-export const MenuArrow = forwardRef<HTMLDivElement, MenuArrowProps>((props, ref) => {
+export const MenuArrow = ({ ref, ...props }: MenuArrowProps) => {
   const menu = useMenuContext()
   const mergedProps = mergeProps(menu.getArrowProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 MenuArrow.displayName = 'MenuArrow'

--- a/packages/react/src/components/menu/menu-checkbox-item.tsx
+++ b/packages/react/src/components/menu/menu-checkbox-item.tsx
@@ -2,7 +2,6 @@
 
 import type { OptionItemProps } from '@zag-js/menu'
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useMenuContext } from './use-menu-context'
@@ -16,7 +15,7 @@ export interface MenuCheckboxItemProps extends HTMLProps<'div'>, MenuCheckboxIte
 
 const splitOptionItemProps = createSplitProps<PartialOptionItemProps>()
 
-export const MenuCheckboxItem = forwardRef<HTMLDivElement, MenuCheckboxItemProps>((props, ref) => {
+export const MenuCheckboxItem = ({ ref, ...props }: MenuCheckboxItemProps) => {
   const [partialOptionItemProps, localProps] = splitOptionItemProps(props, [
     'checked',
     'closeOnSelect',
@@ -40,6 +39,6 @@ export const MenuCheckboxItem = forwardRef<HTMLDivElement, MenuCheckboxItemProps
       </MenuItemProvider>
     </MenuItemPropsProvider>
   )
-})
+}
 
 MenuCheckboxItem.displayName = 'MenuCheckboxItem'

--- a/packages/react/src/components/menu/menu-content.tsx
+++ b/packages/react/src/components/menu/menu-content.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { composeRefs } from '../../utils/compose-refs'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { usePresenceContext } from '../presence'
@@ -10,7 +9,7 @@ import { useMenuContext } from './use-menu-context'
 export interface MenuContentBaseProps extends PolymorphicProps {}
 export interface MenuContentProps extends HTMLProps<'div'>, MenuContentBaseProps {}
 
-export const MenuContent = forwardRef<HTMLDivElement, MenuContentProps>((props, ref) => {
+export const MenuContent = ({ ref, ...props }: MenuContentProps) => {
   const menu = useMenuContext()
   const presence = usePresenceContext()
   const mergedProps = mergeProps(menu.getContentProps(), presence.getPresenceProps(), props)
@@ -20,6 +19,6 @@ export const MenuContent = forwardRef<HTMLDivElement, MenuContentProps>((props, 
   }
 
   return <ark.div {...mergedProps} ref={composeRefs(presence.ref, ref)} />
-})
+}
 
 MenuContent.displayName = 'MenuContent'

--- a/packages/react/src/components/menu/menu-context-trigger.tsx
+++ b/packages/react/src/components/menu/menu-context-trigger.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useMenuContext } from './use-menu-context'
 
 export interface MenuContextTriggerBaseProps extends PolymorphicProps {}
 export interface MenuContextTriggerProps extends HTMLProps<'button'>, MenuContextTriggerBaseProps {}
 
-export const MenuContextTrigger = forwardRef<HTMLButtonElement, MenuContextTriggerProps>((props, ref) => {
+export const MenuContextTrigger = ({ ref, ...props }: MenuContextTriggerProps) => {
   const menu = useMenuContext()
   const mergedProps = mergeProps(menu.getContextTriggerProps(), props)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 MenuContextTrigger.displayName = 'MenuContextTrigger'

--- a/packages/react/src/components/menu/menu-indicator.tsx
+++ b/packages/react/src/components/menu/menu-indicator.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useMenuContext } from './use-menu-context'
 
 export interface MenuIndicatorBaseProps extends PolymorphicProps {}
 export interface MenuIndicatorProps extends HTMLProps<'div'>, MenuIndicatorBaseProps {}
 
-export const MenuIndicator = forwardRef<HTMLDivElement, MenuIndicatorProps>((props, ref) => {
+export const MenuIndicator = ({ ref, ...props }: MenuIndicatorProps) => {
   const menu = useMenuContext()
   const mergedProps = mergeProps(menu.getIndicatorProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 MenuIndicator.displayName = 'MenuIndicator'

--- a/packages/react/src/components/menu/menu-item-group-label.tsx
+++ b/packages/react/src/components/menu/menu-item-group-label.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useMenuContext } from './use-menu-context'
 import { useMenuItemGroupContext } from './use-menu-item-group-context'
@@ -9,12 +8,12 @@ import { useMenuItemGroupContext } from './use-menu-item-group-context'
 export interface MenuItemGroupLabelBaseProps extends PolymorphicProps {}
 export interface MenuItemGroupLabelProps extends HTMLProps<'div'>, MenuItemGroupLabelBaseProps {}
 
-export const MenuItemGroupLabel = forwardRef<HTMLDivElement, MenuItemGroupLabelProps>((props, ref) => {
+export const MenuItemGroupLabel = ({ ref, ...props }: MenuItemGroupLabelProps) => {
   const menu = useMenuContext()
   const itemGroup = useMenuItemGroupContext()
   const mergedProps = mergeProps(menu.getItemGroupLabelProps({ htmlFor: itemGroup.id }), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 MenuItemGroupLabel.displayName = 'MenuItemGroupLabel'

--- a/packages/react/src/components/menu/menu-item-group.tsx
+++ b/packages/react/src/components/menu/menu-item-group.tsx
@@ -2,7 +2,7 @@
 
 import type { ItemGroupProps } from '@zag-js/menu'
 import { mergeProps } from '@zag-js/react'
-import { forwardRef, useId } from 'react'
+import { useId } from 'react'
 import type { Optional } from '../../types'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -16,7 +16,7 @@ export interface MenuItemGroupProps extends HTMLProps<'div'>, MenuItemGroupBaseP
 
 const splitItemGroupProps = createSplitProps<OptionalItemGroupProps>()
 
-export const MenuItemGroup = forwardRef<HTMLDivElement, MenuItemGroupProps>((props, ref) => {
+export const MenuItemGroup = ({ ref, ...props }: MenuItemGroupProps) => {
   const [optionalItemGroupProps, localProps] = splitItemGroupProps(props, ['id'])
   const menu = useMenuContext()
   const id = useId()
@@ -28,6 +28,6 @@ export const MenuItemGroup = forwardRef<HTMLDivElement, MenuItemGroupProps>((pro
       <ark.div {...mergedProps} ref={ref} />
     </MenuItemGroupProvider>
   )
-})
+}
 
 MenuItemGroup.displayName = 'MenuItemGroup'

--- a/packages/react/src/components/menu/menu-item-indicator.tsx
+++ b/packages/react/src/components/menu/menu-item-indicator.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useMenuContext } from './use-menu-context'
 import { useMenuItemPropsContext } from './use-menu-option-item-props-context'
@@ -9,12 +8,12 @@ import { useMenuItemPropsContext } from './use-menu-option-item-props-context'
 export interface MenuItemIndicatorBaseProps extends PolymorphicProps {}
 export interface MenuItemIndicatorProps extends HTMLProps<'div'>, MenuItemIndicatorBaseProps {}
 
-export const MenuItemIndicator = forwardRef<HTMLDivElement, MenuItemIndicatorProps>((props, ref) => {
+export const MenuItemIndicator = ({ ref, ...props }: MenuItemIndicatorProps) => {
   const menu = useMenuContext()
   const itemProps = useMenuItemPropsContext()
   const mergedProps = mergeProps(menu.getItemIndicatorProps(itemProps), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 MenuItemIndicator.displayName = 'MenuItemIndicator'

--- a/packages/react/src/components/menu/menu-item-text.tsx
+++ b/packages/react/src/components/menu/menu-item-text.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useMenuContext } from './use-menu-context'
 import { useMenuItemPropsContext } from './use-menu-option-item-props-context'
@@ -9,12 +8,12 @@ import { useMenuItemPropsContext } from './use-menu-option-item-props-context'
 export interface MenuItemTextBaseProps extends PolymorphicProps {}
 export interface MenuItemTextProps extends HTMLProps<'div'>, MenuItemTextBaseProps {}
 
-export const MenuItemText = forwardRef<HTMLDivElement, MenuItemTextProps>((props, ref) => {
+export const MenuItemText = ({ ref, ...props }: MenuItemTextProps) => {
   const menu = useMenuContext()
   const itemProps = useMenuItemPropsContext()
   const mergedProps = mergeProps(menu.getItemTextProps(itemProps), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 MenuItemText.displayName = 'MenuItemText'

--- a/packages/react/src/components/menu/menu-item.tsx
+++ b/packages/react/src/components/menu/menu-item.tsx
@@ -2,7 +2,7 @@
 
 import type { ItemProps } from '@zag-js/menu'
 import { mergeProps } from '@zag-js/react'
-import { forwardRef, useEffect } from 'react'
+import { useEffect } from 'react'
 import type { Assign } from '../../types'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -23,7 +23,7 @@ export interface MenuItemProps extends Assign<HTMLProps<'div'>, MenuItemBaseProp
 
 const splitItemBaseProps = createSplitProps<ItemBaseProps>()
 
-export const MenuItem = forwardRef<HTMLDivElement, MenuItemProps>((props, ref) => {
+export const MenuItem = ({ ref, ...props }: MenuItemProps) => {
   const [itemProps, localProps] = splitItemBaseProps(props, [
     'closeOnSelect',
     'disabled',
@@ -48,6 +48,6 @@ export const MenuItem = forwardRef<HTMLDivElement, MenuItemProps>((props, ref) =
       </MenuItemProvider>
     </MenuItemPropsProvider>
   )
-})
+}
 
 MenuItem.displayName = 'MenuItem'

--- a/packages/react/src/components/menu/menu-positioner.tsx
+++ b/packages/react/src/components/menu/menu-positioner.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { usePresenceContext } from '../presence'
 import { useMenuContext } from './use-menu-context'
@@ -9,7 +8,7 @@ import { useMenuContext } from './use-menu-context'
 export interface MenuPositionerBaseProps extends PolymorphicProps {}
 export interface MenuPositionerProps extends HTMLProps<'div'>, MenuPositionerBaseProps {}
 
-export const MenuPositioner = forwardRef<HTMLDivElement, MenuPositionerProps>((props, ref) => {
+export const MenuPositioner = ({ ref, ...props }: MenuPositionerProps) => {
   const menu = useMenuContext()
   const mergedProps = mergeProps(menu.getPositionerProps(), props)
   const presence = usePresenceContext()
@@ -19,6 +18,6 @@ export const MenuPositioner = forwardRef<HTMLDivElement, MenuPositionerProps>((p
   }
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 MenuPositioner.displayName = 'MenuPositioner'

--- a/packages/react/src/components/menu/menu-radio-item-group.tsx
+++ b/packages/react/src/components/menu/menu-radio-item-group.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef, useId } from 'react'
+import { useId } from 'react'
 import type { Optional } from '../../types'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -15,7 +15,7 @@ export interface MenuRadioItemGroupProps extends HTMLProps<'div'>, MenuRadioItem
 
 const splitItemGroupProps = createSplitProps<OptionalUseMenuItemGroupContext>()
 
-export const MenuRadioItemGroup = forwardRef<HTMLDivElement, MenuRadioItemGroupProps>((props, ref) => {
+export const MenuRadioItemGroup = ({ ref, ...props }: MenuRadioItemGroupProps) => {
   const [optionalItemGroupProps, localProps] = splitItemGroupProps(props, ['id', 'onValueChange', 'value'])
   const menu = useMenuContext()
   const id = useId()
@@ -27,6 +27,6 @@ export const MenuRadioItemGroup = forwardRef<HTMLDivElement, MenuRadioItemGroupP
       <ark.div {...mergedProps} ref={ref} />
     </MenuItemGroupProvider>
   )
-})
+}
 
 MenuRadioItemGroup.displayName = 'MenuRadioItemGroup'

--- a/packages/react/src/components/menu/menu-radio-item.tsx
+++ b/packages/react/src/components/menu/menu-radio-item.tsx
@@ -2,7 +2,6 @@
 
 import type { OptionItemProps } from '@zag-js/menu'
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useMenuContext } from './use-menu-context'
@@ -17,7 +16,7 @@ export interface MenuRadioItemProps extends HTMLProps<'div'>, MenuRadioItemBaseP
 
 const splitOptionItemProps = createSplitProps<PartialOptionItemProps>()
 
-export const MenuRadioItem = forwardRef<HTMLDivElement, MenuRadioItemProps>((props, ref) => {
+export const MenuRadioItem = ({ ref, ...props }: MenuRadioItemProps) => {
   const [partialItemProps, localProps] = splitOptionItemProps(props, [
     'closeOnSelect',
     'disabled',
@@ -42,6 +41,6 @@ export const MenuRadioItem = forwardRef<HTMLDivElement, MenuRadioItemProps>((pro
       </MenuItemProvider>
     </MenuItemPropsProvider>
   )
-})
+}
 
 MenuRadioItem.displayName = 'MenuRadioItem'

--- a/packages/react/src/components/menu/menu-separator.tsx
+++ b/packages/react/src/components/menu/menu-separator.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useMenuContext } from './use-menu-context'
 
 export interface MenuSeparatorBaseProps extends PolymorphicProps {}
 export interface MenuSeparatorProps extends HTMLProps<'hr'>, MenuSeparatorBaseProps {}
 
-export const MenuSeparator = forwardRef<HTMLHRElement, MenuSeparatorProps>((props, ref) => {
+export const MenuSeparator = ({ ref, ...props }: MenuSeparatorProps) => {
   const menu = useMenuContext()
   const mergedProps = mergeProps(menu.getSeparatorProps(), props)
 
   return <ark.hr {...mergedProps} ref={ref} />
-})
+}
 
 MenuSeparator.displayName = 'MenuSeparator'

--- a/packages/react/src/components/menu/menu-trigger-item.tsx
+++ b/packages/react/src/components/menu/menu-trigger-item.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useMenuTriggerItemContext } from './use-menu-trigger-item-context'
 import { MenuItemPropsProvider } from './use-menu-option-item-props-context'
@@ -9,7 +8,7 @@ import { MenuItemPropsProvider } from './use-menu-option-item-props-context'
 export interface MenuTriggerItemBaseProps extends PolymorphicProps {}
 export interface MenuTriggerItemProps extends HTMLProps<'div'>, MenuTriggerItemBaseProps {}
 
-export const MenuTriggerItem = forwardRef<HTMLDivElement, MenuTriggerItemProps>((props, ref) => {
+export const MenuTriggerItem = ({ ref, ...props }: MenuTriggerItemProps) => {
   const getTriggerItemProps = useMenuTriggerItemContext()
   const mergedProps = mergeProps(getTriggerItemProps?.() ?? {}, props)
 
@@ -18,6 +17,6 @@ export const MenuTriggerItem = forwardRef<HTMLDivElement, MenuTriggerItemProps>(
       <ark.div {...mergedProps} ref={ref} />
     </MenuItemPropsProvider>
   )
-})
+}
 
 MenuTriggerItem.displayName = 'MenuTriggerItem'

--- a/packages/react/src/components/menu/menu-trigger.tsx
+++ b/packages/react/src/components/menu/menu-trigger.tsx
@@ -2,7 +2,6 @@
 
 import { mergeProps } from '@zag-js/react'
 import type { TriggerProps } from '@zag-js/menu'
-import { forwardRef } from 'react'
 import type { Assign } from '../../types'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -14,7 +13,7 @@ export interface MenuTriggerProps extends Assign<HTMLProps<'button'>, MenuTrigge
 
 const splitTriggerProps = createSplitProps<TriggerProps>()
 
-export const MenuTrigger = forwardRef<HTMLButtonElement, MenuTriggerProps>((props, ref) => {
+export const MenuTrigger = ({ ref, ...props }: MenuTriggerProps) => {
   const [triggerProps, localProps] = splitTriggerProps(props, ['value'])
   const menu = useMenuContext()
   const presence = usePresenceContext()
@@ -28,6 +27,6 @@ export const MenuTrigger = forwardRef<HTMLButtonElement, MenuTriggerProps>((prop
   )
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 MenuTrigger.displayName = 'MenuTrigger'

--- a/packages/react/src/components/navigation-menu/navigation-menu-arrow.tsx
+++ b/packages/react/src/components/navigation-menu/navigation-menu-arrow.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useNavigationMenuContext } from './use-navigation-menu-context'
 
 export interface NavigationMenuArrowBaseProps extends PolymorphicProps {}
 export interface NavigationMenuArrowProps extends HTMLProps<'div'>, NavigationMenuArrowBaseProps {}
 
-export const NavigationMenuArrow = forwardRef<HTMLDivElement, NavigationMenuArrowProps>((props, ref) => {
+export const NavigationMenuArrow = ({ ref, ...props }: NavigationMenuArrowProps) => {
   const navigationMenu = useNavigationMenuContext()
   const mergedProps = mergeProps(navigationMenu.getArrowProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 NavigationMenuArrow.displayName = 'NavigationMenuArrow'

--- a/packages/react/src/components/navigation-menu/navigation-menu-content.tsx
+++ b/packages/react/src/components/navigation-menu/navigation-menu-content.tsx
@@ -2,7 +2,6 @@
 
 import type { ContentProps } from '@zag-js/navigation-menu'
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import type { Assign } from '../../types'
 import { composeRefs } from '../../utils/compose-refs'
 import { createSplitProps } from '../../utils/create-split-props'
@@ -18,7 +17,7 @@ export interface NavigationMenuContentProps extends Assign<HTMLProps<'div'>, Nav
 
 const splitContentProps = createSplitProps<ContentProps>()
 
-export const NavigationMenuContent = forwardRef<HTMLDivElement, NavigationMenuContentProps>((props, ref) => {
+export const NavigationMenuContent = ({ ref, ...props }: NavigationMenuContentProps) => {
   const api = useNavigationMenuContext()
   const itemContext = useNavigationMenuItemPropsContext()
 
@@ -47,6 +46,6 @@ export const NavigationMenuContent = forwardRef<HTMLDivElement, NavigationMenuCo
   }
 
   return content
-})
+}
 
 NavigationMenuContent.displayName = 'NavigationMenuContent'

--- a/packages/react/src/components/navigation-menu/navigation-menu-indicator.tsx
+++ b/packages/react/src/components/navigation-menu/navigation-menu-indicator.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { composeRefs } from '../../utils/compose-refs'
 import { useRenderStrategyPropsContext } from '../../utils/render-strategy'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -11,7 +10,7 @@ import { useNavigationMenuContext } from './use-navigation-menu-context'
 export interface NavigationMenuIndicatorBaseProps extends PolymorphicProps {}
 export interface NavigationMenuIndicatorProps extends HTMLProps<'div'>, NavigationMenuIndicatorBaseProps {}
 
-export const NavigationMenuIndicator = forwardRef<HTMLDivElement, NavigationMenuIndicatorProps>((props, ref) => {
+export const NavigationMenuIndicator = ({ ref, ...props }: NavigationMenuIndicatorProps) => {
   const navigationMenu = useNavigationMenuContext()
   const renderStrategyProps = useRenderStrategyPropsContext()
   const presence = usePresence({ ...renderStrategyProps, present: navigationMenu.open })
@@ -22,6 +21,6 @@ export const NavigationMenuIndicator = forwardRef<HTMLDivElement, NavigationMenu
       {presence.unmounted ? null : <ark.div {...mergedProps} ref={composeRefs(presence.ref, ref)} />}
     </PresenceProvider>
   )
-})
+}
 
 NavigationMenuIndicator.displayName = 'NavigationMenuIndicator'

--- a/packages/react/src/components/navigation-menu/navigation-menu-item-indicator.tsx
+++ b/packages/react/src/components/navigation-menu/navigation-menu-item-indicator.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useNavigationMenuContext } from './use-navigation-menu-context'
 import { useNavigationMenuItemPropsContext } from './use-navigation-menu-item-props-context'
@@ -9,14 +8,12 @@ import { useNavigationMenuItemPropsContext } from './use-navigation-menu-item-pr
 export interface NavigationMenuItemIndicatorBaseProps extends PolymorphicProps {}
 export interface NavigationMenuItemIndicatorProps extends HTMLProps<'div'>, NavigationMenuItemIndicatorBaseProps {}
 
-export const NavigationMenuItemIndicator = forwardRef<HTMLDivElement, NavigationMenuItemIndicatorProps>(
-  (props, ref) => {
-    const navigationMenu = useNavigationMenuContext()
-    const itemProps = useNavigationMenuItemPropsContext()
-    const mergedProps = mergeProps(navigationMenu.getItemIndicatorProps(itemProps), props)
+export const NavigationMenuItemIndicator = ({ ref, ...props }: NavigationMenuItemIndicatorProps) => {
+  const navigationMenu = useNavigationMenuContext()
+  const itemProps = useNavigationMenuItemPropsContext()
+  const mergedProps = mergeProps(navigationMenu.getItemIndicatorProps(itemProps), props)
 
-    return <ark.div {...mergedProps} ref={ref} />
-  },
-)
+  return <ark.div {...mergedProps} ref={ref} />
+}
 
 NavigationMenuItemIndicator.displayName = 'NavigationMenuItemIndicator'

--- a/packages/react/src/components/navigation-menu/navigation-menu-item.tsx
+++ b/packages/react/src/components/navigation-menu/navigation-menu-item.tsx
@@ -2,7 +2,6 @@
 
 import type { ItemProps } from '@zag-js/navigation-menu'
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useNavigationMenuContext } from './use-navigation-menu-context'
@@ -13,7 +12,7 @@ export interface NavigationMenuItemProps extends HTMLProps<'div'>, NavigationMen
 
 const splitItemProps = createSplitProps<ItemProps>()
 
-export const NavigationMenuItem = forwardRef<HTMLDivElement, NavigationMenuItemProps>((props, ref) => {
+export const NavigationMenuItem = ({ ref, ...props }: NavigationMenuItemProps) => {
   const [itemProps, localProps] = splitItemProps(props, ['disabled', 'value'])
   const navigationMenu = useNavigationMenuContext()
   const mergedProps = mergeProps(navigationMenu.getItemProps(itemProps), localProps)
@@ -23,6 +22,6 @@ export const NavigationMenuItem = forwardRef<HTMLDivElement, NavigationMenuItemP
       <ark.div {...mergedProps} ref={ref} />
     </NavigationMenuItemPropsProvider>
   )
-})
+}
 
 NavigationMenuItem.displayName = 'NavigationMenuItem'

--- a/packages/react/src/components/navigation-menu/navigation-menu-link.tsx
+++ b/packages/react/src/components/navigation-menu/navigation-menu-link.tsx
@@ -2,7 +2,6 @@
 
 import type { LinkProps } from '@zag-js/navigation-menu'
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import type { Assign } from '../../types'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -14,7 +13,7 @@ export interface NavigationMenuLinkProps extends Assign<HTMLProps<'a'>, Navigati
 
 const splitLinkProps = createSplitProps<LinkProps>()
 
-export const NavigationMenuLink = forwardRef<HTMLAnchorElement, NavigationMenuLinkProps>((props, ref) => {
+export const NavigationMenuLink = ({ ref, ...props }: NavigationMenuLinkProps) => {
   const itemContext = useNavigationMenuItemPropsContext()
   const value = props.value ?? itemContext?.value
 
@@ -23,6 +22,6 @@ export const NavigationMenuLink = forwardRef<HTMLAnchorElement, NavigationMenuLi
   const mergedProps = mergeProps(navigationMenu.getLinkProps(linkProps), localProps)
 
   return <ark.a {...mergedProps} ref={ref} />
-})
+}
 
 NavigationMenuLink.displayName = 'NavigationMenuLink'

--- a/packages/react/src/components/navigation-menu/navigation-menu-list.tsx
+++ b/packages/react/src/components/navigation-menu/navigation-menu-list.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useNavigationMenuContext } from './use-navigation-menu-context'
 
 export interface NavigationMenuListBaseProps extends PolymorphicProps {}
 export interface NavigationMenuListProps extends HTMLProps<'div'>, NavigationMenuListBaseProps {}
 
-export const NavigationMenuList = forwardRef<HTMLDivElement, NavigationMenuListProps>((props, ref) => {
+export const NavigationMenuList = ({ ref, ...props }: NavigationMenuListProps) => {
   const navigationMenu = useNavigationMenuContext()
   const mergedProps = mergeProps(navigationMenu.getListProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 NavigationMenuList.displayName = 'NavigationMenuList'

--- a/packages/react/src/components/navigation-menu/navigation-menu-root-provider.tsx
+++ b/packages/react/src/components/navigation-menu/navigation-menu-root-provider.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import {
   type RenderStrategyProps,
@@ -21,7 +20,7 @@ export interface NavigationMenuRootProviderProps extends HTMLProps<'nav'>, Navig
 
 const splitRootProviderProps = createSplitProps<RootProviderProps>()
 
-export const NavigationMenuRootProvider = forwardRef<HTMLElement, NavigationMenuRootProviderProps>((props, ref) => {
+export const NavigationMenuRootProvider = ({ ref, ...props }: NavigationMenuRootProviderProps) => {
   const [renderStrategyProps, navigationMenuProps] = splitRenderStrategyProps(props)
   const [{ value: navigationMenu }, localProps] = splitRootProviderProps(navigationMenuProps, ['value'])
   const mergedProps = mergeProps(navigationMenu.getRootProps(), localProps)
@@ -33,6 +32,6 @@ export const NavigationMenuRootProvider = forwardRef<HTMLElement, NavigationMenu
       </RenderStrategyPropsProvider>
     </NavigationMenuProvider>
   )
-})
+}
 
 NavigationMenuRootProvider.displayName = 'NavigationMenuRootProvider'

--- a/packages/react/src/components/navigation-menu/navigation-menu-root.tsx
+++ b/packages/react/src/components/navigation-menu/navigation-menu-root.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import type { Assign } from '../../types'
 import { createSplitProps } from '../../utils/create-split-props'
 import {
@@ -18,7 +17,7 @@ export interface NavigationMenuRootProps extends Assign<HTMLProps<'nav'>, Naviga
 
 const splitRootProps = createSplitProps<UseNavigationMenuProps>()
 
-export const NavigationMenuRoot = forwardRef<HTMLElement, NavigationMenuRootProps>((props, ref) => {
+export const NavigationMenuRoot = ({ ref, ...props }: NavigationMenuRootProps) => {
   const [renderStrategyProps, navigationMenuProps] = splitRenderStrategyProps(props)
   const [useNavigationMenuProps, localProps] = splitRootProps(navigationMenuProps, [
     'closeDelay',
@@ -44,6 +43,6 @@ export const NavigationMenuRoot = forwardRef<HTMLElement, NavigationMenuRootProp
       </RenderStrategyPropsProvider>
     </NavigationMenuProvider>
   )
-})
+}
 
 NavigationMenuRoot.displayName = 'NavigationMenuRoot'

--- a/packages/react/src/components/navigation-menu/navigation-menu-trigger.tsx
+++ b/packages/react/src/components/navigation-menu/navigation-menu-trigger.tsx
@@ -3,7 +3,6 @@
 import { mergeProps } from '@zag-js/react'
 import type { ItemProps } from '@zag-js/navigation-menu'
 import { ensure } from '@zag-js/utils'
-import { forwardRef } from 'react'
 import type { Assign } from '../../types'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useNavigationMenuContext } from './use-navigation-menu-context'
@@ -15,7 +14,7 @@ export interface NavigationMenuTriggerProps extends Assign<HTMLProps<'button'>, 
 
 const splitItemProps = createSplitProps<ItemProps>()
 
-export const NavigationMenuTrigger = forwardRef<HTMLButtonElement, NavigationMenuTriggerProps>((props, ref) => {
+export const NavigationMenuTrigger = ({ ref, ...props }: NavigationMenuTriggerProps) => {
   const itemContext = useNavigationMenuItemPropsContext()
   ensure(itemContext, () => 'NavigationMenu.Trigger must be used within NavigationMenu.Item')
 
@@ -27,6 +26,6 @@ export const NavigationMenuTrigger = forwardRef<HTMLButtonElement, NavigationMen
   const mergedProps = mergeProps(navigationMenu.getTriggerProps(triggerProps), localProps)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 NavigationMenuTrigger.displayName = 'NavigationMenuTrigger'

--- a/packages/react/src/components/navigation-menu/navigation-menu-viewport-positioner.tsx
+++ b/packages/react/src/components/navigation-menu/navigation-menu-viewport-positioner.tsx
@@ -2,7 +2,6 @@
 
 import { mergeProps } from '@zag-js/react'
 import type { ViewportProps } from '@zag-js/navigation-menu'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useNavigationMenuContext } from './use-navigation-menu-context'
@@ -14,18 +13,16 @@ export interface NavigationMenuViewportPositionerProps
 
 const splitViewportProps = createSplitProps<ViewportProps>()
 
-export const NavigationMenuViewportPositioner = forwardRef<HTMLDivElement, NavigationMenuViewportPositionerProps>(
-  (props, ref) => {
-    const [viewportProps, localProps] = splitViewportProps(props, ['align'])
-    const navigationMenu = useNavigationMenuContext()
-    const mergedProps = mergeProps(navigationMenu.getViewportPositionerProps(viewportProps), localProps)
+export const NavigationMenuViewportPositioner = ({ ref, ...props }: NavigationMenuViewportPositionerProps) => {
+  const [viewportProps, localProps] = splitViewportProps(props, ['align'])
+  const navigationMenu = useNavigationMenuContext()
+  const mergedProps = mergeProps(navigationMenu.getViewportPositionerProps(viewportProps), localProps)
 
-    return (
-      <NavigationMenuViewportPropsProvider value={viewportProps}>
-        <ark.div {...mergedProps} ref={ref} />
-      </NavigationMenuViewportPropsProvider>
-    )
-  },
-)
+  return (
+    <NavigationMenuViewportPropsProvider value={viewportProps}>
+      <ark.div {...mergedProps} ref={ref} />
+    </NavigationMenuViewportPropsProvider>
+  )
+}
 
 NavigationMenuViewportPositioner.displayName = 'NavigationMenuViewportPositioner'

--- a/packages/react/src/components/navigation-menu/navigation-menu-viewport.tsx
+++ b/packages/react/src/components/navigation-menu/navigation-menu-viewport.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { composeRefs } from '../../utils/compose-refs'
 import { useRenderStrategyPropsContext } from '../../utils/render-strategy'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -12,7 +11,7 @@ import { useNavigationMenuViewportPropsContext } from './use-navigation-menu-vie
 export interface NavigationMenuViewportBaseProps extends PolymorphicProps {}
 export interface NavigationMenuViewportProps extends HTMLProps<'div'>, NavigationMenuViewportBaseProps {}
 
-export const NavigationMenuViewport = forwardRef<HTMLDivElement, NavigationMenuViewportProps>((props, ref) => {
+export const NavigationMenuViewport = ({ ref, ...props }: NavigationMenuViewportProps) => {
   const viewportPropsContext = useNavigationMenuViewportPropsContext()
   const navigationMenu = useNavigationMenuContext()
   const renderStrategyProps = useRenderStrategyPropsContext()
@@ -33,6 +32,6 @@ export const NavigationMenuViewport = forwardRef<HTMLDivElement, NavigationMenuV
       {presence.unmounted ? null : <ark.div {...mergedProps} ref={composeRefs(presence.ref, ref)} />}
     </PresenceProvider>
   )
-})
+}
 
 NavigationMenuViewport.displayName = 'NavigationMenuViewport'

--- a/packages/react/src/components/number-input/number-input-control.tsx
+++ b/packages/react/src/components/number-input/number-input-control.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useNumberInputContext } from './use-number-input-context'
 
 export interface NumberInputControlBaseProps extends PolymorphicProps {}
 export interface NumberInputControlProps extends HTMLProps<'div'>, NumberInputControlBaseProps {}
 
-export const NumberInputControl = forwardRef<HTMLDivElement, NumberInputControlProps>((props, ref) => {
+export const NumberInputControl = ({ ref, ...props }: NumberInputControlProps) => {
   const numberInput = useNumberInputContext()
   const mergedProps = mergeProps(numberInput.getControlProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 NumberInputControl.displayName = 'NumberInputControl'

--- a/packages/react/src/components/number-input/number-input-decrement-trigger.tsx
+++ b/packages/react/src/components/number-input/number-input-decrement-trigger.tsx
@@ -1,20 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useNumberInputContext } from './use-number-input-context'
 
 export interface NumberInputDecrementTriggerBaseProps extends PolymorphicProps {}
 export interface NumberInputDecrementTriggerProps extends HTMLProps<'button'>, NumberInputDecrementTriggerBaseProps {}
 
-export const NumberInputDecrementTrigger = forwardRef<HTMLButtonElement, NumberInputDecrementTriggerProps>(
-  (props, ref) => {
-    const numberInput = useNumberInputContext()
-    const mergedProps = mergeProps(numberInput.getDecrementTriggerProps(), props)
+export const NumberInputDecrementTrigger = ({ ref, ...props }: NumberInputDecrementTriggerProps) => {
+  const numberInput = useNumberInputContext()
+  const mergedProps = mergeProps(numberInput.getDecrementTriggerProps(), props)
 
-    return <ark.button {...mergedProps} ref={ref} />
-  },
-)
+  return <ark.button {...mergedProps} ref={ref} />
+}
 
 NumberInputDecrementTrigger.displayName = 'NumberInputDecrementTrigger'

--- a/packages/react/src/components/number-input/number-input-increment-trigger.tsx
+++ b/packages/react/src/components/number-input/number-input-increment-trigger.tsx
@@ -1,20 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useNumberInputContext } from './use-number-input-context'
 
 export interface NumberInputIncrementTriggerBaseProps extends PolymorphicProps {}
 export interface NumberInputIncrementTriggerProps extends HTMLProps<'button'>, NumberInputIncrementTriggerBaseProps {}
 
-export const NumberInputIncrementTrigger = forwardRef<HTMLButtonElement, NumberInputIncrementTriggerProps>(
-  (props, ref) => {
-    const numberInput = useNumberInputContext()
-    const mergedProps = mergeProps(numberInput.getIncrementTriggerProps(), props)
+export const NumberInputIncrementTrigger = ({ ref, ...props }: NumberInputIncrementTriggerProps) => {
+  const numberInput = useNumberInputContext()
+  const mergedProps = mergeProps(numberInput.getIncrementTriggerProps(), props)
 
-    return <ark.button {...mergedProps} ref={ref} />
-  },
-)
+  return <ark.button {...mergedProps} ref={ref} />
+}
 
 NumberInputIncrementTrigger.displayName = 'NumberInputIncrementTrigger'

--- a/packages/react/src/components/number-input/number-input-input.tsx
+++ b/packages/react/src/components/number-input/number-input-input.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useFieldContext } from '../field'
 import { useNumberInputContext } from './use-number-input-context'
@@ -9,12 +8,12 @@ import { useNumberInputContext } from './use-number-input-context'
 export interface NumberInputInputBaseProps extends PolymorphicProps {}
 export interface NumberInputInputProps extends HTMLProps<'input'>, NumberInputInputBaseProps {}
 
-export const NumberInputInput = forwardRef<HTMLInputElement, NumberInputInputProps>((props, ref) => {
+export const NumberInputInput = ({ ref, ...props }: NumberInputInputProps) => {
   const numberInput = useNumberInputContext()
   const mergedProps = mergeProps(numberInput.getInputProps(), props)
   const field = useFieldContext()
 
   return <ark.input aria-describedby={field?.ariaDescribedby} {...mergedProps} ref={ref} />
-})
+}
 
 NumberInputInput.displayName = 'NumberInputInput'

--- a/packages/react/src/components/number-input/number-input-label.tsx
+++ b/packages/react/src/components/number-input/number-input-label.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useNumberInputContext } from './use-number-input-context'
 
 export interface NumberInputLabelBaseProps extends PolymorphicProps {}
 export interface NumberInputLabelProps extends HTMLProps<'label'>, NumberInputLabelBaseProps {}
 
-export const NumberInputLabel = forwardRef<HTMLLabelElement, NumberInputLabelProps>((props, ref) => {
+export const NumberInputLabel = ({ ref, ...props }: NumberInputLabelProps) => {
   const numberInput = useNumberInputContext()
   const mergedProps = mergeProps(numberInput.getLabelProps(), props)
 
   return <ark.label {...mergedProps} ref={ref} />
-})
+}
 
 NumberInputLabel.displayName = 'NumberInputLabel'

--- a/packages/react/src/components/number-input/number-input-root-provider.tsx
+++ b/packages/react/src/components/number-input/number-input-root-provider.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import type { UseNumberInputReturn } from './use-number-input'
@@ -16,7 +15,7 @@ export interface NumberInputRootProviderProps extends HTMLProps<'div'>, NumberIn
 
 const splitRootProviderProps = createSplitProps<RootProviderProps>()
 
-export const NumberInputRootProvider = forwardRef<HTMLDivElement, NumberInputRootProviderProps>((props, ref) => {
+export const NumberInputRootProvider = ({ ref, ...props }: NumberInputRootProviderProps) => {
   const [{ value: numberInput }, localProps] = splitRootProviderProps(props, ['value'])
   const mergedProps = mergeProps(numberInput.getRootProps(), localProps)
 
@@ -25,6 +24,6 @@ export const NumberInputRootProvider = forwardRef<HTMLDivElement, NumberInputRoo
       <ark.div {...mergedProps} ref={ref} />
     </NumberInputProvider>
   )
-})
+}
 
 NumberInputRootProvider.displayName = 'NumberInputRootProvider'

--- a/packages/react/src/components/number-input/number-input-root.tsx
+++ b/packages/react/src/components/number-input/number-input-root.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import type { Assign } from '../../types'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -13,7 +12,7 @@ export interface NumberInputRootProps extends Assign<HTMLProps<'div'>, NumberInp
 
 const splitRootProps = createSplitProps<UseNumberInputProps>()
 
-export const NumberInputRoot = forwardRef<HTMLDivElement, NumberInputRootProps>((props, ref) => {
+export const NumberInputRoot = ({ ref, ...props }: NumberInputRootProps) => {
   const [useNumberInputProps, localProps] = splitRootProps(props, [
     'allowMouseWheel',
     'allowOverflow',
@@ -51,6 +50,6 @@ export const NumberInputRoot = forwardRef<HTMLDivElement, NumberInputRootProps>(
       <ark.div {...mergedProps} ref={ref} />
     </NumberInputProvider>
   )
-})
+}
 
 NumberInputRoot.displayName = 'NumberInputRoot'

--- a/packages/react/src/components/number-input/number-input-scrubber.tsx
+++ b/packages/react/src/components/number-input/number-input-scrubber.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useNumberInputContext } from './use-number-input-context'
 
 export interface NumberInputScrubberBaseProps extends PolymorphicProps {}
 export interface NumberInputScrubberProps extends HTMLProps<'div'>, NumberInputScrubberBaseProps {}
 
-export const NumberInputScrubber = forwardRef<HTMLDivElement, NumberInputScrubberProps>((props, ref) => {
+export const NumberInputScrubber = ({ ref, ...props }: NumberInputScrubberProps) => {
   const numberInput = useNumberInputContext()
   const mergedProps = mergeProps(numberInput.getScrubberProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 NumberInputScrubber.displayName = 'NumberInputScrubber'

--- a/packages/react/src/components/number-input/number-input-value-text.tsx
+++ b/packages/react/src/components/number-input/number-input-value-text.tsx
@@ -1,14 +1,13 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useNumberInputContext } from './use-number-input-context'
 
 export interface NumberInputValueTextBaseProps extends PolymorphicProps {}
 export interface NumberInputValueTextProps extends HTMLProps<'span'>, NumberInputValueTextBaseProps {}
 
-export const NumberInputValueText = forwardRef<HTMLSpanElement, NumberInputValueTextProps>((props, ref) => {
+export const NumberInputValueText = ({ ref, ...props }: NumberInputValueTextProps) => {
   const { children, ...localProps } = props
   const numberInput = useNumberInputContext()
   const mergedProps = mergeProps(numberInput.getValueTextProps(), localProps)
@@ -18,6 +17,6 @@ export const NumberInputValueText = forwardRef<HTMLSpanElement, NumberInputValue
       {children || numberInput.value}
     </ark.span>
   )
-})
+}
 
 NumberInputValueText.displayName = 'NumberInputValueText'

--- a/packages/react/src/components/pagination/pagination-ellipsis.tsx
+++ b/packages/react/src/components/pagination/pagination-ellipsis.tsx
@@ -2,7 +2,6 @@
 
 import type { EllipsisProps } from '@zag-js/pagination'
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { usePaginationContext } from './use-pagination-context'
@@ -12,12 +11,12 @@ export interface PaginationEllipsisProps extends HTMLProps<'div'>, PaginationEll
 
 const splitEllipsisProps = createSplitProps<EllipsisProps>()
 
-export const PaginationEllipsis = forwardRef<HTMLDivElement, PaginationEllipsisProps>((props, ref) => {
+export const PaginationEllipsis = ({ ref, ...props }: PaginationEllipsisProps) => {
   const [ellipsisProps, localProps] = splitEllipsisProps(props, ['index'])
   const pagination = usePaginationContext()
   const mergedProps = mergeProps(pagination.getEllipsisProps(ellipsisProps), localProps)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 PaginationEllipsis.displayName = 'PaginationEllipsis'

--- a/packages/react/src/components/pagination/pagination-first-trigger.tsx
+++ b/packages/react/src/components/pagination/pagination-first-trigger.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { usePaginationContext } from './use-pagination-context'
 
 export interface PaginationFirstTriggerBaseProps extends PolymorphicProps {}
 export interface PaginationFirstTriggerProps extends HTMLProps<'button'>, PaginationFirstTriggerBaseProps {}
 
-export const PaginationFirstTrigger = forwardRef<HTMLButtonElement, PaginationFirstTriggerProps>((props, ref) => {
+export const PaginationFirstTrigger = ({ ref, ...props }: PaginationFirstTriggerProps) => {
   const pagination = usePaginationContext()
   const mergedProps = mergeProps(pagination.getFirstTriggerProps(), props)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 PaginationFirstTrigger.displayName = 'PaginationFirstTrigger'

--- a/packages/react/src/components/pagination/pagination-item.tsx
+++ b/packages/react/src/components/pagination/pagination-item.tsx
@@ -2,7 +2,6 @@
 
 import type { ItemProps } from '@zag-js/pagination'
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import type { Assign } from '../../types'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -13,12 +12,12 @@ export interface PaginationItemProps extends Assign<HTMLProps<'button'>, Paginat
 
 const splitItemProps = createSplitProps<ItemProps>()
 
-export const PaginationItem = forwardRef<HTMLButtonElement, PaginationItemProps>((props, ref) => {
+export const PaginationItem = ({ ref, ...props }: PaginationItemProps) => {
   const [itemProps, localProps] = splitItemProps(props, ['value', 'type'])
   const pagination = usePaginationContext()
   const mergedProps = mergeProps(pagination.getItemProps(itemProps), localProps)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 PaginationItem.displayName = 'PaginationItem'

--- a/packages/react/src/components/pagination/pagination-last-trigger.tsx
+++ b/packages/react/src/components/pagination/pagination-last-trigger.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { usePaginationContext } from './use-pagination-context'
 
 export interface PaginationLastTriggerBaseProps extends PolymorphicProps {}
 export interface PaginationLastTriggerProps extends HTMLProps<'button'>, PaginationLastTriggerBaseProps {}
 
-export const PaginationLastTrigger = forwardRef<HTMLButtonElement, PaginationLastTriggerProps>((props, ref) => {
+export const PaginationLastTrigger = ({ ref, ...props }: PaginationLastTriggerProps) => {
   const pagination = usePaginationContext()
   const mergedProps = mergeProps(pagination.getLastTriggerProps(), props)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 PaginationLastTrigger.displayName = 'PaginationLastTrigger'

--- a/packages/react/src/components/pagination/pagination-next-trigger.tsx
+++ b/packages/react/src/components/pagination/pagination-next-trigger.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { usePaginationContext } from './use-pagination-context'
 
 export interface PaginationNextTriggerBaseProps extends PolymorphicProps {}
 export interface PaginationNextTriggerProps extends HTMLProps<'button'>, PaginationNextTriggerBaseProps {}
 
-export const PaginationNextTrigger = forwardRef<HTMLButtonElement, PaginationNextTriggerProps>((props, ref) => {
+export const PaginationNextTrigger = ({ ref, ...props }: PaginationNextTriggerProps) => {
   const pagination = usePaginationContext()
   const mergedProps = mergeProps(pagination.getNextTriggerProps(), props)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 PaginationNextTrigger.displayName = 'PaginationNextTrigger'

--- a/packages/react/src/components/pagination/pagination-prev-trigger.tsx
+++ b/packages/react/src/components/pagination/pagination-prev-trigger.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { usePaginationContext } from './use-pagination-context'
 
 export interface PaginationPrevTriggerBaseProps extends PolymorphicProps {}
 export interface PaginationPrevTriggerProps extends HTMLProps<'button'>, PaginationPrevTriggerBaseProps {}
 
-export const PaginationPrevTrigger = forwardRef<HTMLButtonElement, PaginationPrevTriggerProps>((props, ref) => {
+export const PaginationPrevTrigger = ({ ref, ...props }: PaginationPrevTriggerProps) => {
   const pagination = usePaginationContext()
   const mergedProps = mergeProps(pagination.getPrevTriggerProps(), props)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 PaginationPrevTrigger.displayName = 'PaginationPrevTrigger'

--- a/packages/react/src/components/pagination/pagination-root-provider.tsx
+++ b/packages/react/src/components/pagination/pagination-root-provider.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import type { UsePaginationReturn } from './use-pagination'
@@ -16,7 +15,7 @@ export interface PaginationRootProviderProps extends HTMLProps<'nav'>, Paginatio
 
 const splitRootProviderProps = createSplitProps<RootProviderProps>()
 
-export const PaginationRootProvider = forwardRef<HTMLElement, PaginationRootProviderProps>((props, ref) => {
+export const PaginationRootProvider = ({ ref, ...props }: PaginationRootProviderProps) => {
   const [{ value: pagination }, localProps] = splitRootProviderProps(props, ['value'])
   const mergedProps = mergeProps(pagination.getRootProps(), localProps)
 
@@ -25,6 +24,6 @@ export const PaginationRootProvider = forwardRef<HTMLElement, PaginationRootProv
       <ark.nav {...mergedProps} ref={ref} />
     </PaginationProvider>
   )
-})
+}
 
 PaginationRootProvider.displayName = 'PaginationRootProvider'

--- a/packages/react/src/components/pagination/pagination-root.tsx
+++ b/packages/react/src/components/pagination/pagination-root.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { type UsePaginationProps, usePagination } from './use-pagination'
@@ -12,7 +11,7 @@ export interface PaginationRootProps extends HTMLProps<'nav'>, PaginationRootBas
 
 const splitRootProps = createSplitProps<UsePaginationProps>()
 
-export const PaginationRoot = forwardRef<HTMLElement, PaginationRootProps>((props, ref) => {
+export const PaginationRoot = ({ ref, ...props }: PaginationRootProps) => {
   const [paginationProps, localProps] = splitRootProps(props, [
     'boundaryCount',
     'count',
@@ -38,6 +37,6 @@ export const PaginationRoot = forwardRef<HTMLElement, PaginationRootProps>((prop
       <ark.nav {...mergedProps} ref={ref} />
     </PaginationProvider>
   )
-})
+}
 
 PaginationRoot.displayName = 'PaginationRoot'

--- a/packages/react/src/components/password-input/password-input-control.tsx
+++ b/packages/react/src/components/password-input/password-input-control.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { usePasswordInputContext } from './use-password-input-context'
 
 export interface PasswordInputControlBaseProps extends PolymorphicProps {}
 export interface PasswordInputControlProps extends HTMLProps<'div'>, PasswordInputControlBaseProps {}
 
-export const PasswordInputControl = forwardRef<HTMLDivElement, PasswordInputControlProps>((props, ref) => {
+export const PasswordInputControl = ({ ref, ...props }: PasswordInputControlProps) => {
   const passwordInput = usePasswordInputContext()
   const mergedProps = mergeProps(passwordInput.getControlProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 PasswordInputControl.displayName = 'PasswordInputControl'

--- a/packages/react/src/components/password-input/password-input-indicator.tsx
+++ b/packages/react/src/components/password-input/password-input-indicator.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { usePasswordInputContext } from './use-password-input-context'
 
@@ -13,7 +12,7 @@ export interface PasswordInputIndicatorBaseProps extends PolymorphicProps {
 }
 export interface PasswordInputIndicatorProps extends HTMLProps<'span'>, PasswordInputIndicatorBaseProps {}
 
-export const PasswordInputIndicator = forwardRef<HTMLSpanElement, PasswordInputIndicatorProps>((props, ref) => {
+export const PasswordInputIndicator = ({ ref, ...props }: PasswordInputIndicatorProps) => {
   const passwordInput = usePasswordInputContext()
   const { fallback, children, ...rest } = props
   const mergedProps = mergeProps(passwordInput.getIndicatorProps(), rest)
@@ -23,6 +22,6 @@ export const PasswordInputIndicator = forwardRef<HTMLSpanElement, PasswordInputI
       {passwordInput.visible ? children : fallback}
     </ark.span>
   )
-})
+}
 
 PasswordInputIndicator.displayName = 'PasswordInputIndicator'

--- a/packages/react/src/components/password-input/password-input-input.tsx
+++ b/packages/react/src/components/password-input/password-input-input.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useFieldContext } from '../field'
 import { usePasswordInputContext } from './use-password-input-context'
@@ -9,12 +8,12 @@ import { usePasswordInputContext } from './use-password-input-context'
 export interface PasswordInputInputBaseProps extends PolymorphicProps {}
 export interface PasswordInputInputProps extends HTMLProps<'input'>, PasswordInputInputBaseProps {}
 
-export const PasswordInputInput = forwardRef<HTMLInputElement, PasswordInputInputProps>((props, ref) => {
+export const PasswordInputInput = ({ ref, ...props }: PasswordInputInputProps) => {
   const passwordInput = usePasswordInputContext()
   const mergedProps = mergeProps(passwordInput.getInputProps(), props)
   const field = useFieldContext()
 
   return <ark.input aria-describedby={field?.ariaDescribedby} {...mergedProps} ref={ref} />
-})
+}
 
 PasswordInputInput.displayName = 'PasswordInputInput'

--- a/packages/react/src/components/password-input/password-input-label.tsx
+++ b/packages/react/src/components/password-input/password-input-label.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { usePasswordInputContext } from './use-password-input-context'
 
 export interface PasswordInputLabelBaseProps extends PolymorphicProps {}
 export interface PasswordInputLabelProps extends HTMLProps<'label'>, PasswordInputLabelBaseProps {}
 
-export const PasswordInputLabel = forwardRef<HTMLLabelElement, PasswordInputLabelProps>((props, ref) => {
+export const PasswordInputLabel = ({ ref, ...props }: PasswordInputLabelProps) => {
   const passwordInput = usePasswordInputContext()
   const mergedProps = mergeProps(passwordInput.getLabelProps(), props)
 
   return <ark.label {...mergedProps} ref={ref} />
-})
+}
 
 PasswordInputLabel.displayName = 'PasswordInputLabel'

--- a/packages/react/src/components/password-input/password-input-root-provider.tsx
+++ b/packages/react/src/components/password-input/password-input-root-provider.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import type { UsePasswordInputReturn } from './use-password-input'
 import { PasswordInputProvider } from './use-password-input-context'
@@ -13,7 +12,7 @@ interface RootProviderProps {
 export interface PasswordInputRootProviderBaseProps extends RootProviderProps, PolymorphicProps {}
 export interface PasswordInputRootProviderProps extends HTMLProps<'div'>, PasswordInputRootProviderBaseProps {}
 
-export const PasswordInputRootProvider = forwardRef<HTMLDivElement, PasswordInputRootProviderProps>((props, ref) => {
+export const PasswordInputRootProvider = ({ ref, ...props }: PasswordInputRootProviderProps) => {
   const { value: passwordInput, ...localProps } = props
   const mergedProps = mergeProps(passwordInput.getRootProps(), localProps)
 
@@ -22,6 +21,6 @@ export const PasswordInputRootProvider = forwardRef<HTMLDivElement, PasswordInpu
       <ark.div {...mergedProps} ref={ref} />
     </PasswordInputProvider>
   )
-})
+}
 
 PasswordInputRootProvider.displayName = 'PasswordInputRootProvider'

--- a/packages/react/src/components/password-input/password-input-root.tsx
+++ b/packages/react/src/components/password-input/password-input-root.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import type { Assign } from '../../types'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -13,7 +12,7 @@ export interface PasswordInputRootProps extends Assign<HTMLProps<'div'>, Passwor
 
 const splitRootProps = createSplitProps<UsePasswordInputProps>()
 
-export const PasswordInputRoot = forwardRef<HTMLDivElement, PasswordInputRootProps>((props, ref) => {
+export const PasswordInputRoot = ({ ref, ...props }: PasswordInputRootProps) => {
   const [usePasswordInputProps, localProps] = splitRootProps(props, [
     'autoComplete',
     'defaultVisible',
@@ -37,6 +36,6 @@ export const PasswordInputRoot = forwardRef<HTMLDivElement, PasswordInputRootPro
       <ark.div {...mergedProps} ref={ref} />
     </PasswordInputProvider>
   )
-})
+}
 
 PasswordInputRoot.displayName = 'PasswordInputRoot'

--- a/packages/react/src/components/password-input/password-input-visibility-trigger.tsx
+++ b/packages/react/src/components/password-input/password-input-visibility-trigger.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { usePasswordInputContext } from './use-password-input-context'
 
@@ -9,13 +8,11 @@ export interface PasswordInputVisibilityTriggerBaseProps extends PolymorphicProp
 export interface PasswordInputVisibilityTriggerProps
   extends HTMLProps<'button'>, PasswordInputVisibilityTriggerBaseProps {}
 
-export const PasswordInputVisibilityTrigger = forwardRef<HTMLButtonElement, PasswordInputVisibilityTriggerProps>(
-  (props, ref) => {
-    const passwordInput = usePasswordInputContext()
-    const mergedProps = mergeProps(passwordInput.getVisibilityTriggerProps(), props)
+export const PasswordInputVisibilityTrigger = ({ ref, ...props }: PasswordInputVisibilityTriggerProps) => {
+  const passwordInput = usePasswordInputContext()
+  const mergedProps = mergeProps(passwordInput.getVisibilityTriggerProps(), props)
 
-    return <ark.button {...mergedProps} ref={ref} />
-  },
-)
+  return <ark.button {...mergedProps} ref={ref} />
+}
 
 PasswordInputVisibilityTrigger.displayName = 'PasswordInputVisibilityTrigger'

--- a/packages/react/src/components/pin-input/pin-input-control.tsx
+++ b/packages/react/src/components/pin-input/pin-input-control.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { usePinInputContext } from './use-pin-input-context'
 
 export interface PinInputControlBaseProps extends PolymorphicProps {}
 export interface PinInputControlProps extends HTMLProps<'div'>, PinInputControlBaseProps {}
 
-export const PinInputControl = forwardRef<HTMLDivElement, PinInputControlProps>((props, ref) => {
+export const PinInputControl = ({ ref, ...props }: PinInputControlProps) => {
   const pinInput = usePinInputContext()
   const mergedProps = mergeProps(pinInput.getControlProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 PinInputControl.displayName = 'PinInputControl'

--- a/packages/react/src/components/pin-input/pin-input-hidden-input.tsx
+++ b/packages/react/src/components/pin-input/pin-input-hidden-input.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useFieldContext } from '../field'
 import { usePinInputContext } from './use-pin-input-context'
@@ -9,12 +8,12 @@ import { usePinInputContext } from './use-pin-input-context'
 export interface PinInputHiddenInputBaseProps extends PolymorphicProps {}
 export interface PinInputHiddenInputProps extends HTMLProps<'input'>, PinInputHiddenInputBaseProps {}
 
-export const PinInputHiddenInput = forwardRef<HTMLInputElement, PinInputHiddenInputProps>((props, ref) => {
+export const PinInputHiddenInput = ({ ref, ...props }: PinInputHiddenInputProps) => {
   const pinInput = usePinInputContext()
   const mergedProps = mergeProps(pinInput.getHiddenInputProps(), props)
   const field = useFieldContext()
 
   return <ark.input aria-describedby={field?.ariaDescribedby} {...mergedProps} ref={ref} />
-})
+}
 
 PinInputHiddenInput.displayName = 'PinInputHiddenInput'

--- a/packages/react/src/components/pin-input/pin-input-input.tsx
+++ b/packages/react/src/components/pin-input/pin-input-input.tsx
@@ -2,7 +2,6 @@
 
 import type { InputProps } from '@zag-js/pin-input'
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { usePinInputContext } from './use-pin-input-context'
@@ -12,12 +11,12 @@ export interface PinInputInputProps extends HTMLProps<'input'>, PinInputInputBas
 
 const splitInputProps = createSplitProps<InputProps>()
 
-export const PinInputInput = forwardRef<HTMLInputElement, PinInputInputProps>((props, ref) => {
+export const PinInputInput = ({ ref, ...props }: PinInputInputProps) => {
   const [inputProps, localProps] = splitInputProps(props, ['index'])
   const pinInput = usePinInputContext()
   const mergedProps = mergeProps(pinInput.getInputProps(inputProps), localProps)
 
   return <ark.input {...mergedProps} ref={ref} />
-})
+}
 
 PinInputInput.displayName = 'PinInputInput'

--- a/packages/react/src/components/pin-input/pin-input-label.tsx
+++ b/packages/react/src/components/pin-input/pin-input-label.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { usePinInputContext } from './use-pin-input-context'
 
 export interface PinInputLabelBaseProps extends PolymorphicProps {}
 export interface PinInputLabelProps extends HTMLProps<'label'>, PinInputLabelBaseProps {}
 
-export const PinInputLabel = forwardRef<HTMLLabelElement, PinInputLabelProps>((props, ref) => {
+export const PinInputLabel = ({ ref, ...props }: PinInputLabelProps) => {
   const pinInput = usePinInputContext()
   const mergedProps = mergeProps(pinInput.getLabelProps(), props)
 
   return <ark.label {...mergedProps} ref={ref} />
-})
+}
 
 PinInputLabel.displayName = 'PinInputLabel'

--- a/packages/react/src/components/pin-input/pin-input-root-provider.tsx
+++ b/packages/react/src/components/pin-input/pin-input-root-provider.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import type { UsePinInputReturn } from './use-pin-input'
@@ -16,7 +15,7 @@ export interface PinInputRootProviderProps extends HTMLProps<'div'>, PinInputRoo
 
 const splitRootProviderProps = createSplitProps<RootProviderProps>()
 
-export const PinInputRootProvider = forwardRef<HTMLDivElement, PinInputRootProviderProps>((props, ref) => {
+export const PinInputRootProvider = ({ ref, ...props }: PinInputRootProviderProps) => {
   const [{ value: pinInput }, localProps] = splitRootProviderProps(props, ['value'])
   const mergedProps = mergeProps(pinInput.getRootProps(), localProps)
 
@@ -25,6 +24,6 @@ export const PinInputRootProvider = forwardRef<HTMLDivElement, PinInputRootProvi
       <ark.div {...mergedProps} ref={ref} />
     </PinInputProvider>
   )
-})
+}
 
 PinInputRootProvider.displayName = 'PinInputRootProvider'

--- a/packages/react/src/components/pin-input/pin-input-root.tsx
+++ b/packages/react/src/components/pin-input/pin-input-root.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import type { Assign } from '../../types'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -13,7 +12,7 @@ export interface PinInputRootProps extends Assign<HTMLProps<'div'>, PinInputRoot
 
 const splitRootProps = createSplitProps<UsePinInputProps>()
 
-export const PinInputRoot = forwardRef<HTMLDivElement, PinInputRootProps>((props, ref) => {
+export const PinInputRoot = ({ ref, ...props }: PinInputRootProps) => {
   const [usePinInputProps, localProps] = splitRootProps(props, [
     'autoFocus',
     'autoSubmit',
@@ -49,6 +48,6 @@ export const PinInputRoot = forwardRef<HTMLDivElement, PinInputRootProps>((props
       <ark.div {...mergedProps} ref={ref} />
     </PinInputProvider>
   )
-})
+}
 
 PinInputRoot.displayName = 'PinInputRoot'

--- a/packages/react/src/components/popover/popover-anchor.tsx
+++ b/packages/react/src/components/popover/popover-anchor.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { usePopoverContext } from './use-popover-context'
 
 export interface PopoverAnchorBaseProps extends PolymorphicProps {}
 export interface PopoverAnchorProps extends HTMLProps<'div'>, PopoverAnchorBaseProps {}
 
-export const PopoverAnchor = forwardRef<HTMLDivElement, PopoverAnchorProps>((props, ref) => {
+export const PopoverAnchor = ({ ref, ...props }: PopoverAnchorProps) => {
   const popover = usePopoverContext()
   const mergedProps = mergeProps(popover.getAnchorProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 PopoverAnchor.displayName = 'PopoverAnchor'

--- a/packages/react/src/components/popover/popover-arrow-tip.tsx
+++ b/packages/react/src/components/popover/popover-arrow-tip.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { usePopoverContext } from './use-popover-context'
 
 export interface PopoverArrowTipBaseProps extends PolymorphicProps {}
 export interface PopoverArrowTipProps extends HTMLProps<'div'>, PopoverArrowTipBaseProps {}
 
-export const PopoverArrowTip = forwardRef<HTMLDivElement, PopoverArrowTipProps>((props, ref) => {
+export const PopoverArrowTip = ({ ref, ...props }: PopoverArrowTipProps) => {
   const popover = usePopoverContext()
   const mergedProps = mergeProps(popover.getArrowTipProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 PopoverArrowTip.displayName = 'PopoverArrowTip'

--- a/packages/react/src/components/popover/popover-arrow.tsx
+++ b/packages/react/src/components/popover/popover-arrow.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { usePopoverContext } from './use-popover-context'
 
 export interface PopoverArrowBaseProps extends PolymorphicProps {}
 export interface PopoverArrowProps extends HTMLProps<'div'>, PopoverArrowBaseProps {}
 
-export const PopoverArrow = forwardRef<HTMLDivElement, PopoverArrowProps>((props, ref) => {
+export const PopoverArrow = ({ ref, ...props }: PopoverArrowProps) => {
   const popover = usePopoverContext()
   const mergedProps = mergeProps(popover.getArrowProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 PopoverArrow.displayName = 'PopoverArrow'

--- a/packages/react/src/components/popover/popover-close-trigger.tsx
+++ b/packages/react/src/components/popover/popover-close-trigger.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { usePopoverContext } from './use-popover-context'
 
 export interface PopoverCloseTriggerBaseProps extends PolymorphicProps {}
 export interface PopoverCloseTriggerProps extends HTMLProps<'button'>, PopoverCloseTriggerBaseProps {}
 
-export const PopoverCloseTrigger = forwardRef<HTMLButtonElement, PopoverCloseTriggerProps>((props, ref) => {
+export const PopoverCloseTrigger = ({ ref, ...props }: PopoverCloseTriggerProps) => {
   const popover = usePopoverContext()
   const mergedProps = mergeProps(popover.getCloseTriggerProps(), props)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 PopoverCloseTrigger.displayName = 'PopoverCloseTrigger'

--- a/packages/react/src/components/popover/popover-content.tsx
+++ b/packages/react/src/components/popover/popover-content.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { composeRefs } from '../../utils/compose-refs'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { usePresenceContext } from '../presence'
@@ -10,7 +9,7 @@ import { usePopoverContext } from './use-popover-context'
 export interface PopoverContentBaseProps extends PolymorphicProps {}
 export interface PopoverContentProps extends HTMLProps<'div'>, PopoverContentBaseProps {}
 
-export const PopoverContent = forwardRef<HTMLDivElement, PopoverContentProps>((props, ref) => {
+export const PopoverContent = ({ ref, ...props }: PopoverContentProps) => {
   const popover = usePopoverContext()
   const presence = usePresenceContext()
   const mergedProps = mergeProps(popover.getContentProps(), presence.getPresenceProps(), props)
@@ -20,6 +19,6 @@ export const PopoverContent = forwardRef<HTMLDivElement, PopoverContentProps>((p
   }
 
   return <ark.div {...mergedProps} ref={composeRefs(presence.ref, ref)} />
-})
+}
 
 PopoverContent.displayName = 'PopoverContent'

--- a/packages/react/src/components/popover/popover-description.tsx
+++ b/packages/react/src/components/popover/popover-description.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { usePopoverContext } from './use-popover-context'
 
 export interface PopoverDescriptionBaseProps extends PolymorphicProps {}
 export interface PopoverDescriptionProps extends HTMLProps<'div'>, PopoverDescriptionBaseProps {}
 
-export const PopoverDescription = forwardRef<HTMLDivElement, PopoverDescriptionProps>((props, ref) => {
+export const PopoverDescription = ({ ref, ...props }: PopoverDescriptionProps) => {
   const popover = usePopoverContext()
   const mergedProps = mergeProps(popover.getDescriptionProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 PopoverDescription.displayName = 'PopoverDescription'

--- a/packages/react/src/components/popover/popover-indicator.tsx
+++ b/packages/react/src/components/popover/popover-indicator.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { usePopoverContext } from './use-popover-context'
 
 export interface PopoverIndicatorBaseProps extends PolymorphicProps {}
 export interface PopoverIndicatorProps extends HTMLProps<'div'>, PopoverIndicatorBaseProps {}
 
-export const PopoverIndicator = forwardRef<HTMLDivElement, PopoverIndicatorProps>((props, ref) => {
+export const PopoverIndicator = ({ ref, ...props }: PopoverIndicatorProps) => {
   const popover = usePopoverContext()
   const mergedProps = mergeProps(popover.getIndicatorProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 PopoverIndicator.displayName = 'PopoverIndicator'

--- a/packages/react/src/components/popover/popover-positioner.tsx
+++ b/packages/react/src/components/popover/popover-positioner.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { usePresenceContext } from '../presence'
 import { usePopoverContext } from './use-popover-context'
@@ -9,7 +8,7 @@ import { usePopoverContext } from './use-popover-context'
 export interface PopoverPositionerBaseProps extends PolymorphicProps {}
 export interface PopoverPositionerProps extends HTMLProps<'div'>, PopoverPositionerBaseProps {}
 
-export const PopoverPositioner = forwardRef<HTMLDivElement, PopoverPositionerProps>((props, ref) => {
+export const PopoverPositioner = ({ ref, ...props }: PopoverPositionerProps) => {
   const popover = usePopoverContext()
   const presence = usePresenceContext()
   const mergedProps = mergeProps(popover.getPositionerProps(), props)
@@ -19,6 +18,6 @@ export const PopoverPositioner = forwardRef<HTMLDivElement, PopoverPositionerPro
   }
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 PopoverPositioner.displayName = 'PopoverPositioner'

--- a/packages/react/src/components/popover/popover-title.tsx
+++ b/packages/react/src/components/popover/popover-title.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { usePopoverContext } from './use-popover-context'
 
 export interface PopoverTitleBaseProps extends PolymorphicProps {}
 export interface PopoverTitleProps extends HTMLProps<'div'>, PopoverTitleBaseProps {}
 
-export const PopoverTitle = forwardRef<HTMLDivElement, PopoverTitleProps>((props, ref) => {
+export const PopoverTitle = ({ ref, ...props }: PopoverTitleProps) => {
   const popover = usePopoverContext()
   const mergedProps = mergeProps(popover.getTitleProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 PopoverTitle.displayName = 'PopoverTitle'

--- a/packages/react/src/components/popover/popover-trigger.tsx
+++ b/packages/react/src/components/popover/popover-trigger.tsx
@@ -2,7 +2,6 @@
 
 import { mergeProps } from '@zag-js/react'
 import type { TriggerProps } from '@zag-js/popover'
-import { forwardRef } from 'react'
 import type { Assign } from '../../types'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -14,7 +13,7 @@ export interface PopoverTriggerProps extends Assign<HTMLProps<'button'>, Popover
 
 const splitTriggerProps = createSplitProps<TriggerProps>()
 
-export const PopoverTrigger = forwardRef<HTMLButtonElement, PopoverTriggerProps>((props, ref) => {
+export const PopoverTrigger = ({ ref, ...props }: PopoverTriggerProps) => {
   const [triggerProps, localProps] = splitTriggerProps(props, ['value'])
   const popover = usePopoverContext()
   const presence = usePresenceContext()
@@ -28,6 +27,6 @@ export const PopoverTrigger = forwardRef<HTMLButtonElement, PopoverTriggerProps>
   )
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 PopoverTrigger.displayName = 'PopoverTrigger'

--- a/packages/react/src/components/presence/presence.tsx
+++ b/packages/react/src/components/presence/presence.tsx
@@ -1,4 +1,3 @@
-import { forwardRef } from 'react'
 import { composeRefs } from '../../utils/compose-refs'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { splitPresenceProps } from './split-presence-props'
@@ -7,7 +6,7 @@ import { type UsePresenceProps, usePresence } from './use-presence'
 export interface PresenceBaseProps extends UsePresenceProps, PolymorphicProps {}
 export interface PresenceProps extends HTMLProps<'div'>, PresenceBaseProps {}
 
-export const Presence = forwardRef<HTMLDivElement, PresenceProps>((props, ref) => {
+export const Presence = ({ ref, ...props }: PresenceProps) => {
   const [presenceProps, localProps] = splitPresenceProps(props)
   const presence = usePresence(presenceProps)
 
@@ -24,6 +23,6 @@ export const Presence = forwardRef<HTMLDivElement, PresenceProps>((props, ref) =
       ref={composeRefs(presence.ref, ref)}
     />
   )
-})
+}
 
 Presence.displayName = 'Presence'

--- a/packages/react/src/components/progress/progress-circle-range.tsx
+++ b/packages/react/src/components/progress/progress-circle-range.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useProgressContext } from './use-progress-context'
 
 export interface ProgressCircleRangeBaseProps extends PolymorphicProps {}
 export interface ProgressCircleRangeProps extends HTMLProps<'circle'>, ProgressCircleRangeBaseProps {}
 
-export const ProgressCircleRange = forwardRef<SVGCircleElement, ProgressCircleRangeProps>((props, ref) => {
+export const ProgressCircleRange = ({ ref, ...props }: ProgressCircleRangeProps) => {
   const progress = useProgressContext()
   const mergedProps = mergeProps(progress.getCircleRangeProps(), props)
 
   return <ark.circle ref={ref} {...mergedProps} />
-})
+}
 
 ProgressCircleRange.displayName = 'ProgressCircleRange'

--- a/packages/react/src/components/progress/progress-circle-track.tsx
+++ b/packages/react/src/components/progress/progress-circle-track.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useProgressContext } from './use-progress-context'
 
 export interface ProgressCircleTrackBaseProps extends PolymorphicProps {}
 export interface ProgressCircleTrackProps extends HTMLProps<'circle'>, ProgressCircleTrackBaseProps {}
 
-export const ProgressCircleTrack = forwardRef<SVGCircleElement, ProgressCircleTrackProps>((props, ref) => {
+export const ProgressCircleTrack = ({ ref, ...props }: ProgressCircleTrackProps) => {
   const progress = useProgressContext()
   const mergedProps = mergeProps(progress.getCircleTrackProps(), props)
 
   return <ark.circle ref={ref} {...mergedProps} />
-})
+}
 
 ProgressCircleTrack.displayName = 'ProgressCircleTrack'

--- a/packages/react/src/components/progress/progress-circle.tsx
+++ b/packages/react/src/components/progress/progress-circle.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useProgressContext } from './use-progress-context'
 
 export interface ProgressCircleBaseProps extends PolymorphicProps {}
 export interface ProgressCircleProps extends HTMLProps<'svg'>, ProgressCircleBaseProps {}
 
-export const ProgressCircle = forwardRef<SVGSVGElement, ProgressCircleProps>((props, ref) => {
+export const ProgressCircle = ({ ref, ...props }: ProgressCircleProps) => {
   const progress = useProgressContext()
   const mergedProps = mergeProps(progress.getCircleProps(), props)
 
   return <ark.svg ref={ref} {...mergedProps} />
-})
+}
 
 ProgressCircle.displayName = 'ProgressCircle'

--- a/packages/react/src/components/progress/progress-label.tsx
+++ b/packages/react/src/components/progress/progress-label.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useProgressContext } from './use-progress-context'
 
 export interface ProgressLabelBaseProps extends PolymorphicProps {}
 export interface ProgressLabelProps extends HTMLProps<'span'>, ProgressLabelBaseProps {}
 
-export const ProgressLabel = forwardRef<HTMLSpanElement, ProgressLabelProps>((props, ref) => {
+export const ProgressLabel = ({ ref, ...props }: ProgressLabelProps) => {
   const progress = useProgressContext()
   const mergedProps = mergeProps(progress.getLabelProps(), props)
 
   return <ark.span {...mergedProps} ref={ref} />
-})
+}
 
 ProgressLabel.displayName = 'ProgressLabel'

--- a/packages/react/src/components/progress/progress-range.tsx
+++ b/packages/react/src/components/progress/progress-range.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useProgressContext } from './use-progress-context'
 
 export interface ProgressRangeBaseProps extends PolymorphicProps {}
 export interface ProgressRangeProps extends HTMLProps<'div'>, ProgressRangeBaseProps {}
 
-export const ProgressRange = forwardRef<HTMLDivElement, ProgressRangeProps>((props, ref) => {
+export const ProgressRange = ({ ref, ...props }: ProgressRangeProps) => {
   const progress = useProgressContext()
   const mergedProps = mergeProps(progress.getRangeProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 ProgressRange.displayName = 'ProgressRange'

--- a/packages/react/src/components/progress/progress-root-provider.tsx
+++ b/packages/react/src/components/progress/progress-root-provider.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import type { UseProgressReturn } from './use-progress'
@@ -16,7 +15,7 @@ export interface ProgressRootProviderProps extends HTMLProps<'div'>, ProgressRoo
 
 const splitRootProviderProps = createSplitProps<RootProviderProps>()
 
-export const ProgressRootProvider = forwardRef<HTMLDivElement, ProgressRootProviderProps>((props, ref) => {
+export const ProgressRootProvider = ({ ref, ...props }: ProgressRootProviderProps) => {
   const [{ value: progress }, localProps] = splitRootProviderProps(props, ['value'])
   const mergedProps = mergeProps(progress.getRootProps(), localProps)
 
@@ -25,6 +24,6 @@ export const ProgressRootProvider = forwardRef<HTMLDivElement, ProgressRootProvi
       <ark.div {...mergedProps} ref={ref} />
     </ProgressProvider>
   )
-})
+}
 
 ProgressRootProvider.displayName = 'ProgressRootProvider'

--- a/packages/react/src/components/progress/progress-root.tsx
+++ b/packages/react/src/components/progress/progress-root.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import type { Assign } from '../../types'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -13,7 +12,7 @@ export interface ProgressRootProps extends Assign<HTMLProps<'div'>, ProgressRoot
 
 const splitRootProps = createSplitProps<UseProgressProps>()
 
-export const ProgressRoot = forwardRef<HTMLDivElement, ProgressRootProps>((props, ref) => {
+export const ProgressRoot = ({ ref, ...props }: ProgressRootProps) => {
   const [progressProps, localProps] = splitRootProps(props, [
     'defaultValue',
     'formatOptions',
@@ -35,6 +34,6 @@ export const ProgressRoot = forwardRef<HTMLDivElement, ProgressRootProps>((props
       <ark.div {...mergedProps} ref={ref} />
     </ProgressProvider>
   )
-})
+}
 
 ProgressRoot.displayName = 'ProgressRoot'

--- a/packages/react/src/components/progress/progress-track.tsx
+++ b/packages/react/src/components/progress/progress-track.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useProgressContext } from './use-progress-context'
 
 export interface ProgressTrackBaseProps extends PolymorphicProps {}
 export interface ProgressTrackProps extends HTMLProps<'div'>, ProgressTrackBaseProps {}
 
-export const ProgressTrack = forwardRef<HTMLDivElement, ProgressTrackProps>((props, ref) => {
+export const ProgressTrack = ({ ref, ...props }: ProgressTrackProps) => {
   const progress = useProgressContext()
   const mergedProps = mergeProps(progress.getTrackProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 ProgressTrack.displayName = 'ProgressTrack'

--- a/packages/react/src/components/progress/progress-value-text.tsx
+++ b/packages/react/src/components/progress/progress-value-text.tsx
@@ -1,14 +1,13 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useProgressContext } from './use-progress-context'
 
 export interface ProgressValueTextBaseProps extends PolymorphicProps {}
 export interface ProgressValueTextProps extends HTMLProps<'span'>, ProgressValueTextBaseProps {}
 
-export const ProgressValueText = forwardRef<HTMLSpanElement, ProgressValueTextProps>((props, ref) => {
+export const ProgressValueText = ({ ref, ...props }: ProgressValueTextProps) => {
   const { children, ...rest } = props
   const progress = useProgressContext()
   const mergedProps = mergeProps(progress.getValueTextProps(), rest)
@@ -18,6 +17,6 @@ export const ProgressValueText = forwardRef<HTMLSpanElement, ProgressValueTextPr
       {children || progress.percentAsString}
     </ark.span>
   )
-})
+}
 
 ProgressValueText.displayName = 'ProgressValueText'

--- a/packages/react/src/components/progress/progress-view.tsx
+++ b/packages/react/src/components/progress/progress-view.tsx
@@ -2,7 +2,6 @@
 
 import type { ViewProps } from '@zag-js/progress'
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useProgressContext } from './use-progress-context'
@@ -12,12 +11,12 @@ export interface ProgressViewProps extends HTMLProps<'span'>, ProgressViewBasePr
 
 const splitViewProps = createSplitProps<ViewProps>()
 
-export const ProgressView = forwardRef<HTMLSpanElement, ProgressViewProps>((props, ref) => {
+export const ProgressView = ({ ref, ...props }: ProgressViewProps) => {
   const [viewProps, localProps] = splitViewProps(props, ['state'])
   const progress = useProgressContext()
   const mergedProps = mergeProps(progress.getViewProps(viewProps), localProps)
 
   return <ark.span {...mergedProps} ref={ref} />
-})
+}
 
 ProgressView.displayName = 'ProgressView'

--- a/packages/react/src/components/qr-code/qr-code-download-trigger.tsx
+++ b/packages/react/src/components/qr-code/qr-code-download-trigger.tsx
@@ -2,7 +2,6 @@
 
 import type { DownloadTriggerProps } from '@zag-js/qr-code'
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useQrCodeContext } from './use-qr-code-context'
@@ -12,12 +11,12 @@ export interface QrCodeDownloadTriggerProps extends HTMLProps<'button'>, QrCodeD
 
 const splitDownloadTriggerProps = createSplitProps<DownloadTriggerProps>()
 
-export const QrCodeDownloadTrigger = forwardRef<HTMLButtonElement, QrCodeDownloadTriggerProps>((props, ref) => {
+export const QrCodeDownloadTrigger = ({ ref, ...props }: QrCodeDownloadTriggerProps) => {
   const [downloadTriggerProps, localProps] = splitDownloadTriggerProps(props, ['fileName', 'mimeType', 'quality'])
   const qrCode = useQrCodeContext()
   const mergedProps = mergeProps(qrCode.getDownloadTriggerProps(downloadTriggerProps), localProps)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 QrCodeDownloadTrigger.displayName = 'QrCodeDownloadTrigger'

--- a/packages/react/src/components/qr-code/qr-code-frame.tsx
+++ b/packages/react/src/components/qr-code/qr-code-frame.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useQrCodeContext } from './use-qr-code-context'
 
 export interface QrCodeFrameBaseProps extends PolymorphicProps {}
 export interface QrCodeFrameProps extends HTMLProps<'svg'>, QrCodeFrameBaseProps {}
 
-export const QrCodeFrame = forwardRef<SVGSVGElement, QrCodeFrameProps>((props, ref) => {
+export const QrCodeFrame = ({ ref, ...props }: QrCodeFrameProps) => {
   const qrCode = useQrCodeContext()
   const mergedProps = mergeProps(qrCode.getFrameProps(), props)
 
   return <ark.svg {...mergedProps} ref={ref} />
-})
+}
 
 QrCodeFrame.displayName = 'QrCodeFrame'

--- a/packages/react/src/components/qr-code/qr-code-overlay.tsx
+++ b/packages/react/src/components/qr-code/qr-code-overlay.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useQrCodeContext } from './use-qr-code-context'
 
 export interface QrCodeOverlayBaseProps extends PolymorphicProps {}
 export interface QrCodeOverlayProps extends HTMLProps<'div'>, QrCodeOverlayBaseProps {}
 
-export const QrCodeOverlay = forwardRef<HTMLDivElement, QrCodeOverlayProps>((props, ref) => {
+export const QrCodeOverlay = ({ ref, ...props }: QrCodeOverlayProps) => {
   const qrCode = useQrCodeContext()
   const mergedProps = mergeProps(qrCode.getOverlayProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 QrCodeOverlay.displayName = 'QrCodeOverlay'

--- a/packages/react/src/components/qr-code/qr-code-pattern.tsx
+++ b/packages/react/src/components/qr-code/qr-code-pattern.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useQrCodeContext } from './use-qr-code-context'
 
 export interface QrCodePatternBaseProps extends PolymorphicProps {}
 export interface QrCodePatternProps extends HTMLProps<'path'>, QrCodePatternBaseProps {}
 
-export const QrCodePattern = forwardRef<SVGPathElement, QrCodePatternProps>((props, ref) => {
+export const QrCodePattern = ({ ref, ...props }: QrCodePatternProps) => {
   const qrCode = useQrCodeContext()
   const mergedProps = mergeProps(qrCode.getPatternProps(), props)
 
   return <ark.path {...mergedProps} ref={ref} />
-})
+}
 
 QrCodePattern.displayName = 'QrCodePattern'

--- a/packages/react/src/components/qr-code/qr-code-root-provider.tsx
+++ b/packages/react/src/components/qr-code/qr-code-root-provider.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import type { UseQrCodeReturn } from './use-qr-code'
@@ -16,7 +15,7 @@ export interface QrCodeRootProviderProps extends HTMLProps<'div'>, QrCodeRootPro
 
 const splitRootProviderProps = createSplitProps<RootProviderProps>()
 
-export const QrCodeRootProvider = forwardRef<HTMLDivElement, QrCodeRootProviderProps>((props, ref) => {
+export const QrCodeRootProvider = ({ ref, ...props }: QrCodeRootProviderProps) => {
   const [{ value: qrCode }, localProps] = splitRootProviderProps(props, ['value'])
   const mergedProps = mergeProps(qrCode.getRootProps(), localProps)
 
@@ -25,6 +24,6 @@ export const QrCodeRootProvider = forwardRef<HTMLDivElement, QrCodeRootProviderP
       <ark.div {...mergedProps} ref={ref} />
     </QrCodeProvider>
   )
-})
+}
 
 QrCodeRootProvider.displayName = 'QrCodeRootProvider'

--- a/packages/react/src/components/qr-code/qr-code-root.tsx
+++ b/packages/react/src/components/qr-code/qr-code-root.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import type { Assign } from '../../types'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -13,7 +12,7 @@ export interface QrCodeRootProps extends Assign<HTMLProps<'div'>, QrCodeRootBase
 
 const splitRootProps = createSplitProps<UseQrCodeProps>()
 
-export const QrCodeRoot = forwardRef<HTMLDivElement, QrCodeRootProps>((props, ref) => {
+export const QrCodeRoot = ({ ref, ...props }: QrCodeRootProps) => {
   const [qrcodeProps, localProps] = splitRootProps(props, [
     'defaultValue',
     'encoding',
@@ -31,6 +30,6 @@ export const QrCodeRoot = forwardRef<HTMLDivElement, QrCodeRootProps>((props, re
       <ark.div {...mergedProps} ref={ref} />
     </QrCodeProvider>
   )
-})
+}
 
 QrCodeRoot.displayName = 'QrcodeRoot'

--- a/packages/react/src/components/radio-group/radio-group-indicator.tsx
+++ b/packages/react/src/components/radio-group/radio-group-indicator.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useRadioGroupContext } from './use-radio-group-context'
 
 export interface RadioGroupIndicatorBaseProps extends PolymorphicProps {}
 export interface RadioGroupIndicatorProps extends HTMLProps<'div'>, RadioGroupIndicatorBaseProps {}
 
-export const RadioGroupIndicator = forwardRef<HTMLDivElement, RadioGroupIndicatorProps>((props, ref) => {
+export const RadioGroupIndicator = ({ ref, ...props }: RadioGroupIndicatorProps) => {
   const radioGroup = useRadioGroupContext()
   const mergedProps = mergeProps(radioGroup.getIndicatorProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 RadioGroupIndicator.displayName = 'RadioGroupIndicator'

--- a/packages/react/src/components/radio-group/radio-group-item-control.tsx
+++ b/packages/react/src/components/radio-group/radio-group-item-control.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useRadioGroupContext } from './use-radio-group-context'
 import { useRadioGroupItemPropsContext } from './use-radio-group-item-props-context'
@@ -9,12 +8,12 @@ import { useRadioGroupItemPropsContext } from './use-radio-group-item-props-cont
 export interface RadioGroupItemControlBaseProps extends PolymorphicProps {}
 export interface RadioGroupItemControlProps extends HTMLProps<'div'>, RadioGroupItemControlBaseProps {}
 
-export const RadioGroupItemControl = forwardRef<HTMLDivElement, RadioGroupItemControlProps>((props, ref) => {
+export const RadioGroupItemControl = ({ ref, ...props }: RadioGroupItemControlProps) => {
   const radioGroup = useRadioGroupContext()
   const itemProps = useRadioGroupItemPropsContext()
   const mergedProps = mergeProps(radioGroup.getItemControlProps(itemProps), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 RadioGroupItemControl.displayName = 'RadioGroupItemControl'

--- a/packages/react/src/components/radio-group/radio-group-item-hidden-input.tsx
+++ b/packages/react/src/components/radio-group/radio-group-item-hidden-input.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useRadioGroupContext } from './use-radio-group-context'
 import { useRadioGroupItemPropsContext } from './use-radio-group-item-props-context'
@@ -9,12 +8,12 @@ import { useRadioGroupItemPropsContext } from './use-radio-group-item-props-cont
 export interface RadioGroupItemHiddenInputBaseProps extends PolymorphicProps {}
 export interface RadioGroupItemHiddenInputProps extends HTMLProps<'input'>, RadioGroupItemHiddenInputBaseProps {}
 
-export const RadioGroupItemHiddenInput = forwardRef<HTMLInputElement, RadioGroupItemHiddenInputProps>((props, ref) => {
+export const RadioGroupItemHiddenInput = ({ ref, ...props }: RadioGroupItemHiddenInputProps) => {
   const radioGroup = useRadioGroupContext()
   const itemProps = useRadioGroupItemPropsContext()
   const mergedProps = mergeProps(radioGroup.getItemHiddenInputProps(itemProps), props)
 
   return <ark.input {...mergedProps} ref={ref} />
-})
+}
 
 RadioGroupItemHiddenInput.displayName = 'RadioGroupItemHiddenInput'

--- a/packages/react/src/components/radio-group/radio-group-item-text.tsx
+++ b/packages/react/src/components/radio-group/radio-group-item-text.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useRadioGroupContext } from './use-radio-group-context'
 import { useRadioGroupItemPropsContext } from './use-radio-group-item-props-context'
@@ -9,12 +8,12 @@ import { useRadioGroupItemPropsContext } from './use-radio-group-item-props-cont
 export interface RadioGroupItemTextBaseProps extends PolymorphicProps {}
 export interface RadioGroupItemTextProps extends HTMLProps<'span'>, RadioGroupItemTextBaseProps {}
 
-export const RadioGroupItemText = forwardRef<HTMLSpanElement, RadioGroupItemTextProps>((props, ref) => {
+export const RadioGroupItemText = ({ ref, ...props }: RadioGroupItemTextProps) => {
   const radioGroup = useRadioGroupContext()
   const itemProps = useRadioGroupItemPropsContext()
   const mergedProps = mergeProps(radioGroup.getItemTextProps(itemProps), props)
 
   return <ark.span {...mergedProps} ref={ref} />
-})
+}
 
 RadioGroupItemText.displayName = 'RadioGroupItemText'

--- a/packages/react/src/components/radio-group/radio-group-item.tsx
+++ b/packages/react/src/components/radio-group/radio-group-item.tsx
@@ -2,7 +2,6 @@
 
 import type { ItemProps } from '@zag-js/radio-group'
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useRadioGroupContext } from './use-radio-group-context'
@@ -14,7 +13,7 @@ export interface RadioGroupItemProps extends HTMLProps<'label'>, RadioGroupItemB
 
 const splitItemProps = createSplitProps<ItemProps>()
 
-export const RadioGroupItem = forwardRef<HTMLLabelElement, RadioGroupItemProps>((props, ref) => {
+export const RadioGroupItem = ({ ref, ...props }: RadioGroupItemProps) => {
   const [itemProps, localProps] = splitItemProps(props, ['value', 'disabled', 'invalid'])
   const radioGroup = useRadioGroupContext()
   const mergedProps = mergeProps(radioGroup.getItemProps(itemProps), localProps)
@@ -27,6 +26,6 @@ export const RadioGroupItem = forwardRef<HTMLLabelElement, RadioGroupItemProps>(
       </RadioGroupItemPropsProvider>
     </RadioGroupItemProvider>
   )
-})
+}
 
 RadioGroupItem.displayName = 'RadioGroupItem'

--- a/packages/react/src/components/radio-group/radio-group-label.tsx
+++ b/packages/react/src/components/radio-group/radio-group-label.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useRadioGroupContext } from './use-radio-group-context'
 
 export interface RadioGroupLabelBaseProps extends PolymorphicProps {}
 export interface RadioGroupLabelProps extends HTMLProps<'span'>, RadioGroupLabelBaseProps {}
 
-export const RadioGroupLabel = forwardRef<HTMLSpanElement, RadioGroupLabelProps>((props, ref) => {
+export const RadioGroupLabel = ({ ref, ...props }: RadioGroupLabelProps) => {
   const radioGroup = useRadioGroupContext()
   const mergedProps = mergeProps(radioGroup.getLabelProps(), props)
 
   return <ark.span {...mergedProps} ref={ref} />
-})
+}
 
 RadioGroupLabel.displayName = 'RadioGroupLabel'

--- a/packages/react/src/components/radio-group/radio-group-root-provider.tsx
+++ b/packages/react/src/components/radio-group/radio-group-root-provider.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import type { UseRadioGroupReturn } from './use-radio-group'
@@ -16,7 +15,7 @@ export interface RadioGroupRootProviderProps extends HTMLProps<'div'>, RadioGrou
 
 const splitRootProviderProps = createSplitProps<RootProviderProps>()
 
-export const RadioGroupRootProvider = forwardRef<HTMLDivElement, RadioGroupRootProviderProps>((props, ref) => {
+export const RadioGroupRootProvider = ({ ref, ...props }: RadioGroupRootProviderProps) => {
   const [{ value: radioGroup }, localProps] = splitRootProviderProps(props, ['value'])
   const mergedProps = mergeProps(radioGroup.getRootProps(), localProps)
 
@@ -25,6 +24,6 @@ export const RadioGroupRootProvider = forwardRef<HTMLDivElement, RadioGroupRootP
       <ark.div {...mergedProps} ref={ref} />
     </RadioGroupProvider>
   )
-})
+}
 
 RadioGroupRootProvider.displayName = 'RadioGroupRootProvider'

--- a/packages/react/src/components/radio-group/radio-group-root.tsx
+++ b/packages/react/src/components/radio-group/radio-group-root.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import type { Assign } from '../../types'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -13,7 +12,7 @@ export interface RadioGroupRootProps extends Assign<HTMLProps<'div'>, RadioGroup
 
 const splitRootProps = createSplitProps<UseRadioGroupProps>()
 
-export const RadioGroupRoot = forwardRef<HTMLDivElement, RadioGroupRootProps>((props, ref) => {
+export const RadioGroupRoot = ({ ref, ...props }: RadioGroupRootProps) => {
   const [useRadioGroupProps, localProps] = splitRootProps(props, [
     'defaultValue',
     'disabled',
@@ -36,6 +35,6 @@ export const RadioGroupRoot = forwardRef<HTMLDivElement, RadioGroupRootProps>((p
       <ark.div {...mergedProps} ref={ref} />
     </RadioGroupProvider>
   )
-})
+}
 
 RadioGroupRoot.displayName = 'RadioGroupRoot'

--- a/packages/react/src/components/rating-group/rating-group-control.tsx
+++ b/packages/react/src/components/rating-group/rating-group-control.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useRatingGroupContext } from './use-rating-group-context'
 
 export interface RatingGroupControlBaseProps extends PolymorphicProps {}
 export interface RatingGroupControlProps extends HTMLProps<'div'>, RatingGroupControlBaseProps {}
 
-export const RatingGroupControl = forwardRef<HTMLDivElement, RatingGroupControlProps>((props, ref) => {
+export const RatingGroupControl = ({ ref, ...props }: RatingGroupControlProps) => {
   const ratingGroup = useRatingGroupContext()
   const mergedProps = mergeProps(ratingGroup.getControlProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 RatingGroupControl.displayName = 'RatingGroupControl'

--- a/packages/react/src/components/rating-group/rating-group-hidden-input.tsx
+++ b/packages/react/src/components/rating-group/rating-group-hidden-input.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useFieldContext } from '../field'
 import { useRatingGroupContext } from './use-rating-group-context'
@@ -9,12 +8,12 @@ import { useRatingGroupContext } from './use-rating-group-context'
 export interface RatingGroupHiddenInputBaseProps extends PolymorphicProps {}
 export interface RatingGroupHiddenInputProps extends HTMLProps<'input'>, RatingGroupHiddenInputBaseProps {}
 
-export const RatingGroupHiddenInput = forwardRef<HTMLInputElement, RatingGroupHiddenInputProps>((props, ref) => {
+export const RatingGroupHiddenInput = ({ ref, ...props }: RatingGroupHiddenInputProps) => {
   const ratingGroup = useRatingGroupContext()
   const mergedProps = mergeProps(ratingGroup.getHiddenInputProps(), props)
   const field = useFieldContext()
 
   return <ark.input aria-describedby={field?.ariaDescribedby} {...mergedProps} ref={ref} />
-})
+}
 
 RatingGroupHiddenInput.displayName = 'RatingGroupHiddenInput'

--- a/packages/react/src/components/rating-group/rating-group-item.tsx
+++ b/packages/react/src/components/rating-group/rating-group-item.tsx
@@ -2,7 +2,6 @@
 
 import type { ItemProps } from '@zag-js/rating-group'
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useRatingGroupContext } from './use-rating-group-context'
@@ -13,7 +12,7 @@ export interface RatingGroupItemProps extends HTMLProps<'span'>, RatingGroupItem
 
 const splitItemProps = createSplitProps<ItemProps>()
 
-export const RatingGroupItem = forwardRef<HTMLSpanElement, RatingGroupItemProps>((props, ref) => {
+export const RatingGroupItem = ({ ref, ...props }: RatingGroupItemProps) => {
   const [itemProps, localProps] = splitItemProps(props, ['index'])
   const ratingGroup = useRatingGroupContext()
   const mergedProps = mergeProps(ratingGroup.getItemProps(itemProps), localProps)
@@ -24,6 +23,6 @@ export const RatingGroupItem = forwardRef<HTMLSpanElement, RatingGroupItemProps>
       <ark.span {...mergedProps} ref={ref} />
     </RatingGroupItemProvider>
   )
-})
+}
 
 RatingGroupItem.displayName = 'RatingGroupItem'

--- a/packages/react/src/components/rating-group/rating-group-label.tsx
+++ b/packages/react/src/components/rating-group/rating-group-label.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useRatingGroupContext } from './use-rating-group-context'
 
 export interface RatingGroupLabelBaseProps extends PolymorphicProps {}
 export interface RatingGroupLabelProps extends HTMLProps<'label'>, RatingGroupLabelBaseProps {}
 
-export const RatingGroupLabel = forwardRef<HTMLLabelElement, RatingGroupLabelProps>((props, ref) => {
+export const RatingGroupLabel = ({ ref, ...props }: RatingGroupLabelProps) => {
   const ratingGroup = useRatingGroupContext()
   const mergedProps = mergeProps(ratingGroup.getLabelProps(), props)
 
   return <ark.label {...mergedProps} ref={ref} />
-})
+}
 
 RatingGroupLabel.displayName = 'RatingGroupLabel'

--- a/packages/react/src/components/rating-group/rating-group-root-provider.tsx
+++ b/packages/react/src/components/rating-group/rating-group-root-provider.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import type { UseRatingGroupReturn } from './use-rating-group'
@@ -16,7 +15,7 @@ export interface RatingGroupRootProviderProps extends HTMLProps<'div'>, RatingGr
 
 const splitRootProviderProps = createSplitProps<RootProviderProps>()
 
-export const RatingGroupRootProvider = forwardRef<HTMLDivElement, RatingGroupRootProviderProps>((props, ref) => {
+export const RatingGroupRootProvider = ({ ref, ...props }: RatingGroupRootProviderProps) => {
   const [{ value: ratingGroup }, localProps] = splitRootProviderProps(props, ['value'])
   const mergedProps = mergeProps(ratingGroup.getRootProps(), localProps)
 
@@ -25,6 +24,6 @@ export const RatingGroupRootProvider = forwardRef<HTMLDivElement, RatingGroupRoo
       <ark.div {...mergedProps} ref={ref} />
     </RatingGroupProvider>
   )
-})
+}
 
 RatingGroupRootProvider.displayName = 'RatingGroupRootProvider'

--- a/packages/react/src/components/rating-group/rating-group-root.tsx
+++ b/packages/react/src/components/rating-group/rating-group-root.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import type { Assign } from '../../types'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -13,7 +12,7 @@ export interface RatingGroupRootProps extends Assign<HTMLProps<'div'>, RatingGro
 
 const splitRootProps = createSplitProps<UseRatingGroupProps>()
 
-export const RatingGroupRoot = forwardRef<HTMLDivElement, RatingGroupRootProps>((props, ref) => {
+export const RatingGroupRoot = ({ ref, ...props }: RatingGroupRootProps) => {
   const [useRatingProps, localProps] = splitRootProps(props, [
     'allowHalf',
     'autoFocus',
@@ -40,6 +39,6 @@ export const RatingGroupRoot = forwardRef<HTMLDivElement, RatingGroupRootProps>(
       <ark.div {...mergedProps} ref={ref} />
     </RatingGroupProvider>
   )
-})
+}
 
 RatingGroupRoot.displayName = 'RatingGroupRoot'

--- a/packages/react/src/components/scroll-area/scroll-area-content.tsx
+++ b/packages/react/src/components/scroll-area/scroll-area-content.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useScrollAreaContext } from './use-scroll-area-context'
 
 export interface ScrollAreaContentBaseProps extends PolymorphicProps {}
 export interface ScrollAreaContentProps extends HTMLProps<'div'>, ScrollAreaContentBaseProps {}
 
-export const ScrollAreaContent = forwardRef<HTMLDivElement, ScrollAreaContentProps>((props, ref) => {
+export const ScrollAreaContent = ({ ref, ...props }: ScrollAreaContentProps) => {
   const scrollArea = useScrollAreaContext()
   const mergedProps = mergeProps(scrollArea.getContentProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 ScrollAreaContent.displayName = 'ScrollAreaContent'

--- a/packages/react/src/components/scroll-area/scroll-area-corner.tsx
+++ b/packages/react/src/components/scroll-area/scroll-area-corner.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useScrollAreaContext } from './use-scroll-area-context'
 
 export interface ScrollAreaCornerBaseProps extends PolymorphicProps {}
 export interface ScrollAreaCornerProps extends HTMLProps<'div'>, ScrollAreaCornerBaseProps {}
 
-export const ScrollAreaCorner = forwardRef<HTMLDivElement, ScrollAreaCornerProps>((props, ref) => {
+export const ScrollAreaCorner = ({ ref, ...props }: ScrollAreaCornerProps) => {
   const scrollArea = useScrollAreaContext()
   const mergedProps = mergeProps(scrollArea.getCornerProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 ScrollAreaCorner.displayName = 'ScrollAreaCorner'

--- a/packages/react/src/components/scroll-area/scroll-area-root-provider.tsx
+++ b/packages/react/src/components/scroll-area/scroll-area-root-provider.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import type { UseScrollAreaReturn } from './use-scroll-area'
@@ -16,7 +15,7 @@ export interface ScrollAreaRootProviderProps extends HTMLProps<'div'>, ScrollAre
 
 const splitRootProviderProps = createSplitProps<RootProviderProps>()
 
-export const ScrollAreaRootProvider = forwardRef<HTMLDivElement, ScrollAreaRootProviderProps>((props, ref) => {
+export const ScrollAreaRootProvider = ({ ref, ...props }: ScrollAreaRootProviderProps) => {
   const [{ value: scrollArea }, localProps] = splitRootProviderProps(props, ['value'])
   const mergedProps = mergeProps(scrollArea.getRootProps(), localProps)
 
@@ -25,6 +24,6 @@ export const ScrollAreaRootProvider = forwardRef<HTMLDivElement, ScrollAreaRootP
       <ark.div {...mergedProps} ref={ref} />
     </ScrollAreaProvider>
   )
-})
+}
 
 ScrollAreaRootProvider.displayName = 'ScrollAreaRootProvider'

--- a/packages/react/src/components/scroll-area/scroll-area-root.tsx
+++ b/packages/react/src/components/scroll-area/scroll-area-root.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { type UseScrollAreaProps, useScrollArea } from './use-scroll-area'
@@ -12,7 +11,7 @@ export interface ScrollAreaRootProps extends HTMLProps<'div'>, ScrollAreaRootBas
 
 const splitRootProps = createSplitProps<UseScrollAreaProps>()
 
-export const ScrollAreaRoot = forwardRef<HTMLDivElement, ScrollAreaRootProps>((props, ref) => {
+export const ScrollAreaRoot = ({ ref, ...props }: ScrollAreaRootProps) => {
   const [useScrollAreaProps, localProps] = splitRootProps(props, ['id', 'ids'])
   const scrollArea = useScrollArea(useScrollAreaProps)
   const mergedProps = mergeProps(scrollArea.getRootProps(), localProps)
@@ -22,6 +21,6 @@ export const ScrollAreaRoot = forwardRef<HTMLDivElement, ScrollAreaRootProps>((p
       <ark.div {...mergedProps} ref={ref} />
     </ScrollAreaProvider>
   )
-})
+}
 
 ScrollAreaRoot.displayName = 'ScrollAreaRoot'

--- a/packages/react/src/components/scroll-area/scroll-area-scrollbar.tsx
+++ b/packages/react/src/components/scroll-area/scroll-area-scrollbar.tsx
@@ -2,7 +2,6 @@
 
 import { mergeProps } from '@zag-js/react'
 import type { Orientation } from '@zag-js/types'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useScrollAreaContext } from './use-scroll-area-context'
@@ -17,7 +16,7 @@ export interface ScrollAreaScrollbarProps extends HTMLProps<'div'>, ScrollAreaSc
 
 const splitScrollbarProps = createSplitProps<ScrollbarProps>()
 
-export const ScrollAreaScrollbar = forwardRef<HTMLDivElement, ScrollAreaScrollbarProps>((props, ref) => {
+export const ScrollAreaScrollbar = ({ ref, ...props }: ScrollAreaScrollbarProps) => {
   const [scrollbarProps, localProps] = splitScrollbarProps(props, ['orientation'])
   const scrollAreaApi = useScrollAreaContext()
   const mergedProps = mergeProps(scrollAreaApi.getScrollbarProps(scrollbarProps), localProps)
@@ -27,6 +26,6 @@ export const ScrollAreaScrollbar = forwardRef<HTMLDivElement, ScrollAreaScrollba
       <ark.div {...mergedProps} ref={ref} />
     </ScrollAreaScrollbarProvider>
   )
-})
+}
 
 ScrollAreaScrollbar.displayName = 'ScrollAreaScrollbar'

--- a/packages/react/src/components/scroll-area/scroll-area-thumb.tsx
+++ b/packages/react/src/components/scroll-area/scroll-area-thumb.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useScrollAreaContext } from './use-scroll-area-context'
 import { useScrollAreaScrollbarContext } from './use-scroll-area-scrollbar-context'
@@ -9,13 +8,13 @@ import { useScrollAreaScrollbarContext } from './use-scroll-area-scrollbar-conte
 export interface ScrollAreaThumbBaseProps extends PolymorphicProps {}
 export interface ScrollAreaThumbProps extends HTMLProps<'div'>, ScrollAreaThumbBaseProps {}
 
-export const ScrollAreaThumb = forwardRef<HTMLDivElement, ScrollAreaThumbProps>((props, ref) => {
+export const ScrollAreaThumb = ({ ref, ...props }: ScrollAreaThumbProps) => {
   const scrollAreaApi = useScrollAreaContext()
   const scrollbarProps = useScrollAreaScrollbarContext()
 
   const mergedProps = mergeProps(scrollAreaApi.getThumbProps(scrollbarProps), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 ScrollAreaThumb.displayName = 'ScrollAreaThumb'

--- a/packages/react/src/components/scroll-area/scroll-area-viewport.tsx
+++ b/packages/react/src/components/scroll-area/scroll-area-viewport.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useScrollAreaContext } from './use-scroll-area-context'
 
 export interface ScrollAreaViewportBaseProps extends PolymorphicProps {}
 export interface ScrollAreaViewportProps extends HTMLProps<'div'>, ScrollAreaViewportBaseProps {}
 
-export const ScrollAreaViewport = forwardRef<HTMLDivElement, ScrollAreaViewportProps>((props, ref) => {
+export const ScrollAreaViewport = ({ ref, ...props }: ScrollAreaViewportProps) => {
   const scrollArea = useScrollAreaContext()
   const mergedProps = mergeProps(scrollArea.getViewportProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 ScrollAreaViewport.displayName = 'ScrollAreaViewport'

--- a/packages/react/src/components/segment-group/segment-group-indicator.tsx
+++ b/packages/react/src/components/segment-group/segment-group-indicator.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { parts } from './segment-group.anatomy'
 import { useSegmentGroupContext } from './use-segment-group-context'
@@ -9,7 +8,7 @@ import { useSegmentGroupContext } from './use-segment-group-context'
 export interface SegmentGroupIndicatorBaseProps extends PolymorphicProps {}
 export interface SegmentGroupIndicatorProps extends HTMLProps<'div'>, SegmentGroupIndicatorBaseProps {}
 
-export const SegmentGroupIndicator = forwardRef<HTMLDivElement, SegmentGroupIndicatorProps>((props, ref) => {
+export const SegmentGroupIndicator = ({ ref, ...props }: SegmentGroupIndicatorProps) => {
   const segmentGroup = useSegmentGroupContext()
   const mergedProps = mergeProps(
     segmentGroup.getIndicatorProps(),
@@ -17,6 +16,6 @@ export const SegmentGroupIndicator = forwardRef<HTMLDivElement, SegmentGroupIndi
     props,
   )
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 SegmentGroupIndicator.displayName = 'SegmentGroupIndicator'

--- a/packages/react/src/components/segment-group/segment-group-item-control.tsx
+++ b/packages/react/src/components/segment-group/segment-group-item-control.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { parts } from './segment-group.anatomy'
 import { useSegmentGroupContext } from './use-segment-group-context'
@@ -10,7 +9,7 @@ import { useSegmentGroupItemPropsContext } from './use-segment-group-item-props-
 export interface SegmentGroupItemControlBaseProps extends PolymorphicProps {}
 export interface SegmentGroupItemControlProps extends HTMLProps<'div'>, SegmentGroupItemControlBaseProps {}
 
-export const SegmentGroupItemControl = forwardRef<HTMLDivElement, SegmentGroupItemControlProps>((props, ref) => {
+export const SegmentGroupItemControl = ({ ref, ...props }: SegmentGroupItemControlProps) => {
   const segmentGroup = useSegmentGroupContext()
   const itemProps = useSegmentGroupItemPropsContext()
   const mergedProps = mergeProps(
@@ -20,6 +19,6 @@ export const SegmentGroupItemControl = forwardRef<HTMLDivElement, SegmentGroupIt
   )
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 SegmentGroupItemControl.displayName = 'SegmentGroupItemControl'

--- a/packages/react/src/components/segment-group/segment-group-item-hidden-input.tsx
+++ b/packages/react/src/components/segment-group/segment-group-item-hidden-input.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useSegmentGroupContext } from './use-segment-group-context'
 import { useSegmentGroupItemPropsContext } from './use-segment-group-item-props-context'
@@ -9,14 +8,12 @@ import { useSegmentGroupItemPropsContext } from './use-segment-group-item-props-
 export interface SegmentGroupItemHiddenInputBaseProps extends PolymorphicProps {}
 export interface SegmentGroupItemHiddenInputProps extends HTMLProps<'input'>, SegmentGroupItemHiddenInputBaseProps {}
 
-export const SegmentGroupItemHiddenInput = forwardRef<HTMLInputElement, SegmentGroupItemHiddenInputProps>(
-  (props, ref) => {
-    const segmentGroup = useSegmentGroupContext()
-    const itemProps = useSegmentGroupItemPropsContext()
-    const mergedProps = mergeProps(segmentGroup.getItemHiddenInputProps(itemProps), props)
+export const SegmentGroupItemHiddenInput = ({ ref, ...props }: SegmentGroupItemHiddenInputProps) => {
+  const segmentGroup = useSegmentGroupContext()
+  const itemProps = useSegmentGroupItemPropsContext()
+  const mergedProps = mergeProps(segmentGroup.getItemHiddenInputProps(itemProps), props)
 
-    return <ark.input {...mergedProps} ref={ref} />
-  },
-)
+  return <ark.input {...mergedProps} ref={ref} />
+}
 
 SegmentGroupItemHiddenInput.displayName = 'SegmentGroupItemHiddenInput'

--- a/packages/react/src/components/segment-group/segment-group-item-text.tsx
+++ b/packages/react/src/components/segment-group/segment-group-item-text.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { parts } from './segment-group.anatomy'
 import { useSegmentGroupContext } from './use-segment-group-context'
@@ -10,7 +9,7 @@ import { useSegmentGroupItemPropsContext } from './use-segment-group-item-props-
 export interface SegmentGroupItemTextBaseProps extends PolymorphicProps {}
 export interface SegmentGroupItemTextProps extends HTMLProps<'span'>, SegmentGroupItemTextBaseProps {}
 
-export const SegmentGroupItemText = forwardRef<HTMLSpanElement, SegmentGroupItemTextProps>((props, ref) => {
+export const SegmentGroupItemText = ({ ref, ...props }: SegmentGroupItemTextProps) => {
   const segmentGroup = useSegmentGroupContext()
   const itemProps = useSegmentGroupItemPropsContext()
   const mergedProps = mergeProps(
@@ -20,6 +19,6 @@ export const SegmentGroupItemText = forwardRef<HTMLSpanElement, SegmentGroupItem
   )
 
   return <ark.span {...mergedProps} ref={ref} />
-})
+}
 
 SegmentGroupItemText.displayName = 'SegmentGroupItemText'

--- a/packages/react/src/components/segment-group/segment-group-item.tsx
+++ b/packages/react/src/components/segment-group/segment-group-item.tsx
@@ -2,7 +2,6 @@
 
 import type { ItemProps } from '@zag-js/radio-group'
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { parts } from './segment-group.anatomy'
@@ -15,7 +14,7 @@ export interface SegmentGroupItemProps extends HTMLProps<'label'>, SegmentGroupI
 
 const splitItemProps = createSplitProps<ItemProps>()
 
-export const SegmentGroupItem = forwardRef<HTMLLabelElement, SegmentGroupItemProps>((props, ref) => {
+export const SegmentGroupItem = ({ ref, ...props }: SegmentGroupItemProps) => {
   const [itemProps, localProps] = splitItemProps(props, ['value', 'disabled', 'invalid'])
   const segmentGroup = useSegmentGroupContext()
   const mergedProps = mergeProps(
@@ -32,6 +31,6 @@ export const SegmentGroupItem = forwardRef<HTMLLabelElement, SegmentGroupItemPro
       </SegmentGroupItemProvider>
     </SegmentGroupItemPropsProvider>
   )
-})
+}
 
 SegmentGroupItem.displayName = 'SegmentGroupItem'

--- a/packages/react/src/components/segment-group/segment-group-label.tsx
+++ b/packages/react/src/components/segment-group/segment-group-label.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { parts } from './segment-group.anatomy'
 import { useSegmentGroupContext } from './use-segment-group-context'
@@ -9,11 +8,11 @@ import { useSegmentGroupContext } from './use-segment-group-context'
 export interface SegmentGroupLabelBaseProps extends PolymorphicProps {}
 export interface SegmentGroupLabelProps extends HTMLProps<'span'>, SegmentGroupLabelBaseProps {}
 
-export const SegmentGroupLabel = forwardRef<HTMLSpanElement, SegmentGroupLabelProps>((props, ref) => {
+export const SegmentGroupLabel = ({ ref, ...props }: SegmentGroupLabelProps) => {
   const segmentGroup = useSegmentGroupContext()
   const mergedProps = mergeProps(segmentGroup.getLabelProps(), parts.label.attrs as Record<string, string>, props)
 
   return <ark.span {...mergedProps} ref={ref} />
-})
+}
 
 SegmentGroupLabel.displayName = 'SegmentGroupLabel'

--- a/packages/react/src/components/segment-group/segment-group-root-provider.tsx
+++ b/packages/react/src/components/segment-group/segment-group-root-provider.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { parts } from './segment-group.anatomy'
@@ -17,7 +16,7 @@ export interface SegmentGroupRootProviderProps extends HTMLProps<'div'>, Segment
 
 const splitRootProviderProps = createSplitProps<RootProviderProps>()
 
-export const SegmentGroupRootProvider = forwardRef<HTMLDivElement, SegmentGroupRootProviderProps>((props, ref) => {
+export const SegmentGroupRootProvider = ({ ref, ...props }: SegmentGroupRootProviderProps) => {
   const [{ value: segmentGroup }, localProps] = splitRootProviderProps(props, ['value'])
   const mergedProps = mergeProps(segmentGroup.getRootProps(), parts.root.attrs as Record<string, string>, localProps)
 
@@ -26,6 +25,6 @@ export const SegmentGroupRootProvider = forwardRef<HTMLDivElement, SegmentGroupR
       <ark.div {...mergedProps} ref={ref} />
     </SegmentGroupProvider>
   )
-})
+}
 
 SegmentGroupRootProvider.displayName = 'SegmentGroupRootProvider'

--- a/packages/react/src/components/segment-group/segment-group-root.tsx
+++ b/packages/react/src/components/segment-group/segment-group-root.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import type { Assign } from '../../types'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -14,7 +13,7 @@ export interface SegmentGroupRootProps extends Assign<HTMLProps<'div'>, SegmentG
 
 const splitRootProps = createSplitProps<UseSegmentGroupProps>()
 
-export const SegmentGroupRoot = forwardRef<HTMLDivElement, SegmentGroupRootProps>((props, ref) => {
+export const SegmentGroupRoot = ({ ref, ...props }: SegmentGroupRootProps) => {
   const [useSegmentGroupProps, localProps] = splitRootProps(props, [
     'defaultValue',
     'disabled',
@@ -37,6 +36,6 @@ export const SegmentGroupRoot = forwardRef<HTMLDivElement, SegmentGroupRootProps
       <ark.div {...mergedProps} ref={ref} />
     </SegmentGroupProvider>
   )
-})
+}
 
 SegmentGroupRoot.displayName = 'SegmentGroupRoot'

--- a/packages/react/src/components/select/index.ts
+++ b/packages/react/src/components/select/index.ts
@@ -44,18 +44,11 @@ export { SelectItemText, type SelectItemTextBaseProps, type SelectItemTextProps 
 export { SelectLabel, type SelectLabelBaseProps, type SelectLabelProps } from './select-label'
 export { SelectList, type SelectListBaseProps, type SelectListProps } from './select-list'
 export { SelectPositioner, type SelectPositionerBaseProps, type SelectPositionerProps } from './select-positioner'
-export {
-  SelectRoot,
-  type SelectRootBaseProps,
-  type SelectRootProps,
-  type SelectRootComponent,
-  type SelectRootComponentProps,
-} from './select-root'
+export { SelectRoot, type SelectRootBaseProps, type SelectRootProps } from './select-root'
 export {
   SelectRootProvider,
   type SelectRootProviderBaseProps,
   type SelectRootProviderProps,
-  type SelectRootProviderComponent,
 } from './select-root-provider'
 export { SelectTrigger, type SelectTriggerBaseProps, type SelectTriggerProps } from './select-trigger'
 export { SelectValueText, type SelectValueTextBaseProps, type SelectValueTextProps } from './select-value-text'

--- a/packages/react/src/components/select/select-clear-trigger.tsx
+++ b/packages/react/src/components/select/select-clear-trigger.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useSelectContext } from './use-select-context'
 
 export interface SelectClearTriggerBaseProps extends PolymorphicProps {}
 export interface SelectClearTriggerProps extends HTMLProps<'button'>, SelectClearTriggerBaseProps {}
 
-export const SelectClearTrigger = forwardRef<HTMLButtonElement, SelectClearTriggerProps>((props, ref) => {
+export const SelectClearTrigger = ({ ref, ...props }: SelectClearTriggerProps) => {
   const select = useSelectContext()
   const mergedProps = mergeProps(select.getClearTriggerProps(), props)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 SelectClearTrigger.displayName = 'SelectClearTrigger'

--- a/packages/react/src/components/select/select-content.tsx
+++ b/packages/react/src/components/select/select-content.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { composeRefs } from '../../utils/compose-refs'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { usePresenceContext } from '../presence'
@@ -10,7 +9,7 @@ import { useSelectContext } from './use-select-context'
 export interface SelectContentBaseProps extends PolymorphicProps {}
 export interface SelectContentProps extends HTMLProps<'div'>, SelectContentBaseProps {}
 
-export const SelectContent = forwardRef<HTMLDivElement, SelectContentProps>((props, ref) => {
+export const SelectContent = ({ ref, ...props }: SelectContentProps) => {
   const select = useSelectContext()
   const presence = usePresenceContext()
   const mergedProps = mergeProps(select.getContentProps(), presence.getPresenceProps(), props)
@@ -20,6 +19,6 @@ export const SelectContent = forwardRef<HTMLDivElement, SelectContentProps>((pro
   }
 
   return <ark.div {...mergedProps} ref={composeRefs(presence.ref, ref)} />
-})
+}
 
 SelectContent.displayName = 'SelectContent'

--- a/packages/react/src/components/select/select-control.tsx
+++ b/packages/react/src/components/select/select-control.tsx
@@ -1,17 +1,16 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useSelectContext } from './use-select-context'
 
 export interface SelectControlBaseProps extends PolymorphicProps {}
 export interface SelectControlProps extends HTMLProps<'div'>, SelectControlBaseProps {}
 
-export const SelectControl = forwardRef<HTMLDivElement, SelectControlProps>((props, ref) => {
+export const SelectControl = ({ ref, ...props }: SelectControlProps) => {
   const select = useSelectContext()
   const mergedProps = mergeProps(select.getControlProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 SelectControl.displayName = 'SelectControl'

--- a/packages/react/src/components/select/select-hidden-select.tsx
+++ b/packages/react/src/components/select/select-hidden-select.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useFieldContext } from '../field'
 import { useSelectContext } from './use-select-context'
@@ -9,7 +8,7 @@ import { useSelectContext } from './use-select-context'
 export interface SelectHiddenSelectBaseProps extends PolymorphicProps {}
 export interface SelectHiddenSelectProps extends HTMLProps<'select'>, SelectHiddenSelectBaseProps {}
 
-export const SelectHiddenSelect = forwardRef<HTMLSelectElement, SelectHiddenSelectProps>((props, ref) => {
+export const SelectHiddenSelect = ({ ref, ...props }: SelectHiddenSelectProps) => {
   const select = useSelectContext()
   const mergedProps = mergeProps(select.getHiddenSelectProps(), props)
   const isValueEmpty = select.value.length === 0
@@ -29,5 +28,5 @@ export const SelectHiddenSelect = forwardRef<HTMLSelectElement, SelectHiddenSele
       ))}
     </ark.select>
   )
-})
+}
 SelectHiddenSelect.displayName = 'SelectHiddenSelect'

--- a/packages/react/src/components/select/select-indicator.tsx
+++ b/packages/react/src/components/select/select-indicator.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useSelectContext } from './use-select-context'
 
 export interface SelectIndicatorBaseProps extends PolymorphicProps {}
 export interface SelectIndicatorProps extends HTMLProps<'div'>, SelectIndicatorBaseProps {}
 
-export const SelectIndicator = forwardRef<HTMLDivElement, SelectIndicatorProps>((props, ref) => {
+export const SelectIndicator = ({ ref, ...props }: SelectIndicatorProps) => {
   const select = useSelectContext()
   const mergedProps = mergeProps(select.getIndicatorProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 SelectIndicator.displayName = 'SelectIndicator'

--- a/packages/react/src/components/select/select-item-group-label.tsx
+++ b/packages/react/src/components/select/select-item-group-label.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useSelectContext } from './use-select-context'
 import { useSelectItemGroupPropsContext } from './use-select-item-group-props'
@@ -9,12 +8,12 @@ import { useSelectItemGroupPropsContext } from './use-select-item-group-props'
 export interface SelectItemGroupLabelBaseProps extends PolymorphicProps {}
 export interface SelectItemGroupLabelProps extends HTMLProps<'div'>, SelectItemGroupLabelBaseProps {}
 
-export const SelectItemGroupLabel = forwardRef<HTMLDivElement, SelectItemGroupLabelProps>((props, ref) => {
+export const SelectItemGroupLabel = ({ ref, ...props }: SelectItemGroupLabelProps) => {
   const select = useSelectContext()
   const itemGroupProps = useSelectItemGroupPropsContext()
   const mergedProps = mergeProps(select.getItemGroupLabelProps({ htmlFor: itemGroupProps.id }), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 SelectItemGroupLabel.displayName = 'SelectItemGroupLabel'

--- a/packages/react/src/components/select/select-item-group.tsx
+++ b/packages/react/src/components/select/select-item-group.tsx
@@ -2,7 +2,7 @@
 
 import { mergeProps } from '@zag-js/react'
 import type { ItemGroupProps } from '@zag-js/select'
-import { forwardRef, useId } from 'react'
+import { useId } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useSelectContext } from './use-select-context'
@@ -13,7 +13,7 @@ export interface SelectItemGroupProps extends HTMLProps<'div'>, SelectItemGroupB
 
 const splitItemGroupProps = createSplitProps<Partial<ItemGroupProps>>()
 
-export const SelectItemGroup = forwardRef<HTMLDivElement, SelectItemGroupProps>((props, ref) => {
+export const SelectItemGroup = ({ ref, ...props }: SelectItemGroupProps) => {
   const id = useId()
   const [_itemGroupProps, localProps] = splitItemGroupProps(props, ['id'])
   const itemGroupProps = { id, ..._itemGroupProps }
@@ -26,6 +26,6 @@ export const SelectItemGroup = forwardRef<HTMLDivElement, SelectItemGroupProps>(
       <ark.div {...mergedProps} ref={ref} />
     </SelectItemGroupPropsProvider>
   )
-})
+}
 
 SelectItemGroup.displayName = 'SelectItemGroup'

--- a/packages/react/src/components/select/select-item-indicator.tsx
+++ b/packages/react/src/components/select/select-item-indicator.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useSelectContext } from './use-select-context'
 import { useSelectItemPropsContext } from './use-select-item-props-context'
@@ -9,12 +8,12 @@ import { useSelectItemPropsContext } from './use-select-item-props-context'
 export interface SelectItemIndicatorBaseProps extends PolymorphicProps {}
 export interface SelectItemIndicatorProps extends HTMLProps<'div'>, SelectItemIndicatorBaseProps {}
 
-export const SelectItemIndicator = forwardRef<HTMLDivElement, SelectItemIndicatorProps>((props, ref) => {
+export const SelectItemIndicator = ({ ref, ...props }: SelectItemIndicatorProps) => {
   const select = useSelectContext()
   const itemProps = useSelectItemPropsContext()
   const mergedProps = mergeProps(select.getItemIndicatorProps(itemProps), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 SelectItemIndicator.displayName = 'SelectItemIndicator'

--- a/packages/react/src/components/select/select-item-text.tsx
+++ b/packages/react/src/components/select/select-item-text.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useSelectContext } from './use-select-context'
 import { useSelectItemPropsContext } from './use-select-item-props-context'
@@ -9,12 +8,12 @@ import { useSelectItemPropsContext } from './use-select-item-props-context'
 export interface SelectItemTextBaseProps extends PolymorphicProps {}
 export interface SelectItemTextProps extends HTMLProps<'span'>, SelectItemTextBaseProps {}
 
-export const SelectItemText = forwardRef<HTMLDivElement, SelectItemTextProps>((props, ref) => {
+export const SelectItemText = ({ ref, ...props }: SelectItemTextProps) => {
   const select = useSelectContext()
   const itemProps = useSelectItemPropsContext()
   const mergedProps = mergeProps(select.getItemTextProps(itemProps), props)
 
   return <ark.span {...mergedProps} ref={ref} />
-})
+}
 
 SelectItemText.displayName = 'SelectItemText'

--- a/packages/react/src/components/select/select-item.tsx
+++ b/packages/react/src/components/select/select-item.tsx
@@ -2,7 +2,6 @@
 
 import { mergeProps } from '@zag-js/react'
 import type { ItemProps } from '@zag-js/select'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useSelectContext } from './use-select-context'
@@ -14,7 +13,7 @@ export interface SelectItemProps extends HTMLProps<'div'>, SelectItemBaseProps {
 
 const splitItemProps = createSplitProps<ItemProps>()
 
-export const SelectItem = forwardRef<HTMLDivElement, SelectItemProps>((props, ref) => {
+export const SelectItem = ({ ref, ...props }: SelectItemProps) => {
   const [itemProps, localProps] = splitItemProps(props, ['item', 'persistFocus'])
   const select = useSelectContext()
   const mergedProps = mergeProps(select.getItemProps(itemProps), localProps)
@@ -27,6 +26,6 @@ export const SelectItem = forwardRef<HTMLDivElement, SelectItemProps>((props, re
       </SelectItemProvider>
     </SelectItemPropsProvider>
   )
-})
+}
 
 SelectItem.displayName = 'SelectItem'

--- a/packages/react/src/components/select/select-label.tsx
+++ b/packages/react/src/components/select/select-label.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useSelectContext } from './use-select-context'
 
 export interface SelectLabelBaseProps extends PolymorphicProps {}
 export interface SelectLabelProps extends HTMLProps<'label'>, SelectLabelBaseProps {}
 
-export const SelectLabel = forwardRef<HTMLLabelElement, SelectLabelProps>((props, ref) => {
+export const SelectLabel = ({ ref, ...props }: SelectLabelProps) => {
   const select = useSelectContext()
   const mergedProps = mergeProps(select.getLabelProps(), props)
 
   return <ark.label {...mergedProps} ref={ref} />
-})
+}
 
 SelectLabel.displayName = 'SelectLabel'

--- a/packages/react/src/components/select/select-list.tsx
+++ b/packages/react/src/components/select/select-list.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useSelectContext } from './use-select-context'
 
 export interface SelectListBaseProps extends PolymorphicProps {}
 export interface SelectListProps extends HTMLProps<'div'>, SelectListBaseProps {}
 
-export const SelectList = forwardRef<HTMLDivElement, SelectListProps>((props, ref) => {
+export const SelectList = ({ ref, ...props }: SelectListProps) => {
   const select = useSelectContext()
   const mergedProps = mergeProps(select.getListProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 SelectList.displayName = 'SelectList'

--- a/packages/react/src/components/select/select-positioner.tsx
+++ b/packages/react/src/components/select/select-positioner.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { usePresenceContext } from '../presence'
 import { useSelectContext } from './use-select-context'
@@ -9,7 +8,7 @@ import { useSelectContext } from './use-select-context'
 export interface SelectPositionerBaseProps extends PolymorphicProps {}
 export interface SelectPositionerProps extends HTMLProps<'div'>, SelectPositionerBaseProps {}
 
-export const SelectPositioner = forwardRef<HTMLDivElement, SelectPositionerProps>((props, ref) => {
+export const SelectPositioner = ({ ref, ...props }: SelectPositionerProps) => {
   const select = useSelectContext()
   const mergedProps = mergeProps(select.getPositionerProps(), props)
   const presence = usePresenceContext()
@@ -19,6 +18,6 @@ export const SelectPositioner = forwardRef<HTMLDivElement, SelectPositionerProps
   }
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 SelectPositioner.displayName = 'SelectPositioner'

--- a/packages/react/src/components/select/select-root-provider.tsx
+++ b/packages/react/src/components/select/select-root-provider.tsx
@@ -1,8 +1,7 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { type JSX, forwardRef } from 'react'
-import type { Assign } from '../../types'
+import type { JSX } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import type { CollectionItem } from '../collection'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -13,12 +12,17 @@ import { SelectProvider } from './use-select-context'
 interface RootProviderProps<T extends CollectionItem> {
   value: UseSelectReturn<T>
 }
+
 export interface SelectRootProviderBaseProps<T extends CollectionItem>
   extends RootProviderProps<T>, UsePresenceProps, PolymorphicProps {}
+
 export interface SelectRootProviderProps<T extends CollectionItem>
   extends HTMLProps<'div'>, SelectRootProviderBaseProps<T> {}
 
-const SelectImpl = <T extends CollectionItem>(props: SelectRootProviderProps<T>, ref: React.Ref<HTMLDivElement>) => {
+export const SelectRootProvider = <T extends CollectionItem>({
+  ref,
+  ...props
+}: SelectRootProviderProps<T>): JSX.Element => {
   const [presenceProps, selectProps] = splitPresenceProps(props)
   const [{ value: select }, localProps] = createSplitProps<RootProviderProps<T>>()(selectProps, ['value'])
   const presence = usePresence(mergeProps({ present: select.open }, presenceProps))
@@ -32,9 +36,3 @@ const SelectImpl = <T extends CollectionItem>(props: SelectRootProviderProps<T>,
     </SelectProvider>
   )
 }
-
-export type SelectRootProviderComponent<P = {}> = <T extends CollectionItem>(
-  props: Assign<SelectRootProviderProps<T>, P> & React.RefAttributes<HTMLDivElement>,
-) => JSX.Element
-
-export const SelectRootProvider = forwardRef(SelectImpl) as SelectRootProviderComponent

--- a/packages/react/src/components/select/select-root.tsx
+++ b/packages/react/src/components/select/select-root.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { type JSX, forwardRef } from 'react'
+import type { JSX } from 'react'
 import type { Assign } from '../../types'
 import { createSplitProps } from '../../utils/create-split-props'
 import type { CollectionItem } from '../collection'
@@ -14,7 +14,7 @@ export interface SelectRootBaseProps<T extends CollectionItem>
   extends UseSelectProps<T>, UsePresenceProps, PolymorphicProps {}
 export interface SelectRootProps<T extends CollectionItem> extends Assign<HTMLProps<'div'>, SelectRootBaseProps<T>> {}
 
-const SelectImpl = <T extends CollectionItem>(props: SelectRootProps<T>, ref: React.Ref<HTMLDivElement>) => {
+export const SelectRoot = <T extends CollectionItem>({ ref, ...props }: SelectRootProps<T>): JSX.Element => {
   const [presenceProps, selectProps] = splitPresenceProps(props)
   const [useSelectProps, localProps] = createSplitProps<UseSelectProps<T>>()(selectProps, [
     'closeOnSelect',
@@ -61,15 +61,3 @@ const SelectImpl = <T extends CollectionItem>(props: SelectRootProps<T>, ref: Re
     </SelectProvider>
   )
 }
-
-export type SelectRootComponentProps<T extends CollectionItem = CollectionItem, P = {}> = Assign<
-  SelectRootProps<T>,
-  P
-> &
-  React.RefAttributes<HTMLDivElement>
-
-export type SelectRootComponent<P = {}> = <T extends CollectionItem>(
-  props: SelectRootComponentProps<T, P>,
-) => JSX.Element
-
-export const SelectRoot = forwardRef(SelectImpl) as SelectRootComponent

--- a/packages/react/src/components/select/select-trigger.tsx
+++ b/packages/react/src/components/select/select-trigger.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useSelectContext } from './use-select-context'
 
 export interface SelectTriggerBaseProps extends PolymorphicProps {}
 export interface SelectTriggerProps extends HTMLProps<'button'>, SelectTriggerBaseProps {}
 
-export const SelectTrigger = forwardRef<HTMLButtonElement, SelectTriggerProps>((props, ref) => {
+export const SelectTrigger = ({ ref, ...props }: SelectTriggerProps) => {
   const select = useSelectContext()
   const mergedProps = mergeProps(select.getTriggerProps(), props)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 SelectTrigger.displayName = 'SelectTrigger'

--- a/packages/react/src/components/select/select-value-text.tsx
+++ b/packages/react/src/components/select/select-value-text.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useSelectContext } from './use-select-context'
 
@@ -13,7 +12,7 @@ export interface SelectValueTextBaseProps extends PolymorphicProps {
 }
 export interface SelectValueTextProps extends HTMLProps<'span'>, SelectValueTextBaseProps {}
 
-export const SelectValueText = forwardRef<HTMLSpanElement, SelectValueTextProps>((props, ref) => {
+export const SelectValueText = ({ ref, ...props }: SelectValueTextProps) => {
   const { children, placeholder, ...localprops } = props
   const select = useSelectContext()
   const mergedProps = mergeProps(select.getValueTextProps(), localprops)
@@ -23,6 +22,6 @@ export const SelectValueText = forwardRef<HTMLSpanElement, SelectValueTextProps>
       {children || select.valueAsString || placeholder}
     </ark.span>
   )
-})
+}
 
 SelectValueText.displayName = 'SelectValueText'

--- a/packages/react/src/components/select/select.ts
+++ b/packages/react/src/components/select/select.ts
@@ -81,14 +81,11 @@ export {
   SelectRoot as Root,
   type SelectRootBaseProps as RootBaseProps,
   type SelectRootProps as RootProps,
-  type SelectRootComponent as RootComponent,
-  type SelectRootComponentProps as RootComponentProps,
 } from './select-root'
 export {
   SelectRootProvider as RootProvider,
   type SelectRootProviderBaseProps as RootProviderBaseProps,
   type SelectRootProviderProps as RootProviderProps,
-  type SelectRootProviderComponent as RootProviderComponent,
 } from './select-root-provider'
 export {
   SelectTrigger as Trigger,

--- a/packages/react/src/components/signature-pad/signature-pad-clear-trigger.tsx
+++ b/packages/react/src/components/signature-pad/signature-pad-clear-trigger.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useSignaturePadContext } from './use-signature-pad-context'
 
 export interface SignaturePadClearTriggerBaseProps extends PolymorphicProps {}
 export interface SignaturePadClearTriggerProps extends HTMLProps<'button'>, SignaturePadClearTriggerBaseProps {}
 
-export const SignaturePadClearTrigger = forwardRef<HTMLButtonElement, SignaturePadClearTriggerProps>((props, ref) => {
+export const SignaturePadClearTrigger = ({ ref, ...props }: SignaturePadClearTriggerProps) => {
   const signaturePad = useSignaturePadContext()
   const mergedProps = mergeProps(signaturePad.getClearTriggerProps(), props)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 SignaturePadClearTrigger.displayName = 'SignaturePadClearTrigger'

--- a/packages/react/src/components/signature-pad/signature-pad-control.tsx
+++ b/packages/react/src/components/signature-pad/signature-pad-control.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useSignaturePadContext } from './use-signature-pad-context'
 
 export interface SignaturePadControlBaseProps extends PolymorphicProps {}
 export interface SignaturePadControlProps extends HTMLProps<'div'>, SignaturePadControlBaseProps {}
 
-export const SignaturePadControl = forwardRef<HTMLDivElement, SignaturePadControlProps>((props, ref) => {
+export const SignaturePadControl = ({ ref, ...props }: SignaturePadControlProps) => {
   const signaturePad = useSignaturePadContext()
   const mergedProps = mergeProps(signaturePad.getControlProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 SignaturePadControl.displayName = 'SignaturePadControl'

--- a/packages/react/src/components/signature-pad/signature-pad-guide.tsx
+++ b/packages/react/src/components/signature-pad/signature-pad-guide.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useSignaturePadContext } from './use-signature-pad-context'
 
 export interface SignaturePadGuideBaseProps extends PolymorphicProps {}
 export interface SignaturePadGuideProps extends HTMLProps<'div'>, SignaturePadGuideBaseProps {}
 
-export const SignaturePadGuide = forwardRef<HTMLDivElement, SignaturePadGuideProps>((props, ref) => {
+export const SignaturePadGuide = ({ ref, ...props }: SignaturePadGuideProps) => {
   const signaturePad = useSignaturePadContext()
   const mergedProps = mergeProps(signaturePad.getGuideProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 SignaturePadGuide.displayName = 'SignaturePadGuide'

--- a/packages/react/src/components/signature-pad/signature-pad-hidden-input.tsx
+++ b/packages/react/src/components/signature-pad/signature-pad-hidden-input.tsx
@@ -2,7 +2,6 @@
 
 import { mergeProps } from '@zag-js/react'
 import type { HiddenInputProps } from '@zag-js/signature-pad'
-import { forwardRef } from 'react'
 import type { Assign } from '../../types'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -14,13 +13,13 @@ export interface SignaturePadHiddenInputProps extends Assign<HTMLProps<'input'>,
 
 const splitHiddenInputProps = createSplitProps<HiddenInputProps>()
 
-export const SignaturePadHiddenInput = forwardRef<HTMLInputElement, SignaturePadHiddenInputProps>((props, ref) => {
+export const SignaturePadHiddenInput = ({ ref, ...props }: SignaturePadHiddenInputProps) => {
   const [hiddenInputProps, localProps] = splitHiddenInputProps(props, ['value'])
   const signaturePad = useSignaturePadContext()
   const mergedProps = mergeProps(signaturePad.getHiddenInputProps(hiddenInputProps), localProps)
   const field = useFieldContext()
 
   return <ark.input aria-describedby={field?.ariaDescribedby} {...mergedProps} ref={ref} />
-})
+}
 
 SignaturePadHiddenInput.displayName = 'SignaturePadHiddenInput'

--- a/packages/react/src/components/signature-pad/signature-pad-label.tsx
+++ b/packages/react/src/components/signature-pad/signature-pad-label.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useSignaturePadContext } from './use-signature-pad-context'
 
 export interface SignaturePadLabelBaseProps extends PolymorphicProps {}
 export interface SignaturePadLabelProps extends HTMLProps<'label'>, SignaturePadLabelBaseProps {}
 
-export const SignaturePadLabel = forwardRef<HTMLLabelElement, SignaturePadLabelProps>((props, ref) => {
+export const SignaturePadLabel = ({ ref, ...props }: SignaturePadLabelProps) => {
   const signaturePad = useSignaturePadContext()
   const mergedProps = mergeProps(signaturePad.getLabelProps(), props)
 
   return <ark.label {...mergedProps} ref={ref} />
-})
+}
 
 SignaturePadLabel.displayName = 'SignaturePadLabel'

--- a/packages/react/src/components/signature-pad/signature-pad-root-provider.tsx
+++ b/packages/react/src/components/signature-pad/signature-pad-root-provider.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import type { UseSignaturePadReturn } from './use-signature-pad'
@@ -16,7 +15,7 @@ export interface SignaturePadRootProviderProps extends HTMLProps<'div'>, Signatu
 
 const splitRootProviderProps = createSplitProps<RootProviderProps>()
 
-export const SignaturePadRootProvider = forwardRef<HTMLDivElement, SignaturePadRootProviderProps>((props, ref) => {
+export const SignaturePadRootProvider = ({ ref, ...props }: SignaturePadRootProviderProps) => {
   const [{ value: signaturePad }, localProps] = splitRootProviderProps(props, ['value'])
   const mergedProps = mergeProps(signaturePad.getRootProps(), localProps)
 
@@ -25,6 +24,6 @@ export const SignaturePadRootProvider = forwardRef<HTMLDivElement, SignaturePadR
       <ark.div {...mergedProps} ref={ref} />
     </SignaturePadProvider>
   )
-})
+}
 
 SignaturePadRootProvider.displayName = 'SignaturePadRootProvider'

--- a/packages/react/src/components/signature-pad/signature-pad-root.tsx
+++ b/packages/react/src/components/signature-pad/signature-pad-root.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { type UseSignaturePadProps, useSignaturePad } from './use-signature-pad'
@@ -12,7 +11,7 @@ export interface SignaturePadRootProps extends HTMLProps<'div'>, SignaturePadRoo
 
 const splitRootProps = createSplitProps<UseSignaturePadProps>()
 
-export const SignaturePadRoot = forwardRef<HTMLDivElement, SignaturePadRootProps>((props, ref) => {
+export const SignaturePadRoot = ({ ref, ...props }: SignaturePadRootProps) => {
   const [useSignaturePadProps, localProps] = splitRootProps(props, [
     'id',
     'ids',
@@ -36,6 +35,6 @@ export const SignaturePadRoot = forwardRef<HTMLDivElement, SignaturePadRootProps
       <ark.div {...mergedProps} ref={ref} />
     </SignaturePadProvider>
   )
-})
+}
 
 SignaturePadRoot.displayName = 'SignaturePadRoot'

--- a/packages/react/src/components/signature-pad/signature-pad-segment.tsx
+++ b/packages/react/src/components/signature-pad/signature-pad-segment.tsx
@@ -1,14 +1,13 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useSignaturePadContext } from './use-signature-pad-context'
 
 export interface SignaturePadSegmentBaseProps extends PolymorphicProps {}
 export interface SignaturePadSegmentProps extends HTMLProps<'svg'>, SignaturePadSegmentBaseProps {}
 
-export const SignaturePadSegment = forwardRef<SVGSVGElement, SignaturePadSegmentProps>((props, ref) => {
+export const SignaturePadSegment = ({ ref, ...props }: SignaturePadSegmentProps) => {
   const signaturePad = useSignaturePadContext()
   const mergedProps = mergeProps(signaturePad.getSegmentProps(), props)
 
@@ -21,6 +20,6 @@ export const SignaturePadSegment = forwardRef<SVGSVGElement, SignaturePadSegment
       {signaturePad.currentPath && <path {...signaturePad.getSegmentPathProps({ path: signaturePad.currentPath })} />}
     </ark.svg>
   )
-})
+}
 
 SignaturePadSegment.displayName = 'SignaturePadSegment'

--- a/packages/react/src/components/slider/slider-control.tsx
+++ b/packages/react/src/components/slider/slider-control.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useSliderContext } from './use-slider-context'
 
 export interface SliderControlBaseProps extends PolymorphicProps {}
 export interface SliderControlProps extends HTMLProps<'div'>, SliderControlBaseProps {}
 
-export const SliderControl = forwardRef<HTMLDivElement, SliderControlProps>((props, ref) => {
+export const SliderControl = ({ ref, ...props }: SliderControlProps) => {
   const slider = useSliderContext()
   const mergedProps = mergeProps(slider.getControlProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 SliderControl.displayName = 'SliderControl'

--- a/packages/react/src/components/slider/slider-dragging-indicator.tsx
+++ b/packages/react/src/components/slider/slider-dragging-indicator.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useSliderContext } from './use-slider-context'
 import { useSliderThumbPropsContext } from './use-slider-thumb-props-context'
@@ -9,7 +8,7 @@ import { useSliderThumbPropsContext } from './use-slider-thumb-props-context'
 export interface SliderDraggingIndicatorBaseProps extends PolymorphicProps {}
 export interface SliderDraggingIndicatorProps extends HTMLProps<'span'>, SliderDraggingIndicatorBaseProps {}
 
-export const SliderDraggingIndicator = forwardRef<HTMLSpanElement, SliderDraggingIndicatorProps>((props, ref) => {
+export const SliderDraggingIndicator = ({ ref, ...props }: SliderDraggingIndicatorProps) => {
   const slider = useSliderContext()
   const { index } = useSliderThumbPropsContext()
   const mergedProps = mergeProps(slider.getDraggingIndicatorProps({ index }), props)
@@ -19,6 +18,6 @@ export const SliderDraggingIndicator = forwardRef<HTMLSpanElement, SliderDraggin
       {props.children || slider.getThumbValue(index)}
     </ark.span>
   )
-})
+}
 
 SliderDraggingIndicator.displayName = 'SliderDraggingIndicator'

--- a/packages/react/src/components/slider/slider-hidden-input.tsx
+++ b/packages/react/src/components/slider/slider-hidden-input.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useSliderContext } from './use-slider-context'
 import { useSliderThumbPropsContext } from './use-slider-thumb-props-context'
@@ -9,12 +8,12 @@ import { useSliderThumbPropsContext } from './use-slider-thumb-props-context'
 export interface SliderHiddenInputBaseProps extends PolymorphicProps {}
 export interface SliderHiddenInputProps extends HTMLProps<'input'>, SliderHiddenInputBaseProps {}
 
-export const SliderHiddenInput = forwardRef<HTMLInputElement, SliderHiddenInputProps>((props, ref) => {
+export const SliderHiddenInput = ({ ref, ...props }: SliderHiddenInputProps) => {
   const slider = useSliderContext()
   const thumbProps = useSliderThumbPropsContext()
   const mergedProps = mergeProps(slider.getHiddenInputProps(thumbProps), props)
 
   return <ark.input {...mergedProps} ref={ref} />
-})
+}
 
 SliderHiddenInput.displayName = 'SliderHiddenInput'

--- a/packages/react/src/components/slider/slider-label.tsx
+++ b/packages/react/src/components/slider/slider-label.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useSliderContext } from './use-slider-context'
 
 export interface SliderLabelBaseProps extends PolymorphicProps {}
 export interface SliderLabelProps extends HTMLProps<'label'>, SliderLabelBaseProps {}
 
-export const SliderLabel = forwardRef<HTMLLabelElement, SliderLabelProps>((props, ref) => {
+export const SliderLabel = ({ ref, ...props }: SliderLabelProps) => {
   const slider = useSliderContext()
   const mergedProps = mergeProps(slider.getLabelProps(), props)
 
   return <ark.label {...mergedProps} ref={ref} />
-})
+}
 
 SliderLabel.displayName = 'SliderLabel'

--- a/packages/react/src/components/slider/slider-marker-group.tsx
+++ b/packages/react/src/components/slider/slider-marker-group.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useSliderContext } from './use-slider-context'
 
 export interface SliderMarkerGroupBaseProps extends PolymorphicProps {}
 export interface SliderMarkerGroupProps extends HTMLProps<'div'>, SliderMarkerGroupBaseProps {}
 
-export const SliderMarkerGroup = forwardRef<HTMLDivElement, SliderMarkerGroupProps>((props, ref) => {
+export const SliderMarkerGroup = ({ ref, ...props }: SliderMarkerGroupProps) => {
   const slider = useSliderContext()
   const mergedProps = mergeProps(slider.getMarkerGroupProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 SliderMarkerGroup.displayName = 'SliderMarkerGroup'

--- a/packages/react/src/components/slider/slider-marker.tsx
+++ b/packages/react/src/components/slider/slider-marker.tsx
@@ -2,7 +2,6 @@
 
 import { mergeProps } from '@zag-js/react'
 import type { MarkerProps } from '@zag-js/slider'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useSliderContext } from './use-slider-context'
@@ -12,12 +11,12 @@ export interface SliderMarkerProps extends HTMLProps<'span'>, SliderMarkerBasePr
 
 const splitMarkerProps = createSplitProps<MarkerProps>()
 
-export const SliderMarker = forwardRef<HTMLSpanElement, SliderMarkerProps>((props, ref) => {
+export const SliderMarker = ({ ref, ...props }: SliderMarkerProps) => {
   const [markerProps, localProps] = splitMarkerProps(props, ['value'])
   const slider = useSliderContext()
   const mergedProps = mergeProps(slider.getMarkerProps(markerProps), localProps)
 
   return <ark.span {...mergedProps} ref={ref} />
-})
+}
 
 SliderMarker.displayName = 'SliderMarker'

--- a/packages/react/src/components/slider/slider-range.tsx
+++ b/packages/react/src/components/slider/slider-range.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useSliderContext } from './use-slider-context'
 
 export interface SliderRangeBaseProps extends PolymorphicProps {}
 export interface SliderRangeProps extends HTMLProps<'div'>, SliderRangeBaseProps {}
 
-export const SliderRange = forwardRef<HTMLDivElement, SliderRangeProps>((props, ref) => {
+export const SliderRange = ({ ref, ...props }: SliderRangeProps) => {
   const slider = useSliderContext()
   const mergedProps = mergeProps(slider.getRangeProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 SliderRange.displayName = 'SliderRange'

--- a/packages/react/src/components/slider/slider-root-provider.tsx
+++ b/packages/react/src/components/slider/slider-root-provider.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import type { UseSliderReturn } from './use-slider'
@@ -16,7 +15,7 @@ export interface SliderRootProviderProps extends HTMLProps<'div'>, SliderRootPro
 
 const splitRootProviderProps = createSplitProps<RootProviderProps>()
 
-export const SliderRootProvider = forwardRef<HTMLDivElement, SliderRootProviderProps>((props, ref) => {
+export const SliderRootProvider = ({ ref, ...props }: SliderRootProviderProps) => {
   const [{ value: slider }, localProps] = splitRootProviderProps(props, ['value'])
   const mergedProps = mergeProps(slider.getRootProps(), localProps)
 
@@ -25,6 +24,6 @@ export const SliderRootProvider = forwardRef<HTMLDivElement, SliderRootProviderP
       <ark.div {...mergedProps} ref={ref} />
     </SliderProvider>
   )
-})
+}
 
 SliderRootProvider.displayName = 'SliderRootProvider'

--- a/packages/react/src/components/slider/slider-root.tsx
+++ b/packages/react/src/components/slider/slider-root.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import type { Assign } from '../../types'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -13,7 +12,7 @@ export interface SliderRootProps extends Assign<HTMLProps<'div'>, SliderRootBase
 
 const splitRootProps = createSplitProps<UseSliderProps>()
 
-export const SliderRoot = forwardRef<HTMLDivElement, SliderRootProps>((props, ref) => {
+export const SliderRoot = ({ ref, ...props }: SliderRootProps) => {
   const [useSliderProps, localProps] = splitRootProps(props, [
     'aria-label',
     'aria-labelledby',
@@ -48,6 +47,6 @@ export const SliderRoot = forwardRef<HTMLDivElement, SliderRootProps>((props, re
       <ark.div {...mergedProps} ref={ref} />
     </SliderProvider>
   )
-})
+}
 
 SliderRoot.displayName = 'SliderRoot'

--- a/packages/react/src/components/slider/slider-thumb.tsx
+++ b/packages/react/src/components/slider/slider-thumb.tsx
@@ -2,7 +2,6 @@
 
 import { mergeProps } from '@zag-js/react'
 import type { ThumbProps } from '@zag-js/slider'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useSliderContext } from './use-slider-context'
@@ -13,7 +12,7 @@ export interface SliderThumbProps extends HTMLProps<'div'>, SliderThumbBaseProps
 
 const splitThumbProps = createSplitProps<ThumbProps>()
 
-export const SliderThumb = forwardRef<HTMLDivElement, SliderThumbProps>((props, ref) => {
+export const SliderThumb = ({ ref, ...props }: SliderThumbProps) => {
   const [thumbProps, localProps] = splitThumbProps(props, ['index', 'name'])
   const slider = useSliderContext()
   const mergedProps = mergeProps(slider.getThumbProps(thumbProps), localProps)
@@ -23,6 +22,6 @@ export const SliderThumb = forwardRef<HTMLDivElement, SliderThumbProps>((props, 
       <ark.div {...mergedProps} ref={ref} />
     </SliderThumbPropsProvider>
   )
-})
+}
 
 SliderThumb.displayName = 'SliderThumb'

--- a/packages/react/src/components/slider/slider-track.tsx
+++ b/packages/react/src/components/slider/slider-track.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useSliderContext } from './use-slider-context'
 
 export interface SliderTrackBaseProps extends PolymorphicProps {}
 export interface SliderTrackProps extends HTMLProps<'div'>, SliderTrackBaseProps {}
 
-export const SliderTrack = forwardRef<HTMLDivElement, SliderTrackProps>((props, ref) => {
+export const SliderTrack = ({ ref, ...props }: SliderTrackProps) => {
   const slider = useSliderContext()
   const mergedProps = mergeProps(slider.getTrackProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 SliderTrack.displayName = 'SliderTrack'

--- a/packages/react/src/components/slider/slider-value-text.tsx
+++ b/packages/react/src/components/slider/slider-value-text.tsx
@@ -1,14 +1,13 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useSliderContext } from './use-slider-context'
 
 export interface SliderValueTextBaseProps extends PolymorphicProps {}
 export interface SliderValueTextProps extends HTMLProps<'span'>, SliderValueTextBaseProps {}
 
-export const SliderValueText = forwardRef<HTMLDivElement, SliderValueTextProps>((props, ref) => {
+export const SliderValueText = ({ ref, ...props }: SliderValueTextProps) => {
   const { children, ...rest } = props
   const slider = useSliderContext()
   const mergedProps = mergeProps(slider.getValueTextProps(), rest)
@@ -18,6 +17,6 @@ export const SliderValueText = forwardRef<HTMLDivElement, SliderValueTextProps>(
       {children || slider.value.join(', ')}
     </ark.span>
   )
-})
+}
 
 SliderValueText.displayName = 'SliderValueText'

--- a/packages/react/src/components/splitter/splitter-panel.tsx
+++ b/packages/react/src/components/splitter/splitter-panel.tsx
@@ -2,7 +2,6 @@
 
 import { mergeProps } from '@zag-js/react'
 import type { PanelProps } from '@zag-js/splitter'
-import { forwardRef } from 'react'
 import type { Assign } from '../../types'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -13,12 +12,12 @@ export interface SplitterPanelProps extends Assign<HTMLProps<'div'>, SplitterPan
 
 const splitPanelProps = createSplitProps<PanelProps>()
 
-export const SplitterPanel = forwardRef<HTMLDivElement, SplitterPanelProps>((props, ref) => {
+export const SplitterPanel = ({ ref, ...props }: SplitterPanelProps) => {
   const [splitterPanelProps, localProps] = splitPanelProps(props, ['id'])
   const splitter = useSplitterContext()
   const mergedProps = mergeProps(splitter.getPanelProps(splitterPanelProps), localProps)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 SplitterPanel.displayName = 'SplitterPanel'

--- a/packages/react/src/components/splitter/splitter-resize-trigger-indicator.tsx
+++ b/packages/react/src/components/splitter/splitter-resize-trigger-indicator.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useSplitterContext } from './use-splitter-context'
 import { useSplitterResizeTriggerPropsContext } from './use-splitter-resize-trigger-props-context'
@@ -10,14 +9,12 @@ export interface SplitterResizeTriggerIndicatorBaseProps extends PolymorphicProp
 export interface SplitterResizeTriggerIndicatorProps
   extends HTMLProps<'div'>, SplitterResizeTriggerIndicatorBaseProps {}
 
-export const SplitterResizeTriggerIndicator = forwardRef<HTMLDivElement, SplitterResizeTriggerIndicatorProps>(
-  (props, ref) => {
-    const splitter = useSplitterContext()
-    const triggerProps = useSplitterResizeTriggerPropsContext()
-    const mergedProps = mergeProps(splitter.getResizeTriggerIndicator(triggerProps), props)
+export const SplitterResizeTriggerIndicator = ({ ref, ...props }: SplitterResizeTriggerIndicatorProps) => {
+  const splitter = useSplitterContext()
+  const triggerProps = useSplitterResizeTriggerPropsContext()
+  const mergedProps = mergeProps(splitter.getResizeTriggerIndicator(triggerProps), props)
 
-    return <ark.div ref={ref} {...mergedProps} />
-  },
-)
+  return <ark.div ref={ref} {...mergedProps} />
+}
 
 SplitterResizeTriggerIndicator.displayName = 'SplitterResizeTriggerIndicator'

--- a/packages/react/src/components/splitter/splitter-resize-trigger.tsx
+++ b/packages/react/src/components/splitter/splitter-resize-trigger.tsx
@@ -2,7 +2,6 @@
 
 import { mergeProps } from '@zag-js/react'
 import type { ResizeTriggerProps } from '@zag-js/splitter'
-import { forwardRef } from 'react'
 import type { Assign } from '../../types'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -14,7 +13,7 @@ export interface SplitterResizeTriggerProps extends Assign<HTMLProps<'button'>, 
 
 const splitResizeTriggerProps = createSplitProps<ResizeTriggerProps>()
 
-export const SplitterResizeTrigger = forwardRef<HTMLButtonElement, SplitterResizeTriggerProps>((props, ref) => {
+export const SplitterResizeTrigger = ({ ref, ...props }: SplitterResizeTriggerProps) => {
   const [triggerProps, localProps] = splitResizeTriggerProps(props, ['disabled', 'id'])
   const splitter = useSplitterContext()
   const mergedProps = mergeProps(splitter.getResizeTriggerProps(triggerProps), localProps)
@@ -24,6 +23,6 @@ export const SplitterResizeTrigger = forwardRef<HTMLButtonElement, SplitterResiz
       <ark.button ref={ref} {...mergedProps} />
     </SplitterResizeTriggerPropsProvider>
   )
-})
+}
 
 SplitterResizeTrigger.displayName = 'SplitterResizeTrigger'

--- a/packages/react/src/components/splitter/splitter-root-provider.tsx
+++ b/packages/react/src/components/splitter/splitter-root-provider.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import type { UseSplitterReturn } from './use-splitter'
@@ -16,7 +15,7 @@ export interface SplitterRootProviderProps extends HTMLProps<'div'>, SplitterRoo
 
 const splitRootProviderProps = createSplitProps<RootProviderProps>()
 
-export const SplitterRootProvider = forwardRef<HTMLDivElement, SplitterRootProviderProps>((props, ref) => {
+export const SplitterRootProvider = ({ ref, ...props }: SplitterRootProviderProps) => {
   const [{ value: splitter }, localProps] = splitRootProviderProps(props, ['value'])
   const mergedProps = mergeProps(splitter.getRootProps(), localProps)
 
@@ -25,6 +24,6 @@ export const SplitterRootProvider = forwardRef<HTMLDivElement, SplitterRootProvi
       <ark.div {...mergedProps} ref={ref} />
     </SplitterProvider>
   )
-})
+}
 
 SplitterRootProvider.displayName = 'SplitterRootProvider'

--- a/packages/react/src/components/splitter/splitter-root.tsx
+++ b/packages/react/src/components/splitter/splitter-root.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import type { Assign } from '../../types'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -13,7 +12,7 @@ export interface SplitterRootProps extends Assign<HTMLProps<'div'>, SplitterRoot
 
 const splitRootProps = createSplitProps<UseSplitterProps>()
 
-export const SplitterRoot = forwardRef<HTMLDivElement, SplitterRootProps>((props, ref) => {
+export const SplitterRoot = ({ ref, ...props }: SplitterRootProps) => {
   const [useSplitterProps, localProps] = splitRootProps(props, [
     'defaultSize',
     'id',
@@ -38,6 +37,6 @@ export const SplitterRoot = forwardRef<HTMLDivElement, SplitterRootProps>((props
       <ark.div {...mergedProps} ref={ref} />
     </SplitterProvider>
   )
-})
+}
 
 SplitterRoot.displayName = 'SplitterRoot'

--- a/packages/react/src/components/steps/steps-completed-content.tsx
+++ b/packages/react/src/components/steps/steps-completed-content.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useStepsContext } from './use-steps-context'
 
 export interface StepsCompletedContentBaseProps extends PolymorphicProps {}
 export interface StepsCompletedContentProps extends HTMLProps<'div'>, StepsCompletedContentBaseProps {}
 
-export const StepsCompletedContent = forwardRef<HTMLDivElement, StepsCompletedContentProps>((props, ref) => {
+export const StepsCompletedContent = ({ ref, ...props }: StepsCompletedContentProps) => {
   const steps = useStepsContext()
   const mergedProps = mergeProps(steps.getContentProps({ index: steps.count }), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 StepsCompletedContent.displayName = 'StepsCompletedContent'

--- a/packages/react/src/components/steps/steps-content.tsx
+++ b/packages/react/src/components/steps/steps-content.tsx
@@ -2,7 +2,6 @@
 
 import { mergeProps } from '@zag-js/react'
 import type { ItemProps } from '@zag-js/steps'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useStepsContext } from './use-steps-context'
@@ -12,12 +11,12 @@ export interface StepsContentProps extends HTMLProps<'div'>, StepsContentBasePro
 
 const splitContentProps = createSplitProps<ItemProps>()
 
-export const StepsContent = forwardRef<HTMLDivElement, StepsContentProps>((props, ref) => {
+export const StepsContent = ({ ref, ...props }: StepsContentProps) => {
   const [itemProps, localProps] = splitContentProps(props, ['index'])
   const steps = useStepsContext()
   const mergedProps = mergeProps(steps.getContentProps(itemProps), localProps)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 StepsContent.displayName = 'StepsContent'

--- a/packages/react/src/components/steps/steps-indicator.tsx
+++ b/packages/react/src/components/steps/steps-indicator.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useStepsContext } from './use-steps-context'
 import { useStepsItemPropsContext } from './use-steps-item-props-context'
@@ -9,12 +8,12 @@ import { useStepsItemPropsContext } from './use-steps-item-props-context'
 export interface StepsIndicatorBaseProps extends PolymorphicProps {}
 export interface StepsIndicatorProps extends HTMLProps<'div'>, StepsIndicatorBaseProps {}
 
-export const StepsIndicator = forwardRef<HTMLDivElement, StepsIndicatorProps>((props, ref) => {
+export const StepsIndicator = ({ ref, ...props }: StepsIndicatorProps) => {
   const steps = useStepsContext()
   const itemProps = useStepsItemPropsContext()
   const mergedProps = mergeProps(steps.getIndicatorProps(itemProps), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 StepsIndicator.displayName = 'StepsIndicator'

--- a/packages/react/src/components/steps/steps-item.tsx
+++ b/packages/react/src/components/steps/steps-item.tsx
@@ -2,7 +2,6 @@
 
 import { mergeProps } from '@zag-js/react'
 import type { ItemProps } from '@zag-js/steps'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useStepsContext } from './use-steps-context'
@@ -14,7 +13,7 @@ export interface StepsItemProps extends HTMLProps<'div'>, StepsItemBaseProps {}
 
 const splitItemProps = createSplitProps<ItemProps>()
 
-export const StepsItem = forwardRef<HTMLDivElement, StepsItemProps>((props, ref) => {
+export const StepsItem = ({ ref, ...props }: StepsItemProps) => {
   const [itemProps, localProps] = splitItemProps(props, ['index'])
   const steps = useStepsContext()
   const mergedProps = mergeProps(steps.getItemProps(itemProps), localProps)
@@ -27,6 +26,6 @@ export const StepsItem = forwardRef<HTMLDivElement, StepsItemProps>((props, ref)
       </StepsItemProvider>
     </StepsItemPropsProvider>
   )
-})
+}
 
 StepsItem.displayName = 'StepsItem'

--- a/packages/react/src/components/steps/steps-list.tsx
+++ b/packages/react/src/components/steps/steps-list.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useStepsContext } from './use-steps-context'
 
 export interface StepsListBaseProps extends PolymorphicProps {}
 export interface StepsListProps extends HTMLProps<'div'>, StepsListBaseProps {}
 
-export const StepsList = forwardRef<HTMLDivElement, StepsListProps>((props, ref) => {
+export const StepsList = ({ ref, ...props }: StepsListProps) => {
   const steps = useStepsContext()
   const mergedProps = mergeProps(steps.getListProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 StepsList.displayName = 'StepsList'

--- a/packages/react/src/components/steps/steps-next-trigger.tsx
+++ b/packages/react/src/components/steps/steps-next-trigger.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useStepsContext } from './use-steps-context'
 
 export interface StepsNextTriggerBaseProps extends PolymorphicProps {}
 export interface StepsNextTriggerProps extends HTMLProps<'button'>, StepsNextTriggerBaseProps {}
 
-export const StepsNextTrigger = forwardRef<HTMLButtonElement, StepsNextTriggerProps>((props, ref) => {
+export const StepsNextTrigger = ({ ref, ...props }: StepsNextTriggerProps) => {
   const steps = useStepsContext()
   const mergedProps = mergeProps(steps.getNextTriggerProps(), props)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 StepsNextTrigger.displayName = 'StepsNextTrigger'

--- a/packages/react/src/components/steps/steps-prev-trigger.tsx
+++ b/packages/react/src/components/steps/steps-prev-trigger.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useStepsContext } from './use-steps-context'
 
 export interface StepsPrevTriggerBaseProps extends PolymorphicProps {}
 export interface StepsPrevTriggerProps extends HTMLProps<'button'>, StepsPrevTriggerBaseProps {}
 
-export const StepsPrevTrigger = forwardRef<HTMLButtonElement, StepsPrevTriggerProps>((props, ref) => {
+export const StepsPrevTrigger = ({ ref, ...props }: StepsPrevTriggerProps) => {
   const steps = useStepsContext()
   const mergedProps = mergeProps(steps.getPrevTriggerProps(), props)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 StepsPrevTrigger.displayName = 'StepsPrevTrigger'

--- a/packages/react/src/components/steps/steps-progress.tsx
+++ b/packages/react/src/components/steps/steps-progress.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useStepsContext } from './use-steps-context'
 
 export interface StepsProgressBaseProps extends PolymorphicProps {}
 export interface StepsProgressProps extends HTMLProps<'div'>, StepsProgressBaseProps {}
 
-export const StepsProgress = forwardRef<HTMLDivElement, StepsProgressProps>((props, ref) => {
+export const StepsProgress = ({ ref, ...props }: StepsProgressProps) => {
   const steps = useStepsContext()
   const mergedProps = mergeProps(steps.getProgressProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 StepsProgress.displayName = 'StepsProgress'

--- a/packages/react/src/components/steps/steps-root-provider.tsx
+++ b/packages/react/src/components/steps/steps-root-provider.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import type { UseStepsReturn } from './use-steps'
@@ -16,7 +15,7 @@ export interface StepsRootProviderProps extends HTMLProps<'div'>, StepsRootProvi
 
 const splitRootProviderProps = createSplitProps<RootProviderProps>()
 
-export const StepsRootProvider = forwardRef<HTMLDivElement, StepsRootProviderProps>((props, ref) => {
+export const StepsRootProvider = ({ ref, ...props }: StepsRootProviderProps) => {
   const [{ value: steps }, rootProps] = splitRootProviderProps(props, ['value'])
   const mergedProps = mergeProps(steps.getRootProps(), rootProps)
 
@@ -27,6 +26,6 @@ export const StepsRootProvider = forwardRef<HTMLDivElement, StepsRootProviderPro
       </ark.div>
     </StepsProvider>
   )
-})
+}
 
 StepsRootProvider.displayName = 'StepsRootProvider'

--- a/packages/react/src/components/steps/steps-root.tsx
+++ b/packages/react/src/components/steps/steps-root.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { type UseStepsProps, useSteps } from './use-steps'
@@ -12,7 +11,7 @@ export interface StepsRootProps extends HTMLProps<'div'>, StepsRootBaseProps {}
 
 const splitRootProps = createSplitProps<UseStepsProps>()
 
-export const StepsRoot = forwardRef<HTMLDivElement, StepsRootProps>((props, ref) => {
+export const StepsRoot = ({ ref, ...props }: StepsRootProps) => {
   const [useStepsProps, localProps] = splitRootProps(props, [
     'count',
     'defaultStep',
@@ -36,6 +35,6 @@ export const StepsRoot = forwardRef<HTMLDivElement, StepsRootProps>((props, ref)
       <ark.div {...mergedProps} ref={ref} />
     </StepsProvider>
   )
-})
+}
 
 StepsRoot.displayName = 'StepsRoot'

--- a/packages/react/src/components/steps/steps-separator.tsx
+++ b/packages/react/src/components/steps/steps-separator.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useStepsContext } from './use-steps-context'
 import { useStepsItemPropsContext } from './use-steps-item-props-context'
@@ -9,12 +8,12 @@ import { useStepsItemPropsContext } from './use-steps-item-props-context'
 export interface StepsSeparatorBaseProps extends PolymorphicProps {}
 export interface StepsSeparatorProps extends HTMLProps<'div'>, StepsSeparatorBaseProps {}
 
-export const StepsSeparator = forwardRef<HTMLDivElement, StepsSeparatorProps>((props, ref) => {
+export const StepsSeparator = ({ ref, ...props }: StepsSeparatorProps) => {
   const steps = useStepsContext()
   const itemProps = useStepsItemPropsContext()
   const mergedProps = mergeProps(steps.getSeparatorProps(itemProps), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 StepsSeparator.displayName = 'StepsSeparator'

--- a/packages/react/src/components/steps/steps-trigger.tsx
+++ b/packages/react/src/components/steps/steps-trigger.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useStepsContext } from './use-steps-context'
 import { useStepsItemPropsContext } from './use-steps-item-props-context'
@@ -9,12 +8,12 @@ import { useStepsItemPropsContext } from './use-steps-item-props-context'
 export interface StepsTriggerBaseProps extends PolymorphicProps {}
 export interface StepsTriggerProps extends HTMLProps<'button'>, StepsTriggerBaseProps {}
 
-export const StepsTrigger = forwardRef<HTMLButtonElement, StepsTriggerProps>((props, ref) => {
+export const StepsTrigger = ({ ref, ...props }: StepsTriggerProps) => {
   const steps = useStepsContext()
   const itemProps = useStepsItemPropsContext()
   const mergedProps = mergeProps(steps.getTriggerProps(itemProps), props)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 StepsTrigger.displayName = 'StepsTrigger'

--- a/packages/react/src/components/swap/swap-indicator.tsx
+++ b/packages/react/src/components/swap/swap-indicator.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { composeRefs } from '../../utils/compose-refs'
 import type { HTMLProps, PolymorphicProps } from '../factory'
 import { ark } from '../factory'
@@ -13,7 +12,7 @@ export interface SwapIndicatorBaseProps extends PolymorphicProps {
 
 export interface SwapIndicatorProps extends HTMLProps<'span'>, SwapIndicatorBaseProps {}
 
-export const SwapIndicator = forwardRef<HTMLSpanElement, SwapIndicatorProps>((props, ref) => {
+export const SwapIndicator = ({ ref, ...props }: SwapIndicatorProps) => {
   const { type, ...restProps } = props
   const swap = useSwapContext()
   const presence = type === 'on' ? swap.onPresence : swap.offPresence
@@ -23,6 +22,6 @@ export const SwapIndicator = forwardRef<HTMLSpanElement, SwapIndicatorProps>((pr
   const mergedProps = mergeProps(swap.getIndicatorProps({ type }), restProps)
 
   return <ark.span {...mergedProps} ref={composeRefs(presence.ref, ref)} />
-})
+}
 
 SwapIndicator.displayName = 'SwapIndicator'

--- a/packages/react/src/components/swap/swap-root-provider.tsx
+++ b/packages/react/src/components/swap/swap-root-provider.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import type { HTMLProps, PolymorphicProps } from '../factory'
 import { ark } from '../factory'
 import type { UseSwapReturn } from './use-swap'
@@ -13,7 +12,7 @@ export interface SwapRootProviderBaseProps extends PolymorphicProps {
 
 export interface SwapRootProviderProps extends HTMLProps<'span'>, SwapRootProviderBaseProps {}
 
-export const SwapRootProvider = forwardRef<HTMLSpanElement, SwapRootProviderProps>((props, ref) => {
+export const SwapRootProvider = ({ ref, ...props }: SwapRootProviderProps) => {
   const { value, children, ...restProps } = props
   const mergedProps = mergeProps(value.getRootProps(), restProps)
 
@@ -24,6 +23,6 @@ export const SwapRootProvider = forwardRef<HTMLSpanElement, SwapRootProviderProp
       </ark.span>
     </SwapProvider>
   )
-})
+}
 
 SwapRootProvider.displayName = 'SwapRootProvider'

--- a/packages/react/src/components/swap/swap-root.tsx
+++ b/packages/react/src/components/swap/swap-root.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import type { HTMLProps, PolymorphicProps } from '../factory'
 import { ark } from '../factory'
 import { type UseSwapProps, useSwap } from './use-swap'
@@ -11,7 +10,7 @@ export interface SwapRootBaseProps extends UseSwapProps, PolymorphicProps {}
 
 export interface SwapRootProps extends HTMLProps<'span'>, SwapRootBaseProps {}
 
-export const SwapRoot = forwardRef<HTMLSpanElement, SwapRootProps>((props, ref) => {
+export const SwapRoot = ({ ref, ...props }: SwapRootProps) => {
   const { children, swap: swapProp, lazyMount, unmountOnExit, ...restProps } = props
   const swap = useSwap({ swap: swapProp, lazyMount, unmountOnExit })
   const mergedProps = mergeProps(swap.getRootProps(), restProps)
@@ -23,6 +22,6 @@ export const SwapRoot = forwardRef<HTMLSpanElement, SwapRootProps>((props, ref) 
       </ark.span>
     </SwapProvider>
   )
-})
+}
 
 SwapRoot.displayName = 'SwapRoot'

--- a/packages/react/src/components/switch/switch-control.tsx
+++ b/packages/react/src/components/switch/switch-control.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useSwitchContext } from './use-switch-context'
 
 export interface SwitchControlBaseProps extends PolymorphicProps {}
 export interface SwitchControlProps extends HTMLProps<'span'>, SwitchControlBaseProps {}
 
-export const SwitchControl = forwardRef<HTMLSpanElement, SwitchControlProps>((props, ref) => {
+export const SwitchControl = ({ ref, ...props }: SwitchControlProps) => {
   const switchContext = useSwitchContext()
   const mergedProps = mergeProps(switchContext.getControlProps(), props)
 
   return <ark.span {...mergedProps} ref={ref} />
-})
+}
 
 SwitchControl.displayName = 'SwitchControl'

--- a/packages/react/src/components/switch/switch-hidden-input.tsx
+++ b/packages/react/src/components/switch/switch-hidden-input.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useFieldContext } from '../field'
 import { useSwitchContext } from './use-switch-context'
@@ -9,12 +8,12 @@ import { useSwitchContext } from './use-switch-context'
 export interface SwitchHiddenInputBaseProps extends PolymorphicProps {}
 export interface SwitchHiddenInputProps extends HTMLProps<'input'>, SwitchHiddenInputBaseProps {}
 
-export const SwitchHiddenInput = forwardRef<HTMLInputElement, SwitchHiddenInputProps>((props, ref) => {
+export const SwitchHiddenInput = ({ ref, ...props }: SwitchHiddenInputProps) => {
   const switchContext = useSwitchContext()
   const mergedProps = mergeProps(switchContext.getHiddenInputProps(), props)
   const field = useFieldContext()
 
   return <ark.input aria-describedby={field?.ariaDescribedby} {...mergedProps} ref={ref} />
-})
+}
 
 SwitchHiddenInput.displayName = 'SwitchHiddenInput'

--- a/packages/react/src/components/switch/switch-label.tsx
+++ b/packages/react/src/components/switch/switch-label.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useSwitchContext } from './use-switch-context'
 
 export interface SwitchLabelBaseProps extends PolymorphicProps {}
 export interface SwitchLabelProps extends HTMLProps<'span'>, SwitchLabelBaseProps {}
 
-export const SwitchLabel = forwardRef<HTMLSpanElement, SwitchLabelProps>((props, ref) => {
+export const SwitchLabel = ({ ref, ...props }: SwitchLabelProps) => {
   const switchContext = useSwitchContext()
   const mergedProps = mergeProps(switchContext.getLabelProps(), props)
 
   return <ark.span {...mergedProps} ref={ref} />
-})
+}
 
 SwitchLabel.displayName = 'SwitchLabel'

--- a/packages/react/src/components/switch/switch-root-provider.tsx
+++ b/packages/react/src/components/switch/switch-root-provider.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import type { UseSwitchReturn } from './use-switch'
@@ -16,7 +15,7 @@ export interface SwitchRootProviderProps extends HTMLProps<'label'>, SwitchRootP
 
 const splitRootProviderProps = createSplitProps<RootProviderProps>()
 
-export const SwitchRootProvider = forwardRef<HTMLLabelElement, SwitchRootProviderProps>((props, ref) => {
+export const SwitchRootProvider = ({ ref, ...props }: SwitchRootProviderProps) => {
   const [{ value: api }, localProps] = splitRootProviderProps(props, ['value'])
   const mergedProps = mergeProps(api.getRootProps(), localProps)
 
@@ -25,6 +24,6 @@ export const SwitchRootProvider = forwardRef<HTMLLabelElement, SwitchRootProvide
       <ark.label {...mergedProps} ref={ref} />
     </SwitchProvider>
   )
-})
+}
 
 SwitchRootProvider.displayName = 'SwitchRootProvider'

--- a/packages/react/src/components/switch/switch-root.tsx
+++ b/packages/react/src/components/switch/switch-root.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { type UseSwitchProps, useSwitch } from './use-switch'
@@ -12,7 +11,7 @@ export interface SwitchRootProps extends HTMLProps<'label'>, SwitchRootBaseProps
 
 const splitRootProps = createSplitProps<UseSwitchProps>()
 
-export const SwitchRoot = forwardRef<HTMLLabelElement, SwitchRootProps>((props, ref) => {
+export const SwitchRoot = ({ ref, ...props }: SwitchRootProps) => {
   const [useSwitchProps, localProps] = splitRootProps(props, [
     'checked',
     'defaultChecked',
@@ -37,6 +36,6 @@ export const SwitchRoot = forwardRef<HTMLLabelElement, SwitchRootProps>((props, 
       <ark.label {...mergedProps} ref={ref} />
     </SwitchProvider>
   )
-})
+}
 
 SwitchRoot.displayName = 'SwitchRoot'

--- a/packages/react/src/components/switch/switch-thumb.tsx
+++ b/packages/react/src/components/switch/switch-thumb.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useSwitchContext } from './use-switch-context'
 
 export interface SwitchThumbBaseProps extends PolymorphicProps {}
 export interface SwitchThumbProps extends HTMLProps<'span'>, SwitchThumbBaseProps {}
 
-export const SwitchThumb = forwardRef<HTMLSpanElement, SwitchThumbProps>((props, ref) => {
+export const SwitchThumb = ({ ref, ...props }: SwitchThumbProps) => {
   const switchContext = useSwitchContext()
   const mergedProps = mergeProps(switchContext.getThumbProps(), props)
 
   return <ark.span {...mergedProps} ref={ref} />
-})
+}
 
 SwitchThumb.displayName = 'SwitchThumb'

--- a/packages/react/src/components/tabs/tab-content.tsx
+++ b/packages/react/src/components/tabs/tab-content.tsx
@@ -2,7 +2,6 @@
 
 import { mergeProps } from '@zag-js/react'
 import type { ContentProps } from '@zag-js/tabs'
-import { forwardRef } from 'react'
 import { composeRefs } from '../../utils/compose-refs'
 import { createSplitProps } from '../../utils/create-split-props'
 import { useRenderStrategyPropsContext } from '../../utils/render-strategy'
@@ -15,7 +14,7 @@ export interface TabContentProps extends HTMLProps<'div'>, TabContentBaseProps {
 
 const splitContentProps = createSplitProps<ContentProps>()
 
-export const TabContent = forwardRef<HTMLDivElement, TabContentProps>((props, ref) => {
+export const TabContent = ({ ref, ...props }: TabContentProps) => {
   const [contentProps, localProps] = splitContentProps(props, ['value'])
   const tabs = useTabsContext()
   const renderStrategyProps = useRenderStrategyPropsContext()
@@ -33,6 +32,6 @@ export const TabContent = forwardRef<HTMLDivElement, TabContentProps>((props, re
       {presence.unmounted ? null : <ark.div {...mergedProps} ref={composeRefs(presence.ref, ref)} />}
     </PresenceProvider>
   )
-})
+}
 
 TabContent.displayName = 'TabContent'

--- a/packages/react/src/components/tabs/tab-indicator.tsx
+++ b/packages/react/src/components/tabs/tab-indicator.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useTabsContext } from './use-tabs-context'
 
 export interface TabIndicatorBaseProps extends PolymorphicProps {}
 export interface TabIndicatorProps extends HTMLProps<'div'>, TabIndicatorBaseProps {}
 
-export const TabIndicator = forwardRef<HTMLDivElement, TabIndicatorProps>((props, ref) => {
+export const TabIndicator = ({ ref, ...props }: TabIndicatorProps) => {
   const tabs = useTabsContext()
   const mergedProps = mergeProps(tabs.getIndicatorProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 TabIndicator.displayName = 'TabIndicator'

--- a/packages/react/src/components/tabs/tab-list.tsx
+++ b/packages/react/src/components/tabs/tab-list.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useTabsContext } from './use-tabs-context'
 
 export interface TabListBaseProps extends PolymorphicProps {}
 export interface TabListProps extends HTMLProps<'div'>, TabListBaseProps {}
 
-export const TabList = forwardRef<HTMLDivElement, TabListProps>((props, ref) => {
+export const TabList = ({ ref, ...props }: TabListProps) => {
   const tabs = useTabsContext()
   const mergedProps = mergeProps(tabs.getListProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 TabList.displayName = 'TabList'

--- a/packages/react/src/components/tabs/tab-trigger.tsx
+++ b/packages/react/src/components/tabs/tab-trigger.tsx
@@ -2,7 +2,6 @@
 
 import { mergeProps } from '@zag-js/react'
 import type { TriggerProps } from '@zag-js/tabs'
-import { forwardRef } from 'react'
 import type { Assign } from '../../types'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -13,12 +12,12 @@ export interface TabTriggerProps extends Assign<HTMLProps<'button'>, TabTriggerB
 
 const splitTriggerProps = createSplitProps<TriggerProps>()
 
-export const TabTrigger = forwardRef<HTMLButtonElement, TabTriggerProps>((props, ref) => {
+export const TabTrigger = ({ ref, ...props }: TabTriggerProps) => {
   const [tabProps, localProps] = splitTriggerProps(props, ['disabled', 'value'])
   const tabs = useTabsContext()
   const mergedProps = mergeProps(tabs.getTriggerProps(tabProps), localProps)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 TabTrigger.displayName = 'TabTrigger'

--- a/packages/react/src/components/tabs/tabs-root-provider.tsx
+++ b/packages/react/src/components/tabs/tabs-root-provider.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import {
   type RenderStrategyProps,
@@ -21,7 +20,7 @@ export interface TabsRootProviderProps extends HTMLProps<'div'>, TabsRootProvide
 
 const splitRootProviderProps = createSplitProps<RootProviderProps>()
 
-export const TabsRootProvider = forwardRef<HTMLDivElement, TabsRootProviderProps>((props, ref) => {
+export const TabsRootProvider = ({ ref, ...props }: TabsRootProviderProps) => {
   const [renderStrategyProps, tabsProps] = splitRenderStrategyProps(props)
   const [{ value: tabs }, localProps] = splitRootProviderProps(tabsProps, ['value'])
   const mergedProps = mergeProps(tabs.getRootProps(), localProps)
@@ -33,6 +32,6 @@ export const TabsRootProvider = forwardRef<HTMLDivElement, TabsRootProviderProps
       </RenderStrategyPropsProvider>
     </TabsProvider>
   )
-})
+}
 
 TabsRootProvider.displayName = 'TabsRootProvider'

--- a/packages/react/src/components/tabs/tabs-root.tsx
+++ b/packages/react/src/components/tabs/tabs-root.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import type { Assign } from '../../types'
 import { createSplitProps } from '../../utils/create-split-props'
 import {
@@ -18,7 +17,7 @@ export interface TabsRootProps extends Assign<HTMLProps<'div'>, TabsRootBaseProp
 
 const splitRootProps = createSplitProps<UseTabsProps>()
 
-export const TabsRoot = forwardRef<HTMLDivElement, TabsRootProps>((props, ref) => {
+export const TabsRoot = ({ ref, ...props }: TabsRootProps) => {
   const [renderStrategyProps, tabsProps] = splitRenderStrategyProps(props)
   const [useTabsProps, localProps] = splitRootProps(tabsProps, [
     'activationMode',
@@ -45,6 +44,6 @@ export const TabsRoot = forwardRef<HTMLDivElement, TabsRootProps>((props, ref) =
       </RenderStrategyPropsProvider>
     </TabsProvider>
   )
-})
+}
 
 TabsRoot.displayName = 'TabsRoot'

--- a/packages/react/src/components/tags-input/tags-input-clear-trigger.tsx
+++ b/packages/react/src/components/tags-input/tags-input-clear-trigger.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useTagsInputContext } from './use-tags-input-context'
 
 export interface TagsInputClearTriggerBaseProps extends PolymorphicProps {}
 export interface TagsInputClearTriggerProps extends HTMLProps<'button'>, TagsInputClearTriggerBaseProps {}
 
-export const TagsInputClearTrigger = forwardRef<HTMLButtonElement, TagsInputClearTriggerProps>((props, ref) => {
+export const TagsInputClearTrigger = ({ ref, ...props }: TagsInputClearTriggerProps) => {
   const tagsInput = useTagsInputContext()
   const mergedProps = mergeProps(tagsInput.getClearTriggerProps(), props)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 TagsInputClearTrigger.displayName = 'TagsInputClearTrigger'

--- a/packages/react/src/components/tags-input/tags-input-control.tsx
+++ b/packages/react/src/components/tags-input/tags-input-control.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useTagsInputContext } from './use-tags-input-context'
 
 export interface TagsInputControlBaseProps extends PolymorphicProps {}
 export interface TagsInputControlProps extends HTMLProps<'div'>, TagsInputControlBaseProps {}
 
-export const TagsInputControl = forwardRef<HTMLDivElement, TagsInputControlProps>((props, ref) => {
+export const TagsInputControl = ({ ref, ...props }: TagsInputControlProps) => {
   const tagsInput = useTagsInputContext()
   const mergedProps = mergeProps(tagsInput.getControlProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 TagsInputControl.displayName = 'TagsInputControl'

--- a/packages/react/src/components/tags-input/tags-input-hidden-input.tsx
+++ b/packages/react/src/components/tags-input/tags-input-hidden-input.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useFieldContext } from '../field'
 import { useTagsInputContext } from './use-tags-input-context'
@@ -9,12 +8,12 @@ import { useTagsInputContext } from './use-tags-input-context'
 export interface TagsInputHiddenInputBaseProps extends PolymorphicProps {}
 export interface TagsInputHiddenInputProps extends HTMLProps<'input'>, TagsInputHiddenInputBaseProps {}
 
-export const TagsInputHiddenInput = forwardRef<HTMLInputElement, TagsInputHiddenInputProps>((props, ref) => {
+export const TagsInputHiddenInput = ({ ref, ...props }: TagsInputHiddenInputProps) => {
   const tagsInput = useTagsInputContext()
   const mergedProps = mergeProps(tagsInput.getHiddenInputProps(), props)
   const field = useFieldContext()
 
   return <ark.input aria-describedby={field?.ariaDescribedby} {...mergedProps} ref={ref} />
-})
+}
 
 TagsInputHiddenInput.displayName = 'TagsInputHiddenInput'

--- a/packages/react/src/components/tags-input/tags-input-input.tsx
+++ b/packages/react/src/components/tags-input/tags-input-input.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useTagsInputContext } from './use-tags-input-context'
 
 export interface TagsInputInputBaseProps extends PolymorphicProps {}
 export interface TagsInputInputProps extends HTMLProps<'input'>, TagsInputInputBaseProps {}
 
-export const TagsInputInput = forwardRef<HTMLInputElement, TagsInputInputProps>((props, ref) => {
+export const TagsInputInput = ({ ref, ...props }: TagsInputInputProps) => {
   const tagsInput = useTagsInputContext()
   const mergedProps = mergeProps(tagsInput.getInputProps(), props)
 
   return <ark.input {...mergedProps} ref={ref} />
-})
+}
 
 TagsInputInput.displayName = 'TagsInputInput'

--- a/packages/react/src/components/tags-input/tags-input-item-delete-trigger.tsx
+++ b/packages/react/src/components/tags-input/tags-input-item-delete-trigger.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useTagsInputContext } from './use-tags-input-context'
 import { useTagsInputItemPropsContext } from './use-tags-input-item-props-context'
@@ -9,14 +8,12 @@ import { useTagsInputItemPropsContext } from './use-tags-input-item-props-contex
 export interface TagsInputItemDeleteTriggerBaseProps extends PolymorphicProps {}
 export interface TagsInputItemDeleteTriggerProps extends HTMLProps<'button'>, TagsInputItemDeleteTriggerBaseProps {}
 
-export const TagsInputItemDeleteTrigger = forwardRef<HTMLButtonElement, TagsInputItemDeleteTriggerProps>(
-  (props, ref) => {
-    const tagsInput = useTagsInputContext()
-    const itemProps = useTagsInputItemPropsContext()
-    const mergedProps = mergeProps(tagsInput.getItemDeleteTriggerProps(itemProps), props)
+export const TagsInputItemDeleteTrigger = ({ ref, ...props }: TagsInputItemDeleteTriggerProps) => {
+  const tagsInput = useTagsInputContext()
+  const itemProps = useTagsInputItemPropsContext()
+  const mergedProps = mergeProps(tagsInput.getItemDeleteTriggerProps(itemProps), props)
 
-    return <ark.button {...mergedProps} ref={ref} />
-  },
-)
+  return <ark.button {...mergedProps} ref={ref} />
+}
 
 TagsInputItemDeleteTrigger.displayName = 'TagsInputItemDeleteTrigger'

--- a/packages/react/src/components/tags-input/tags-input-item-input.tsx
+++ b/packages/react/src/components/tags-input/tags-input-item-input.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useTagsInputContext } from './use-tags-input-context'
 import { useTagsInputItemPropsContext } from './use-tags-input-item-props-context'
@@ -9,12 +8,12 @@ import { useTagsInputItemPropsContext } from './use-tags-input-item-props-contex
 export interface TagsInputItemInputBaseProps extends PolymorphicProps {}
 export interface TagsInputItemInputProps extends HTMLProps<'input'>, TagsInputItemInputBaseProps {}
 
-export const TagsInputItemInput = forwardRef<HTMLInputElement, TagsInputItemInputProps>((props, ref) => {
+export const TagsInputItemInput = ({ ref, ...props }: TagsInputItemInputProps) => {
   const tagsInput = useTagsInputContext()
   const itemProps = useTagsInputItemPropsContext()
   const mergedProps = mergeProps(tagsInput.getItemInputProps(itemProps), props)
 
   return <ark.input {...mergedProps} ref={ref} />
-})
+}
 
 TagsInputItemInput.displayName = 'TagsInputItemInput'

--- a/packages/react/src/components/tags-input/tags-input-item-preview.tsx
+++ b/packages/react/src/components/tags-input/tags-input-item-preview.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useTagsInputContext } from './use-tags-input-context'
 import { useTagsInputItemPropsContext } from './use-tags-input-item-props-context'
@@ -9,12 +8,12 @@ import { useTagsInputItemPropsContext } from './use-tags-input-item-props-contex
 export interface TagsInputItemPreviewBaseProps extends PolymorphicProps {}
 export interface TagsInputItemPreviewProps extends HTMLProps<'div'>, TagsInputItemPreviewBaseProps {}
 
-export const TagsInputItemPreview = forwardRef<HTMLDivElement, TagsInputItemPreviewProps>((props, ref) => {
+export const TagsInputItemPreview = ({ ref, ...props }: TagsInputItemPreviewProps) => {
   const tagsInput = useTagsInputContext()
   const itemProps = useTagsInputItemPropsContext()
   const mergedProps = mergeProps(tagsInput.getItemPreviewProps(itemProps), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 TagsInputItemPreview.displayName = 'TagsInputItemPreview'

--- a/packages/react/src/components/tags-input/tags-input-item-text.tsx
+++ b/packages/react/src/components/tags-input/tags-input-item-text.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useTagsInputContext } from './use-tags-input-context'
 import { useTagsInputItemPropsContext } from './use-tags-input-item-props-context'
@@ -9,12 +8,12 @@ import { useTagsInputItemPropsContext } from './use-tags-input-item-props-contex
 export interface TagsInputItemTextBaseProps extends PolymorphicProps {}
 export interface TagsInputItemTextProps extends HTMLProps<'span'>, TagsInputItemTextBaseProps {}
 
-export const TagsInputItemText = forwardRef<HTMLSpanElement, TagsInputItemTextProps>((props, ref) => {
+export const TagsInputItemText = ({ ref, ...props }: TagsInputItemTextProps) => {
   const tagsInput = useTagsInputContext()
   const itemProps = useTagsInputItemPropsContext()
   const mergedProps = mergeProps(tagsInput.getItemTextProps(itemProps), props)
 
   return <ark.span {...mergedProps} ref={ref} />
-})
+}
 
 TagsInputItemText.displayName = 'TagsInputItemText'

--- a/packages/react/src/components/tags-input/tags-input-item.tsx
+++ b/packages/react/src/components/tags-input/tags-input-item.tsx
@@ -2,7 +2,6 @@
 
 import { mergeProps } from '@zag-js/react'
 import type { ItemProps } from '@zag-js/tags-input'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useTagsInputContext } from './use-tags-input-context'
@@ -14,7 +13,7 @@ export interface TagsInputItemProps extends HTMLProps<'div'>, TagsInputItemBaseP
 
 const splitItemProps = createSplitProps<ItemProps>()
 
-export const TagsInputItem = forwardRef<HTMLDivElement, TagsInputItemProps>((props, ref) => {
+export const TagsInputItem = ({ ref, ...props }: TagsInputItemProps) => {
   const [itemProps, localProps] = splitItemProps(props, ['index', 'disabled', 'value'])
   const tagsInput = useTagsInputContext()
   const mergedProps = mergeProps(tagsInput.getItemProps(itemProps), localProps)
@@ -27,6 +26,6 @@ export const TagsInputItem = forwardRef<HTMLDivElement, TagsInputItemProps>((pro
       </TagsInputItemProvider>
     </TagsInputItemPropsProvider>
   )
-})
+}
 
 TagsInputItem.displayName = 'TagsInputItem'

--- a/packages/react/src/components/tags-input/tags-input-label.tsx
+++ b/packages/react/src/components/tags-input/tags-input-label.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useTagsInputContext } from './use-tags-input-context'
 
 export interface TagsInputLabelBaseProps extends PolymorphicProps {}
 export interface TagsInputLabelProps extends HTMLProps<'label'>, TagsInputLabelBaseProps {}
 
-export const TagsInputLabel = forwardRef<HTMLLabelElement, TagsInputLabelProps>((props, ref) => {
+export const TagsInputLabel = ({ ref, ...props }: TagsInputLabelProps) => {
   const tagsInput = useTagsInputContext()
   const mergedProps = mergeProps(tagsInput.getLabelProps(), props)
 
   return <ark.label {...mergedProps} ref={ref} />
-})
+}
 
 TagsInputLabel.displayName = 'TagsInputLabel'

--- a/packages/react/src/components/tags-input/tags-input-root-provider.tsx
+++ b/packages/react/src/components/tags-input/tags-input-root-provider.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import type { UseTagsInputReturn } from './use-tags-input'
@@ -16,7 +15,7 @@ export interface TagsInputRootProviderProps extends HTMLProps<'div'>, TagsInputR
 
 const splitRootProviderProps = createSplitProps<RootProviderProps>()
 
-export const TagsInputRootProvider = forwardRef<HTMLDivElement, TagsInputRootProviderProps>((props, ref) => {
+export const TagsInputRootProvider = ({ ref, ...props }: TagsInputRootProviderProps) => {
   const [{ value: tagsInput }, localProps] = splitRootProviderProps(props, ['value'])
   const mergedProps = mergeProps(tagsInput.getRootProps(), localProps)
 
@@ -25,6 +24,6 @@ export const TagsInputRootProvider = forwardRef<HTMLDivElement, TagsInputRootPro
       <ark.div {...mergedProps} ref={ref} />
     </TagsInputProvider>
   )
-})
+}
 
 TagsInputRootProvider.displayName = 'TagsInputRootProvider'

--- a/packages/react/src/components/tags-input/tags-input-root.tsx
+++ b/packages/react/src/components/tags-input/tags-input-root.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import type { Assign } from '../../types'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -13,7 +12,7 @@ export interface TagsInputRootProps extends Assign<HTMLProps<'div'>, TagsInputRo
 
 const splitTagsInputProps = createSplitProps<UseTagsInputProps>()
 
-export const TagsInputRoot = forwardRef<HTMLDivElement, TagsInputRootProps>((props, ref) => {
+export const TagsInputRoot = ({ ref, ...props }: TagsInputRootProps) => {
   const [useTagsInputProps, localProps] = splitTagsInputProps(props, [
     'addOnPaste',
     'allowDuplicates',
@@ -56,6 +55,6 @@ export const TagsInputRoot = forwardRef<HTMLDivElement, TagsInputRootProps>((pro
       <ark.div {...mergedProps} ref={ref} />
     </TagsInputProvider>
   )
-})
+}
 
 TagsInputRoot.displayName = 'TagsInputRoot'

--- a/packages/react/src/components/timer/timer-action-trigger.tsx
+++ b/packages/react/src/components/timer/timer-action-trigger.tsx
@@ -2,7 +2,6 @@
 
 import { mergeProps } from '@zag-js/react'
 import type { ActionTriggerProps } from '@zag-js/timer'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useTimerContext } from './use-timer-context'
@@ -12,12 +11,12 @@ export interface TimerActionTriggerProps extends HTMLProps<'button'>, TimerActio
 
 const splitActionTriggerProps = createSplitProps<ActionTriggerProps>()
 
-export const TimerActionTrigger = forwardRef<HTMLButtonElement, TimerActionTriggerProps>((props, ref) => {
+export const TimerActionTrigger = ({ ref, ...props }: TimerActionTriggerProps) => {
   const [actionTriggerProps, localProps] = splitActionTriggerProps(props, ['action'])
   const timer = useTimerContext()
   const mergedProps = mergeProps(timer.getActionTriggerProps(actionTriggerProps), localProps)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 TimerActionTrigger.displayName = 'TimerActionTrigger'

--- a/packages/react/src/components/timer/timer-area.tsx
+++ b/packages/react/src/components/timer/timer-area.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useTimerContext } from './use-timer-context'
 
 export interface TimerAreaBaseProps extends PolymorphicProps {}
 export interface TimerAreaProps extends HTMLProps<'div'>, TimerAreaBaseProps {}
 
-export const TimerArea = forwardRef<HTMLDivElement, TimerAreaProps>((props, ref) => {
+export const TimerArea = ({ ref, ...props }: TimerAreaProps) => {
   const timer = useTimerContext()
   const mergedProps = mergeProps(timer.getAreaProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 TimerArea.displayName = 'TimerArea'

--- a/packages/react/src/components/timer/timer-control.tsx
+++ b/packages/react/src/components/timer/timer-control.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useTimerContext } from './use-timer-context'
 
 export interface TimerControlBaseProps extends PolymorphicProps {}
 export interface TimerControlProps extends HTMLProps<'div'>, TimerControlBaseProps {}
 
-export const TimerControl = forwardRef<HTMLDivElement, TimerControlProps>((props, ref) => {
+export const TimerControl = ({ ref, ...props }: TimerControlProps) => {
   const timer = useTimerContext()
   const mergedProps = mergeProps(timer.getControlProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 TimerControl.displayName = 'TimerControl'

--- a/packages/react/src/components/timer/timer-item.tsx
+++ b/packages/react/src/components/timer/timer-item.tsx
@@ -2,7 +2,6 @@
 
 import { mergeProps } from '@zag-js/react'
 import type { ItemProps } from '@zag-js/timer'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useTimerContext } from './use-timer-context'
@@ -12,7 +11,7 @@ export interface TimerItemProps extends HTMLProps<'div'>, TimerItemBaseProps {}
 
 const splitItemProps = createSplitProps<ItemProps>()
 
-export const TimerItem = forwardRef<HTMLDivElement, TimerItemProps>((props, ref) => {
+export const TimerItem = ({ ref, ...props }: TimerItemProps) => {
   const [itemProps, localProps] = splitItemProps(props, ['type'])
   const timer = useTimerContext()
 
@@ -23,6 +22,6 @@ export const TimerItem = forwardRef<HTMLDivElement, TimerItemProps>((props, ref)
       {timer.formattedTime[itemProps.type]}
     </ark.div>
   )
-})
+}
 
 TimerItem.displayName = 'TimerItem'

--- a/packages/react/src/components/timer/timer-root-provider.tsx
+++ b/packages/react/src/components/timer/timer-root-provider.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import type { UseTimerReturn } from './use-timer'
@@ -16,7 +15,7 @@ export interface TimerRootProviderProps extends HTMLProps<'div'>, TimerRootProvi
 
 const splitRootProviderProps = createSplitProps<RootProviderProps>()
 
-export const TimerRootProvider = forwardRef<HTMLDivElement, TimerRootProviderProps>((props, ref) => {
+export const TimerRootProvider = ({ ref, ...props }: TimerRootProviderProps) => {
   const [{ value: timer }, localProps] = splitRootProviderProps(props, ['value'])
   const mergedProps = mergeProps(timer.getRootProps(), localProps)
 
@@ -25,6 +24,6 @@ export const TimerRootProvider = forwardRef<HTMLDivElement, TimerRootProviderPro
       <ark.div {...mergedProps} ref={ref} />
     </TimerProvider>
   )
-})
+}
 
 TimerRootProvider.displayName = 'TimerRootProvider'

--- a/packages/react/src/components/timer/timer-root.tsx
+++ b/packages/react/src/components/timer/timer-root.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { type UseTimerProps, useTimer } from './use-timer'
@@ -13,7 +12,7 @@ export interface TimerRootProps extends HTMLProps<'div'>, TimerRootBaseProps {}
 
 const splitRootProps = createSplitProps<UseTimerProps>()
 
-export const TimerRoot = forwardRef<HTMLDivElement, TimerRootProps>((props, ref) => {
+export const TimerRoot = ({ ref, ...props }: TimerRootProps) => {
   const [useTimerProps, localProps] = splitRootProps(props, [
     'id',
     'ids',
@@ -35,6 +34,6 @@ export const TimerRoot = forwardRef<HTMLDivElement, TimerRootProps>((props, ref)
       <ark.div {...mergedProps} ref={ref} />
     </TimerProvider>
   )
-})
+}
 
 TimerRoot.displayName = 'TimerRoot'

--- a/packages/react/src/components/timer/timer-separator.tsx
+++ b/packages/react/src/components/timer/timer-separator.tsx
@@ -1,19 +1,18 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useTimerContext } from './use-timer-context'
 
 export interface TimerSeparatorBaseProps extends PolymorphicProps {}
 export interface TimerSeparatorProps extends HTMLProps<'div'>, TimerSeparatorBaseProps {}
 
-export const TimerSeparator = forwardRef<HTMLDivElement, TimerSeparatorProps>((props, ref) => {
+export const TimerSeparator = ({ ref, ...props }: TimerSeparatorProps) => {
   const timer = useTimerContext()
 
   const mergedProps = mergeProps(timer.getSeparatorProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 TimerSeparator.displayName = 'TimerSeparator'

--- a/packages/react/src/components/toast/toast-action-trigger.tsx
+++ b/packages/react/src/components/toast/toast-action-trigger.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useToastContext } from './use-toast-context'
 
 export interface ToastActionTriggerBaseProps extends PolymorphicProps {}
 export interface ToastActionTriggerProps extends HTMLProps<'button'>, ToastActionTriggerBaseProps {}
 
-export const ToastActionTrigger = forwardRef<HTMLButtonElement, ToastActionTriggerProps>((props, ref) => {
+export const ToastActionTrigger = ({ ref, ...props }: ToastActionTriggerProps) => {
   const toast = useToastContext()
   const mergedProps = mergeProps(toast.getActionTriggerProps(), props)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 ToastActionTrigger.displayName = 'ToastActionTrigger'

--- a/packages/react/src/components/toast/toast-close-trigger.tsx
+++ b/packages/react/src/components/toast/toast-close-trigger.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useToastContext } from './use-toast-context'
 
 export interface ToastCloseTriggerBaseProps extends PolymorphicProps {}
 export interface ToastCloseTriggerProps extends HTMLProps<'button'>, ToastCloseTriggerBaseProps {}
 
-export const ToastCloseTrigger = forwardRef<HTMLButtonElement, ToastCloseTriggerProps>((props, ref) => {
+export const ToastCloseTrigger = ({ ref, ...props }: ToastCloseTriggerProps) => {
   const toast = useToastContext()
   const mergedProps = mergeProps(toast.getCloseTriggerProps(), props)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 ToastCloseTrigger.displayName = 'ToastCloseTrigger'

--- a/packages/react/src/components/toast/toast-description.tsx
+++ b/packages/react/src/components/toast/toast-description.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useToastContext } from './use-toast-context'
 
 export interface ToastDescriptionBaseProps extends PolymorphicProps {}
 export interface ToastDescriptionProps extends HTMLProps<'div'>, ToastDescriptionBaseProps {}
 
-export const ToastDescription = forwardRef<HTMLDivElement, ToastDescriptionProps>((props, ref) => {
+export const ToastDescription = ({ ref, ...props }: ToastDescriptionProps) => {
   const toast = useToastContext()
   const mergedProps = mergeProps(toast.getDescriptionProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 ToastDescription.displayName = 'ToastDescription'

--- a/packages/react/src/components/toast/toast-root.tsx
+++ b/packages/react/src/components/toast/toast-root.tsx
@@ -1,14 +1,13 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import type { HTMLProps, PolymorphicProps } from '../factory'
 import { useToastContext } from './use-toast-context'
 
 export interface ToastRootBaseProps extends PolymorphicProps {}
 export interface ToastRootProps extends HTMLProps<'div'>, ToastRootBaseProps {}
 
-export const ToastRoot = forwardRef<HTMLDivElement, ToastRootProps>((props, ref) => {
+export const ToastRoot = ({ ref, ...props }: ToastRootProps) => {
   const toast = useToastContext()
   const mergedProps = mergeProps(toast.getRootProps(), props)
 
@@ -19,6 +18,6 @@ export const ToastRoot = forwardRef<HTMLDivElement, ToastRootProps>((props, ref)
       <div {...toast.getGhostAfterProps()} />
     </div>
   )
-})
+}
 
 ToastRoot.displayName = 'ToastRoot'

--- a/packages/react/src/components/toast/toast-title.tsx
+++ b/packages/react/src/components/toast/toast-title.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useToastContext } from './use-toast-context'
 
 export interface ToastTitleBaseProps extends PolymorphicProps {}
 export interface ToastTitleProps extends HTMLProps<'div'>, ToastTitleBaseProps {}
 
-export const ToastTitle = forwardRef<HTMLDivElement, ToastTitleProps>((props, ref) => {
+export const ToastTitle = ({ ref, ...props }: ToastTitleProps) => {
   const toast = useToastContext()
   const mergedProps = mergeProps(toast.getTitleProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 ToastTitle.displayName = 'ToastTitle'

--- a/packages/react/src/components/toast/toaster.tsx
+++ b/packages/react/src/components/toast/toaster.tsx
@@ -2,7 +2,7 @@
 
 import { mergeProps, normalizeProps, useMachine } from '@zag-js/react'
 import * as toast from '@zag-js/toast'
-import { type ReactNode, forwardRef, useId } from 'react'
+import { type ReactNode, useId } from 'react'
 import { useEnvironmentContext, useLocaleContext } from '../../providers'
 import type { Assign } from '../../types'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -18,7 +18,7 @@ export interface ToasterBaseProps extends PolymorphicProps, Omit<toast.GroupProp
 
 export interface ToasterProps extends Assign<HTMLProps<'div'>, ToasterBaseProps> {}
 
-export const Toaster = forwardRef<HTMLDivElement, ToasterProps>((props, ref) => {
+export const Toaster = ({ ref, ...props }: ToasterProps) => {
   const { toaster, children, ...localProps } = props
 
   const locale = useLocaleContext()
@@ -44,7 +44,7 @@ export const Toaster = forwardRef<HTMLDivElement, ToasterProps>((props, ref) => 
       ))}
     </ark.div>
   )
-})
+}
 
 Toaster.displayName = 'Toaster'
 

--- a/packages/react/src/components/toggle-group/toggle-group-item.tsx
+++ b/packages/react/src/components/toggle-group/toggle-group-item.tsx
@@ -2,7 +2,6 @@
 
 import { mergeProps } from '@zag-js/react'
 import type { ItemProps } from '@zag-js/toggle-group'
-import { forwardRef } from 'react'
 import type { Assign } from '../../types'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -13,12 +12,12 @@ export interface ToggleGroupItemProps extends Assign<HTMLProps<'button'>, Toggle
 
 const splitItemProps = createSplitProps<ItemProps>()
 
-export const ToggleGroupItem = forwardRef<HTMLButtonElement, ToggleGroupItemProps>((props, ref) => {
+export const ToggleGroupItem = ({ ref, ...props }: ToggleGroupItemProps) => {
   const [itemProps, localProps] = splitItemProps(props, ['value', 'disabled'])
   const toggleGroup = useToggleGroupContext()
   const mergedProps = mergeProps(toggleGroup.getItemProps(itemProps), localProps)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 ToggleGroupItem.displayName = 'ToggleGroupItem'

--- a/packages/react/src/components/toggle-group/toggle-group-root-provider.tsx
+++ b/packages/react/src/components/toggle-group/toggle-group-root-provider.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import type { UseToggleGroupReturn } from './use-toggle-group'
@@ -16,7 +15,7 @@ export interface ToggleGroupRootProviderProps extends HTMLProps<'div'>, ToggleGr
 
 const splitRootProviderProps = createSplitProps<RootProviderProps>()
 
-export const ToggleGroupRootProvider = forwardRef<HTMLDivElement, ToggleGroupRootProviderProps>((props, ref) => {
+export const ToggleGroupRootProvider = ({ ref, ...props }: ToggleGroupRootProviderProps) => {
   const [{ value: toggleGroup }, localProps] = splitRootProviderProps(props, ['value'])
   const mergedProps = mergeProps(toggleGroup.getRootProps(), localProps)
 
@@ -25,6 +24,6 @@ export const ToggleGroupRootProvider = forwardRef<HTMLDivElement, ToggleGroupRoo
       <ark.div {...mergedProps} ref={ref} />
     </ToggleGroupProvider>
   )
-})
+}
 
 ToggleGroupRootProvider.displayName = 'ToggleGroupRootProvider'

--- a/packages/react/src/components/toggle-group/toggle-group-root.tsx
+++ b/packages/react/src/components/toggle-group/toggle-group-root.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import type { Assign } from '../../types'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -13,7 +12,7 @@ export interface ToggleGroupRootProps extends Assign<HTMLProps<'div'>, ToggleGro
 
 const splitRootProps = createSplitProps<UseToggleGroupProps>()
 
-export const ToggleGroupRoot = forwardRef<HTMLDivElement, ToggleGroupRootProps>((props, ref) => {
+export const ToggleGroupRoot = ({ ref, ...props }: ToggleGroupRootProps) => {
   const [useToggleGroupProps, localProps] = splitRootProps(props, [
     'defaultValue',
     'deselectable',
@@ -35,6 +34,6 @@ export const ToggleGroupRoot = forwardRef<HTMLDivElement, ToggleGroupRootProps>(
       <ark.div {...mergedProps} ref={ref} />
     </ToggleGroupProvider>
   )
-})
+}
 
 ToggleGroupRoot.displayName = 'ToggleGroupRoot'

--- a/packages/react/src/components/toggle/toggle-indicator.tsx
+++ b/packages/react/src/components/toggle/toggle-indicator.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import type { HTMLArkProps } from '../factory'
 import { ark } from '../factory'
 import { useToggleContext } from './use-toggle-context'
@@ -15,7 +14,7 @@ export interface ToggleIndicatorBaseProps {
 
 export interface ToggleIndicatorProps extends HTMLArkProps<'div'>, ToggleIndicatorBaseProps {}
 
-export const ToggleIndicator = forwardRef<HTMLDivElement, ToggleIndicatorProps>((props, ref) => {
+export const ToggleIndicator = ({ ref, ...props }: ToggleIndicatorProps) => {
   const { children, fallback, ...restProps } = props
   const toggle = useToggleContext()
   const mergedProps = mergeProps(toggle.getIndicatorProps(), restProps)
@@ -24,6 +23,6 @@ export const ToggleIndicator = forwardRef<HTMLDivElement, ToggleIndicatorProps>(
       {toggle.pressed ? children : fallback}
     </ark.div>
   )
-})
+}
 
 ToggleIndicator.displayName = 'ToggleIndicator'

--- a/packages/react/src/components/toggle/toggle-root.tsx
+++ b/packages/react/src/components/toggle/toggle-root.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import type { HTMLProps, PolymorphicProps } from '../factory'
 import { ark } from '../factory'
@@ -14,7 +13,7 @@ export interface ToggleRootProps extends HTMLProps<'button'>, ToggleRootBaseProp
 
 const splitRootProps = createSplitProps<UseToggleProps>()
 
-export const ToggleRoot = forwardRef<HTMLButtonElement, ToggleRootProps>((props, ref) => {
+export const ToggleRoot = ({ ref, ...props }: ToggleRootProps) => {
   const [useToggleProps, localProps] = splitRootProps(props, [
     'pressed',
     'defaultPressed',
@@ -30,6 +29,6 @@ export const ToggleRoot = forwardRef<HTMLButtonElement, ToggleRootProps>((props,
       <ark.button {...mergedProps} ref={ref} />
     </ToggleProvider>
   )
-})
+}
 
 ToggleRoot.displayName = 'ToggleRoot'

--- a/packages/react/src/components/tooltip/tooltip-arrow-tip.tsx
+++ b/packages/react/src/components/tooltip/tooltip-arrow-tip.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useTooltipContext } from './use-tooltip-context'
 
 export interface TooltipArrowTipBaseProps extends PolymorphicProps {}
 export interface TooltipArrowTipProps extends HTMLProps<'div'>, TooltipArrowTipBaseProps {}
 
-export const TooltipArrowTip = forwardRef<HTMLDivElement, TooltipArrowTipProps>((props, ref) => {
+export const TooltipArrowTip = ({ ref, ...props }: TooltipArrowTipProps) => {
   const tooltip = useTooltipContext()
   const mergedProps = mergeProps(tooltip.getArrowTipProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 TooltipArrowTip.displayName = 'TooltipArrowTip'

--- a/packages/react/src/components/tooltip/tooltip-arrow.tsx
+++ b/packages/react/src/components/tooltip/tooltip-arrow.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useTooltipContext } from './use-tooltip-context'
 
 export interface TooltipArrowBaseProps extends PolymorphicProps {}
 export interface TooltipArrowProps extends HTMLProps<'div'>, TooltipArrowBaseProps {}
 
-export const TooltipArrow = forwardRef<HTMLDivElement, TooltipArrowProps>((props, ref) => {
+export const TooltipArrow = ({ ref, ...props }: TooltipArrowProps) => {
   const tooltip = useTooltipContext()
   const mergedProps = mergeProps(tooltip.getArrowProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 TooltipArrow.displayName = 'TooltipArrow'

--- a/packages/react/src/components/tooltip/tooltip-content.tsx
+++ b/packages/react/src/components/tooltip/tooltip-content.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { composeRefs } from '../../utils/compose-refs'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { usePresenceContext } from '../presence'
@@ -10,7 +9,7 @@ import { useTooltipContext } from './use-tooltip-context'
 export interface TooltipContentBaseProps extends PolymorphicProps {}
 export interface TooltipContentProps extends HTMLProps<'div'>, TooltipContentBaseProps {}
 
-export const TooltipContent = forwardRef<HTMLDivElement, TooltipContentProps>((props, ref) => {
+export const TooltipContent = ({ ref, ...props }: TooltipContentProps) => {
   const tooltip = useTooltipContext()
   const presence = usePresenceContext()
   const mergedProps = mergeProps(tooltip.getContentProps(), presence.getPresenceProps(), props)
@@ -20,6 +19,6 @@ export const TooltipContent = forwardRef<HTMLDivElement, TooltipContentProps>((p
   }
 
   return <ark.div {...mergedProps} ref={composeRefs(presence.ref, ref)} />
-})
+}
 
 TooltipContent.displayName = 'TooltipContent'

--- a/packages/react/src/components/tooltip/tooltip-positioner.tsx
+++ b/packages/react/src/components/tooltip/tooltip-positioner.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { usePresenceContext } from '../presence'
 import { useTooltipContext } from './use-tooltip-context'
@@ -9,7 +8,7 @@ import { useTooltipContext } from './use-tooltip-context'
 export interface TooltipPositionerBaseProps extends PolymorphicProps {}
 export interface TooltipPositionerProps extends HTMLProps<'div'>, TooltipPositionerBaseProps {}
 
-export const TooltipPositioner = forwardRef<HTMLDivElement, TooltipPositionerProps>((props, ref) => {
+export const TooltipPositioner = ({ ref, ...props }: TooltipPositionerProps) => {
   const tooltip = useTooltipContext()
   const mergedProps = mergeProps(tooltip.getPositionerProps(), props)
   const presence = usePresenceContext()
@@ -19,6 +18,6 @@ export const TooltipPositioner = forwardRef<HTMLDivElement, TooltipPositionerPro
   }
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 TooltipPositioner.displayName = 'TooltipPositioner'

--- a/packages/react/src/components/tooltip/tooltip-trigger.tsx
+++ b/packages/react/src/components/tooltip/tooltip-trigger.tsx
@@ -2,7 +2,6 @@
 
 import { mergeProps } from '@zag-js/react'
 import type { TriggerProps } from '@zag-js/tooltip'
-import { forwardRef } from 'react'
 import type { Assign } from '../../types'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -13,12 +12,12 @@ export interface TooltipTriggerProps extends Assign<HTMLProps<'button'>, Tooltip
 
 const splitTriggerProps = createSplitProps<TriggerProps>()
 
-export const TooltipTrigger = forwardRef<HTMLButtonElement, TooltipTriggerProps>((props, ref) => {
+export const TooltipTrigger = ({ ref, ...props }: TooltipTriggerProps) => {
   const [triggerProps, localProps] = splitTriggerProps(props, ['value'])
   const tooltip = useTooltipContext()
   const mergedProps = mergeProps(tooltip.getTriggerProps(triggerProps), localProps)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 TooltipTrigger.displayName = 'TooltipTrigger'

--- a/packages/react/src/components/tour/tour-action-trigger.tsx
+++ b/packages/react/src/components/tour/tour-action-trigger.tsx
@@ -2,7 +2,6 @@
 
 import { mergeProps } from '@zag-js/react'
 import type { StepActionTriggerProps } from '@zag-js/tour'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useTourContext } from './use-tour-context'
@@ -12,7 +11,7 @@ export interface TourActionTriggerProps extends HTMLProps<'button'>, TourActionT
 
 const splitActionTriggerProps = createSplitProps<StepActionTriggerProps>()
 
-export const TourActionTrigger = forwardRef<HTMLButtonElement, TourActionTriggerProps>((props, ref) => {
+export const TourActionTrigger = ({ ref, ...props }: TourActionTriggerProps) => {
   const [actionTriggerProps, localProps] = splitActionTriggerProps(props, ['action'])
   const tour = useTourContext()
   const mergedProps = mergeProps(tour.getActionTriggerProps(actionTriggerProps), localProps)
@@ -22,6 +21,6 @@ export const TourActionTrigger = forwardRef<HTMLButtonElement, TourActionTrigger
       {mergedProps.children || actionTriggerProps.action.label}
     </ark.button>
   )
-})
+}
 
 TourActionTrigger.displayName = 'TourActionTrigger'

--- a/packages/react/src/components/tour/tour-arrow-tip.tsx
+++ b/packages/react/src/components/tour/tour-arrow-tip.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useTourContext } from './use-tour-context'
 
 export interface TourArrowTipBaseProps extends PolymorphicProps {}
 export interface TourArrowTipProps extends HTMLProps<'div'>, TourArrowTipBaseProps {}
 
-export const TourArrowTip = forwardRef<HTMLDivElement, TourArrowTipProps>((props, ref) => {
+export const TourArrowTip = ({ ref, ...props }: TourArrowTipProps) => {
   const tour = useTourContext()
   const mergedProps = mergeProps(tour.getArrowTipProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 TourArrowTip.displayName = 'TourArrowTip'

--- a/packages/react/src/components/tour/tour-arrow.tsx
+++ b/packages/react/src/components/tour/tour-arrow.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useTourContext } from './use-tour-context'
 
 export interface TourArrowBaseProps extends PolymorphicProps {}
 export interface TourArrowProps extends HTMLProps<'div'>, TourArrowBaseProps {}
 
-export const TourArrow = forwardRef<HTMLDivElement, TourArrowProps>((props, ref) => {
+export const TourArrow = ({ ref, ...props }: TourArrowProps) => {
   const tour = useTourContext()
   const mergedProps = mergeProps(tour.getArrowProps(), props)
 
   return tour.step?.arrow ? <ark.div {...mergedProps} ref={ref} /> : null
-})
+}
 
 TourArrow.displayName = 'TourArrow'

--- a/packages/react/src/components/tour/tour-backdrop.tsx
+++ b/packages/react/src/components/tour/tour-backdrop.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { composeRefs } from '../../utils/compose-refs'
 import { useRenderStrategyPropsContext } from '../../utils/render-strategy'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -11,7 +10,7 @@ import { useTourContext } from './use-tour-context'
 export interface TourBackdropBaseProps extends PolymorphicProps {}
 export interface TourBackdropProps extends HTMLProps<'div'>, TourBackdropBaseProps {}
 
-export const TourBackdrop = forwardRef<HTMLDivElement, TourBackdropProps>((props, ref) => {
+export const TourBackdrop = ({ ref, ...props }: TourBackdropProps) => {
   const tour = useTourContext()
   const renderStrategyProps = useRenderStrategyPropsContext()
   const presence = usePresence({
@@ -25,6 +24,6 @@ export const TourBackdrop = forwardRef<HTMLDivElement, TourBackdropProps>((props
   }
 
   return <ark.div {...mergedProps} ref={composeRefs(presence.ref, ref)} hidden={!tour.step?.backdrop} />
-})
+}
 
 TourBackdrop.displayName = 'TourBackdrop'

--- a/packages/react/src/components/tour/tour-close-trigger.tsx
+++ b/packages/react/src/components/tour/tour-close-trigger.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useTourContext } from './use-tour-context'
 
 export interface TourCloseTriggerBaseProps extends PolymorphicProps {}
 export interface TourCloseTriggerProps extends HTMLProps<'button'>, TourCloseTriggerBaseProps {}
 
-export const TourCloseTrigger = forwardRef<HTMLButtonElement, TourCloseTriggerProps>((props, ref) => {
+export const TourCloseTrigger = ({ ref, ...props }: TourCloseTriggerProps) => {
   const tour = useTourContext()
   const mergedProps = mergeProps(tour.getCloseTriggerProps(), props)
 
   return <ark.button {...mergedProps} ref={ref} />
-})
+}
 
 TourCloseTrigger.displayName = 'TourCloseTrigger'

--- a/packages/react/src/components/tour/tour-content.tsx
+++ b/packages/react/src/components/tour/tour-content.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { composeRefs } from '../../utils/compose-refs'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { usePresenceContext } from '../presence'
@@ -10,7 +9,7 @@ import { useTourContext } from './use-tour-context'
 export interface TourContentBaseProps extends PolymorphicProps {}
 export interface TourContentProps extends HTMLProps<'div'>, TourContentBaseProps {}
 
-export const TourContent = forwardRef<HTMLDivElement, TourContentProps>((props, ref) => {
+export const TourContent = ({ ref, ...props }: TourContentProps) => {
   const tour = useTourContext()
   const presence = usePresenceContext()
   const mergedProps = mergeProps(tour.getContentProps(), presence.getPresenceProps(), props)
@@ -20,6 +19,6 @@ export const TourContent = forwardRef<HTMLDivElement, TourContentProps>((props, 
   }
 
   return <ark.div {...mergedProps} ref={composeRefs(presence.ref, ref)} />
-})
+}
 
 TourContent.displayName = 'TourContent'

--- a/packages/react/src/components/tour/tour-control.tsx
+++ b/packages/react/src/components/tour/tour-control.tsx
@@ -1,14 +1,16 @@
 'use client'
 
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { tourAnatomy } from './tour.anatomy'
 
 export interface TourControlBaseProps extends PolymorphicProps {}
 export interface TourControlProps extends HTMLProps<'div'>, TourControlBaseProps {}
 
-export const TourControl = forwardRef<HTMLDivElement, TourControlProps>((props, ref) => (
-  <ark.div {...tourAnatomy.build().control.attrs} {...props} ref={ref} />
-))
+export const TourControl = ({
+  ref,
+  ...props
+}: TourControlProps & {
+  ref: React.RefObject<HTMLDivElement>
+}) => <ark.div {...tourAnatomy.build().control.attrs} {...props} ref={ref} />
 
 TourControl.displayName = 'TourControl'

--- a/packages/react/src/components/tour/tour-description.tsx
+++ b/packages/react/src/components/tour/tour-description.tsx
@@ -1,14 +1,13 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useTourContext } from './use-tour-context'
 
 export interface TourDescriptionBaseProps extends PolymorphicProps {}
 export interface TourDescriptionProps extends HTMLProps<'div'>, TourDescriptionBaseProps {}
 
-export const TourDescription = forwardRef<HTMLDivElement, TourDescriptionProps>((props, ref) => {
+export const TourDescription = ({ ref, ...props }: TourDescriptionProps) => {
   const tour = useTourContext()
   const mergedProps = mergeProps(tour.getDescriptionProps(), props)
 
@@ -17,6 +16,6 @@ export const TourDescription = forwardRef<HTMLDivElement, TourDescriptionProps>(
       {mergedProps.children || tour.step?.description}
     </ark.div>
   )
-})
+}
 
 TourDescription.displayName = 'TourDescription'

--- a/packages/react/src/components/tour/tour-positioner.tsx
+++ b/packages/react/src/components/tour/tour-positioner.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { usePresenceContext } from '../presence'
 import { useTourContext } from './use-tour-context'
@@ -9,7 +8,7 @@ import { useTourContext } from './use-tour-context'
 export interface TourPositionerBaseProps extends PolymorphicProps {}
 export interface TourPositionerProps extends HTMLProps<'div'>, TourPositionerBaseProps {}
 
-export const TourPositioner = forwardRef<HTMLDivElement, TourPositionerProps>((props, ref) => {
+export const TourPositioner = ({ ref, ...props }: TourPositionerProps) => {
   const tour = useTourContext()
   const mergedProps = mergeProps(tour.getPositionerProps(), props)
   const presence = usePresenceContext()
@@ -19,6 +18,6 @@ export const TourPositioner = forwardRef<HTMLDivElement, TourPositionerProps>((p
   }
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 TourPositioner.displayName = 'TourPositioner'

--- a/packages/react/src/components/tour/tour-progress-text.tsx
+++ b/packages/react/src/components/tour/tour-progress-text.tsx
@@ -1,14 +1,13 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useTourContext } from './use-tour-context'
 
 export interface TourProgressTextBaseProps extends PolymorphicProps {}
 export interface TourProgressTextProps extends HTMLProps<'div'>, TourProgressTextBaseProps {}
 
-export const TourProgressText = forwardRef<HTMLDivElement, TourProgressTextProps>((props, ref) => {
+export const TourProgressText = ({ ref, ...props }: TourProgressTextProps) => {
   const tour = useTourContext()
   const mergedProps = mergeProps(tour.getProgressTextProps(), props)
 
@@ -17,6 +16,6 @@ export const TourProgressText = forwardRef<HTMLDivElement, TourProgressTextProps
       {mergedProps.children || tour.getProgressText()}
     </ark.div>
   )
-})
+}
 
 TourProgressText.displayName = 'TourProgressText'

--- a/packages/react/src/components/tour/tour-spotlight.tsx
+++ b/packages/react/src/components/tour/tour-spotlight.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { composeRefs } from '../../utils/compose-refs'
 import { useRenderStrategyPropsContext } from '../../utils/render-strategy'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
@@ -11,7 +10,7 @@ import { useTourContext } from './use-tour-context'
 export interface TourSpotlightBaseProps extends PolymorphicProps {}
 export interface TourSpotlightProps extends HTMLProps<'div'>, TourSpotlightBaseProps {}
 
-export const TourSpotlight = forwardRef<HTMLDivElement, TourSpotlightProps>((props, ref) => {
+export const TourSpotlight = ({ ref, ...props }: TourSpotlightProps) => {
   const tour = useTourContext()
   const renderStrategyProps = useRenderStrategyPropsContext()
   const presence = usePresence({
@@ -26,6 +25,6 @@ export const TourSpotlight = forwardRef<HTMLDivElement, TourSpotlightProps>((pro
   }
 
   return <ark.div {...mergedProps} ref={composeRefs(presence.ref, ref)} hidden={hidden} />
-})
+}
 
 TourSpotlight.displayName = 'TourSpotlight'

--- a/packages/react/src/components/tour/tour-title.tsx
+++ b/packages/react/src/components/tour/tour-title.tsx
@@ -1,14 +1,13 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useTourContext } from './use-tour-context'
 
 export interface TourTitleBaseProps extends PolymorphicProps {}
 export interface TourTitleProps extends HTMLProps<'h2'>, TourTitleBaseProps {}
 
-export const TourTitle = forwardRef<HTMLHeadingElement, TourTitleProps>((props, ref) => {
+export const TourTitle = ({ ref, ...props }: TourTitleProps) => {
   const tour = useTourContext()
   const mergedProps = mergeProps(tour.getTitleProps(), props)
 
@@ -17,6 +16,6 @@ export const TourTitle = forwardRef<HTMLHeadingElement, TourTitleProps>((props, 
       {mergedProps.children || tour.step?.title}
     </ark.h2>
   )
-})
+}
 
 TourTitle.displayName = 'TourTitle'

--- a/packages/react/src/components/tree-view/index.ts
+++ b/packages/react/src/components/tree-view/index.ts
@@ -58,17 +58,10 @@ export {
   type TreeViewNodeProviderBaseProps,
   type TreeViewNodeProviderProps,
 } from './tree-view-node-provider'
-export {
-  TreeViewRoot,
-  type TreeViewRootBaseProps,
-  type TreeViewRootComponent,
-  type TreeViewRootComponentProps,
-  type TreeViewRootProps,
-} from './tree-view-root'
+export { TreeViewRoot, type TreeViewRootBaseProps, type TreeViewRootProps } from './tree-view-root'
 export {
   TreeViewRootProvider,
   type TreeViewRootProviderBaseProps,
-  type TreeViewRootProviderComponent,
   type TreeViewRootProviderProps,
 } from './tree-view-root-provider'
 export { TreeViewTree, type TreeViewTreeBaseProps, type TreeViewTreeProps } from './tree-view-tree'

--- a/packages/react/src/components/tree-view/tree-view-branch-content.tsx
+++ b/packages/react/src/components/tree-view/tree-view-branch-content.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import { Collapsible } from '../collapsible'
 import type { HTMLProps, PolymorphicProps } from '../factory'
@@ -18,7 +17,7 @@ interface VisibilityProps {
 
 const splitVisibilityProps = createSplitProps<VisibilityProps>()
 
-export const TreeViewBranchContent = forwardRef<HTMLDivElement, TreeViewBranchContentProps>((props, ref) => {
+export const TreeViewBranchContent = ({ ref, ...props }: TreeViewBranchContentProps) => {
   const treeView = useTreeViewContext()
   const nodeProps = useTreeViewNodePropsContext()
   const contentProps = treeView.getBranchContentProps(nodeProps)
@@ -27,6 +26,6 @@ export const TreeViewBranchContent = forwardRef<HTMLDivElement, TreeViewBranchCo
   const mergedProps = mergeProps(branchContentProps, props)
 
   return <Collapsible.Content ref={ref} {...mergedProps} />
-})
+}
 
 TreeViewBranchContent.displayName = 'TreeViewBranchContent'

--- a/packages/react/src/components/tree-view/tree-view-branch-control.tsx
+++ b/packages/react/src/components/tree-view/tree-view-branch-control.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useTreeViewContext } from './use-tree-view-context'
 import { useTreeViewNodePropsContext } from './use-tree-view-node-props-context'
@@ -9,12 +8,12 @@ import { useTreeViewNodePropsContext } from './use-tree-view-node-props-context'
 export interface TreeViewBranchControlBaseProps extends PolymorphicProps {}
 export interface TreeViewBranchControlProps extends HTMLProps<'div'>, TreeViewBranchControlBaseProps {}
 
-export const TreeViewBranchControl = forwardRef<HTMLDivElement, TreeViewBranchControlProps>((props, ref) => {
+export const TreeViewBranchControl = ({ ref, ...props }: TreeViewBranchControlProps) => {
   const treeView = useTreeViewContext()
   const nodeProps = useTreeViewNodePropsContext()
   const mergedProps = mergeProps(treeView.getBranchControlProps(nodeProps), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 TreeViewBranchControl.displayName = 'TreeViewBranchControl'

--- a/packages/react/src/components/tree-view/tree-view-branch-indent-guide.tsx
+++ b/packages/react/src/components/tree-view/tree-view-branch-indent-guide.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useTreeViewContext } from './use-tree-view-context'
 import { useTreeViewNodePropsContext } from './use-tree-view-node-props-context'
@@ -9,12 +8,12 @@ import { useTreeViewNodePropsContext } from './use-tree-view-node-props-context'
 export interface TreeViewBranchIndentGuideBaseProps extends PolymorphicProps {}
 export interface TreeViewBranchIndentGuideProps extends HTMLProps<'div'>, TreeViewBranchIndentGuideBaseProps {}
 
-export const TreeViewBranchIndentGuide = forwardRef<HTMLDivElement, TreeViewBranchIndentGuideProps>((props, ref) => {
+export const TreeViewBranchIndentGuide = ({ ref, ...props }: TreeViewBranchIndentGuideProps) => {
   const treeView = useTreeViewContext()
   const nodeProps = useTreeViewNodePropsContext()
   const mergedProps = mergeProps(treeView.getBranchIndentGuideProps(nodeProps), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 TreeViewBranchIndentGuide.displayName = 'TreeViewBranchIndentGuide'

--- a/packages/react/src/components/tree-view/tree-view-branch-indicator.tsx
+++ b/packages/react/src/components/tree-view/tree-view-branch-indicator.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useTreeViewContext } from './use-tree-view-context'
 import { useTreeViewNodePropsContext } from './use-tree-view-node-props-context'
@@ -9,12 +8,12 @@ import { useTreeViewNodePropsContext } from './use-tree-view-node-props-context'
 export interface TreeViewBranchIndicatorBaseProps extends PolymorphicProps {}
 export interface TreeViewBranchIndicatorProps extends HTMLProps<'div'>, TreeViewBranchIndicatorBaseProps {}
 
-export const TreeViewBranchIndicator = forwardRef<HTMLDivElement, TreeViewBranchIndicatorProps>((props, ref) => {
+export const TreeViewBranchIndicator = ({ ref, ...props }: TreeViewBranchIndicatorProps) => {
   const treeView = useTreeViewContext()
   const nodeProps = useTreeViewNodePropsContext()
   const mergedProps = mergeProps(treeView.getBranchIndicatorProps(nodeProps), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 TreeViewBranchIndicator.displayName = 'TreeViewBranchIndicator'

--- a/packages/react/src/components/tree-view/tree-view-branch-text.tsx
+++ b/packages/react/src/components/tree-view/tree-view-branch-text.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useTreeViewContext } from './use-tree-view-context'
 import { useTreeViewNodePropsContext } from './use-tree-view-node-props-context'
@@ -9,12 +8,12 @@ import { useTreeViewNodePropsContext } from './use-tree-view-node-props-context'
 export interface TreeViewBranchTextBaseProps extends PolymorphicProps {}
 export interface TreeViewBranchTextProps extends HTMLProps<'span'>, TreeViewBranchTextBaseProps {}
 
-export const TreeViewBranchText = forwardRef<HTMLSpanElement, TreeViewBranchTextProps>((props, ref) => {
+export const TreeViewBranchText = ({ ref, ...props }: TreeViewBranchTextProps) => {
   const treeView = useTreeViewContext()
   const nodeProps = useTreeViewNodePropsContext()
   const mergedProps = mergeProps(treeView.getBranchTextProps(nodeProps), props)
 
   return <ark.span {...mergedProps} ref={ref} />
-})
+}
 
 TreeViewBranchText.displayName = 'TreeViewBranchText'

--- a/packages/react/src/components/tree-view/tree-view-branch-trigger.tsx
+++ b/packages/react/src/components/tree-view/tree-view-branch-trigger.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useTreeViewContext } from './use-tree-view-context'
 import { useTreeViewNodePropsContext } from './use-tree-view-node-props-context'
@@ -9,12 +8,12 @@ import { useTreeViewNodePropsContext } from './use-tree-view-node-props-context'
 export interface TreeViewBranchTriggerBaseProps extends PolymorphicProps {}
 export interface TreeViewBranchTriggerProps extends HTMLProps<'div'>, TreeViewBranchTriggerBaseProps {}
 
-export const TreeViewBranchTrigger = forwardRef<HTMLDivElement, TreeViewBranchTriggerProps>((props, ref) => {
+export const TreeViewBranchTrigger = ({ ref, ...props }: TreeViewBranchTriggerProps) => {
   const treeView = useTreeViewContext()
   const nodeProps = useTreeViewNodePropsContext()
   const mergedProps = mergeProps(treeView.getBranchTriggerProps(nodeProps), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 TreeViewBranchTrigger.displayName = 'TreeViewBranchTrigger'

--- a/packages/react/src/components/tree-view/tree-view-branch.tsx
+++ b/packages/react/src/components/tree-view/tree-view-branch.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import type { Assign } from '../../types'
 import { useRenderStrategyPropsContext } from '../../utils/render-strategy'
 import { Collapsible } from '../collapsible'
@@ -13,7 +12,7 @@ import { useTreeViewNodePropsContext } from './use-tree-view-node-props-context'
 export interface TreeViewBranchBaseProps extends PolymorphicProps {}
 export interface TreeViewBranchProps extends Assign<HTMLProps<'div'>, TreeViewBranchBaseProps> {}
 
-export const TreeViewBranch = forwardRef<HTMLDivElement, TreeViewBranchProps>((props, ref) => {
+export const TreeViewBranch = ({ ref, ...props }: TreeViewBranchProps) => {
   const treeView = useTreeViewContext()
   const nodeProps = useTreeViewNodePropsContext()
   const nodeState = useTreeViewNodeContext()
@@ -30,6 +29,6 @@ export const TreeViewBranch = forwardRef<HTMLDivElement, TreeViewBranchProps>((p
       {...mergedProps}
     />
   )
-})
+}
 
 TreeViewBranch.displayName = 'TreeViewBranch'

--- a/packages/react/src/components/tree-view/tree-view-item-indicator.tsx
+++ b/packages/react/src/components/tree-view/tree-view-item-indicator.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useTreeViewContext } from './use-tree-view-context'
 import { useTreeViewNodePropsContext } from './use-tree-view-node-props-context'
@@ -9,12 +8,12 @@ import { useTreeViewNodePropsContext } from './use-tree-view-node-props-context'
 export interface TreeViewItemIndicatorBaseProps extends PolymorphicProps {}
 export interface TreeViewItemIndicatorProps extends HTMLProps<'div'>, TreeViewItemIndicatorBaseProps {}
 
-export const TreeViewItemIndicator = forwardRef<HTMLDivElement, TreeViewItemIndicatorProps>((props, ref) => {
+export const TreeViewItemIndicator = ({ ref, ...props }: TreeViewItemIndicatorProps) => {
   const treeView = useTreeViewContext()
   const nodeProps = useTreeViewNodePropsContext()
   const mergedProps = mergeProps(treeView.getItemIndicatorProps(nodeProps), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 TreeViewItemIndicator.displayName = 'TreeViewItemIndicator'

--- a/packages/react/src/components/tree-view/tree-view-item-text.tsx
+++ b/packages/react/src/components/tree-view/tree-view-item-text.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useTreeViewContext } from './use-tree-view-context'
 import { useTreeViewNodePropsContext } from './use-tree-view-node-props-context'
@@ -9,12 +8,12 @@ import { useTreeViewNodePropsContext } from './use-tree-view-node-props-context'
 export interface TreeViewItemTextBaseProps extends PolymorphicProps {}
 export interface TreeViewItemTextProps extends HTMLProps<'span'>, TreeViewItemTextBaseProps {}
 
-export const TreeViewItemText = forwardRef<HTMLSpanElement, TreeViewItemTextProps>((props, ref) => {
+export const TreeViewItemText = ({ ref, ...props }: TreeViewItemTextProps) => {
   const treeView = useTreeViewContext()
   const nodeProps = useTreeViewNodePropsContext()
   const mergedProps = mergeProps(treeView.getItemTextProps(nodeProps), props)
 
   return <ark.span {...mergedProps} ref={ref} />
-})
+}
 
 TreeViewItemText.displayName = 'TreeViewItemText'

--- a/packages/react/src/components/tree-view/tree-view-item.tsx
+++ b/packages/react/src/components/tree-view/tree-view-item.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import type { Assign } from '../../types'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useTreeViewContext } from './use-tree-view-context'
@@ -10,12 +9,12 @@ import { useTreeViewNodePropsContext } from './use-tree-view-node-props-context'
 export interface TreeViewItemBaseProps extends PolymorphicProps {}
 export interface TreeViewItemProps extends Assign<HTMLProps<'div'>, TreeViewItemBaseProps> {}
 
-export const TreeViewItem = forwardRef<HTMLDivElement, TreeViewItemProps>((props, ref) => {
+export const TreeViewItem = ({ ref, ...props }: TreeViewItemProps) => {
   const treeView = useTreeViewContext()
   const nodeProps = useTreeViewNodePropsContext()
   const mergedProps = mergeProps(treeView.getItemProps(nodeProps), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 TreeViewItem.displayName = 'TreeViewItem'

--- a/packages/react/src/components/tree-view/tree-view-label.tsx
+++ b/packages/react/src/components/tree-view/tree-view-label.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useTreeViewContext } from './use-tree-view-context'
 
 export interface TreeViewLabelBaseProps extends PolymorphicProps {}
 export interface TreeViewLabelProps extends HTMLProps<'h3'>, TreeViewLabelBaseProps {}
 
-export const TreeViewLabel = forwardRef<HTMLHeadingElement, TreeViewLabelProps>((props, ref) => {
+export const TreeViewLabel = ({ ref, ...props }: TreeViewLabelProps) => {
   const treeView = useTreeViewContext()
   const mergedProps = mergeProps(treeView.getLabelProps(), props)
 
   return <ark.h3 {...mergedProps} ref={ref} />
-})
+}
 
 TreeViewLabel.displayName = 'TreeViewLabel'

--- a/packages/react/src/components/tree-view/tree-view-node-checkbox.tsx
+++ b/packages/react/src/components/tree-view/tree-view-node-checkbox.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useTreeViewContext } from './use-tree-view-context'
 import { useTreeViewNodePropsContext } from './use-tree-view-node-props-context'
@@ -9,12 +8,12 @@ import { useTreeViewNodePropsContext } from './use-tree-view-node-props-context'
 export interface TreeViewNodeCheckboxBaseProps extends PolymorphicProps {}
 export interface TreeViewNodeCheckboxProps extends HTMLProps<'span'>, TreeViewNodeCheckboxBaseProps {}
 
-export const TreeViewNodeCheckbox = forwardRef<HTMLSpanElement, TreeViewNodeCheckboxProps>((props, ref) => {
+export const TreeViewNodeCheckbox = ({ ref, ...props }: TreeViewNodeCheckboxProps) => {
   const treeView = useTreeViewContext()
   const nodeProps = useTreeViewNodePropsContext()
   const mergedProps = mergeProps(treeView.getNodeCheckboxProps(nodeProps), props)
 
   return <ark.span {...mergedProps} ref={ref} />
-})
+}
 
 TreeViewNodeCheckbox.displayName = 'TreeViewNodeCheckbox'

--- a/packages/react/src/components/tree-view/tree-view-node-rename-input.tsx
+++ b/packages/react/src/components/tree-view/tree-view-node-rename-input.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import type { Assign } from '../../types'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useTreeViewContext } from './use-tree-view-context'
@@ -10,12 +9,12 @@ import { useTreeViewNodePropsContext } from './use-tree-view-node-props-context'
 export interface TreeViewNodeRenameInputBaseProps extends PolymorphicProps {}
 export interface TreeViewNodeRenameInputProps extends Assign<HTMLProps<'input'>, TreeViewNodeRenameInputBaseProps> {}
 
-export const TreeViewNodeRenameInput = forwardRef<HTMLInputElement, TreeViewNodeRenameInputProps>((props, ref) => {
+export const TreeViewNodeRenameInput = ({ ref, ...props }: TreeViewNodeRenameInputProps) => {
   const treeView = useTreeViewContext()
   const nodeProps = useTreeViewNodePropsContext()
   const mergedProps = mergeProps(treeView.getNodeRenameInputProps(nodeProps), props)
 
   return <ark.input {...mergedProps} ref={ref} />
-})
+}
 
 TreeViewNodeRenameInput.displayName = 'TreeViewNodeRenameInput'

--- a/packages/react/src/components/tree-view/tree-view-root-provider.tsx
+++ b/packages/react/src/components/tree-view/tree-view-root-provider.tsx
@@ -1,8 +1,7 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { type JSX, forwardRef } from 'react'
-import type { Assign } from '../../types'
+import type { JSX } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import {
   type RenderStrategyProps,
@@ -17,12 +16,17 @@ import { TreeViewProvider } from './use-tree-view-context'
 interface RootProviderProps<T extends TreeNode> {
   value: UseTreeViewReturn<T>
 }
+
 export interface TreeViewRootProviderBaseProps<T extends TreeNode>
   extends RootProviderProps<T>, RenderStrategyProps, PolymorphicProps {}
+
 export interface TreeViewRootProviderProps<T extends TreeNode>
   extends HTMLProps<'div'>, TreeViewRootProviderBaseProps<T> {}
 
-const TreeViewImpl = <T extends TreeNode>(props: TreeViewRootProviderProps<T>, ref: React.Ref<HTMLDivElement>) => {
+export const TreeViewRootProvider = <T extends TreeNode>({
+  ref,
+  ...props
+}: TreeViewRootProviderProps<T>): JSX.Element => {
   const [renderStrategyProps, treeViewProps] = splitRenderStrategyProps(props)
   const [{ value: treeView }, localProps] = createSplitProps<RootProviderProps<T>>()(treeViewProps, ['value'])
   const mergedProps = mergeProps(treeView.getRootProps(), localProps)
@@ -35,9 +39,3 @@ const TreeViewImpl = <T extends TreeNode>(props: TreeViewRootProviderProps<T>, r
     </TreeViewProvider>
   )
 }
-
-export type TreeViewRootProviderComponent<P = {}> = <T extends TreeNode>(
-  props: Assign<TreeViewRootProviderProps<T>, P> & React.RefAttributes<HTMLDivElement>,
-) => JSX.Element
-
-export const TreeViewRootProvider = forwardRef(TreeViewImpl) as TreeViewRootProviderComponent

--- a/packages/react/src/components/tree-view/tree-view-root.tsx
+++ b/packages/react/src/components/tree-view/tree-view-root.tsx
@@ -1,8 +1,7 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { type JSX, forwardRef } from 'react'
-import type { Assign } from '../../types'
+import type { JSX } from 'react'
 import { createSplitProps } from '../../utils/create-split-props'
 import {
   type RenderStrategyProps,
@@ -18,7 +17,7 @@ export interface TreeViewRootBaseProps<T extends TreeNode>
   extends UseTreeViewProps<T>, RenderStrategyProps, PolymorphicProps {}
 export interface TreeViewRootProps<T extends TreeNode> extends HTMLProps<'div'>, TreeViewRootBaseProps<T> {}
 
-const TreeViewImpl = <T extends TreeNode>(props: TreeViewRootProps<T>, ref: React.Ref<HTMLDivElement>) => {
+export const TreeViewRoot = <T extends TreeNode>({ ref, ...props }: TreeViewRootProps<T>): JSX.Element => {
   const [renderStrategyProps, treeViewProps] = splitRenderStrategyProps(props)
   const [useTreeViewProps, localProps] = createSplitProps<UseTreeViewProps<T>>()(treeViewProps, [
     'canRename',
@@ -61,10 +60,3 @@ const TreeViewImpl = <T extends TreeNode>(props: TreeViewRootProps<T>, ref: Reac
     </TreeViewProvider>
   )
 }
-
-export type TreeViewRootComponentProps<T extends TreeNode = TreeNode, P = {}> = Assign<TreeViewRootProps<T>, P> &
-  React.RefAttributes<HTMLDivElement>
-
-export type TreeViewRootComponent<P = {}> = <T extends TreeNode>(props: TreeViewRootComponentProps<T, P>) => JSX.Element
-
-export const TreeViewRoot = forwardRef(TreeViewImpl) as TreeViewRootComponent

--- a/packages/react/src/components/tree-view/tree-view-tree.tsx
+++ b/packages/react/src/components/tree-view/tree-view-tree.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { mergeProps } from '@zag-js/react'
-import { forwardRef } from 'react'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory'
 import { useTreeViewContext } from './use-tree-view-context'
 
 export interface TreeViewTreeBaseProps extends PolymorphicProps {}
 export interface TreeViewTreeProps extends HTMLProps<'div'>, TreeViewTreeBaseProps {}
 
-export const TreeViewTree = forwardRef<HTMLDivElement, TreeViewTreeProps>((props, ref) => {
+export const TreeViewTree = ({ ref, ...props }: TreeViewTreeProps) => {
   const treeView = useTreeViewContext()
   const mergedProps = mergeProps(treeView.getTreeProps(), props)
 
   return <ark.div {...mergedProps} ref={ref} />
-})
+}
 
 TreeViewTree.displayName = 'TreeViewTree'

--- a/packages/react/src/components/tree-view/tree-view.ts
+++ b/packages/react/src/components/tree-view/tree-view.ts
@@ -79,14 +79,11 @@ export {
 export {
   TreeViewRoot as Root,
   type TreeViewRootBaseProps as RootBaseProps,
-  type TreeViewRootComponent as RootComponent,
-  type TreeViewRootComponentProps as RootComponentProps,
   type TreeViewRootProps as RootProps,
 } from './tree-view-root'
 export {
   TreeViewRootProvider as RootProvider,
   type TreeViewRootProviderBaseProps as RootProviderBaseProps,
-  type TreeViewRootProviderComponent as RootProviderComponent,
   type TreeViewRootProviderProps as RootProviderProps,
 } from './tree-view-root-provider'
 export {


### PR DESCRIPTION
## Summary

Removes `forwardRef` usage across `@ark-ui/react` in favor of passing `ref` as a plain prop, following the [React 19 deprecation of `forwardRef`](https://react.dev/reference/react/forwardRef).

## Changes

- Remove `forwardRef(...)` wrappers and intermediate `*Impl` functions
- Remove associated `*Component` and `*ComponentProps` exported types
- `ref` is now accepted as a regular prop on all affected components

## Breaking Changes

The following types have been removed:

**Combobox**
- `ComboboxRootComponent`
- `ComboboxRootComponentProps`
- `ComboboxRootProviderComponent`

**Listbox**
- `ListboxRootComponent`
- `ListboxRootComponentProps`
- `ListboxRootProviderComponent`

**Select**
- `SelectRootComponent`
- `SelectRootComponentProps`
- `SelectRootProviderComponent`

**TreeView**
- `TreeViewRootComponent`
- `TreeViewRootComponentProps`
- `TreeViewRootProviderComponent`