### PR TITLE
docs(drawer): fix IndentBackground transition & website Windows path compatibility

### DIFF
--- a/.storybook/modules/drawer.module.css
+++ b/.storybook/modules/drawer.module.css
@@ -300,10 +300,11 @@
 }
 
 .Indent {
-  transition: border-radius 0.3s ease;
+  transition: border-radius 0.3s ease, transform 0.3s ease;
 
   &[data-active] {
     border-radius: calc(16px * (1 - var(--drawer-swipe-progress, 0)));
+    transform: scale(calc(1 - 0.05 * (1 - var(--drawer-swipe-progress, 0))));
   }
 }
 

--- a/website/velite.config.ts
+++ b/website/velite.config.ts
@@ -47,12 +47,13 @@ const pages = defineCollection({
       }),
     })
     .transform((data, { meta }) => {
+      const path = (meta.path as string).replace(/\\/g, '/')
       if (data.id === 'changelog') {
         return {
           ...data,
           slug: 'overview/changelog',
           category: 'overview',
-          framework: (meta.path as string).replace(/.*\/packages\//, '').replace(/\/[^/]*$/, ''),
+          framework: path.replace(/.*\/packages\//, '').replace(/\/[^/]*$/, ''),
           toc: data.toc
             .flatMap((entry) => (entry.url.includes('ark-ui') ? entry.items : [entry]))
             .map((entry) => ({ ...entry, items: [] })),
@@ -60,8 +61,8 @@ const pages = defineCollection({
       }
       return {
         ...data,
-        slug: (meta.path as string).replace(/.*\/pages\//, '').replace(/\.mdx$/, ''),
-        category: (meta.path as string).replace(/.*\/pages\//, '').replace(/\/[^/]*$/, ''),
+        slug: path.replace(/.*\/pages\//, '').replace(/\.mdx$/, ''),
+        category: path.replace(/.*\/pages\//, '').replace(/\/[^/]*$/, ''),
       }
     }),
 })
@@ -82,11 +83,14 @@ const blogs = defineCollection({
       toc: s.toc(),
       code: s.mdx(),
     })
-    .transform((data, { meta }) => ({
-      ...data,
-      slug: (meta.path as string).replace(/.*\/blog\//, '').replace(/\.mdx$/, ''),
-      category: 'blog',
-    })),
+    .transform((data, { meta }) => {
+      const path = (meta.path as string).replace(/\\/g, '/')
+      return {
+        ...data,
+        slug: path.replace(/.*\/blog\//, '').replace(/\.mdx$/, ''),
+        category: 'blog',
+      }
+    }),
 })
 
 const showcases = defineCollection({
@@ -120,11 +124,14 @@ const types = defineCollection({
         emits: s.record(s.string(), PropDefintion).optional(),
       }),
     )
-    .transform((data, { meta }) => ({
-      parts: data,
-      component: (meta.basename as string)?.split('.')[0] ?? '',
-      framework: (meta.path as string).replace(/.*\/types\//, '').replace(/\/[^/]*$/, ''),
-    })),
+    .transform((data, { meta }) => {
+      const path = (meta.path as string).replace(/\\/g, '/')
+      return {
+        parts: data,
+        component: (meta.basename as string)?.split('.')[0] ?? '',
+        framework: path.replace(/.*\/types\//, '').replace(/\/[^/]*$/, ''),
+      }
+    }),
 })
 
 export default defineConfig({


### PR DESCRIPTION
Hi maintainers! 👋

While exploring the repository for my first contribution, I noticed the visual indent effect on the Drawer component wasn't playing in the docs. While setting up the project locally to debug it on my Windows machine, I also stumbled upon and resolved a hidden cross-platform routing bug!

This PR addresses and fixes both issues:
 1. Fix Drawer IndentBackground Transition
The Issue:The Drawer.IndentBackground component was active, but the Indent class wrapping the viewport content was missing the CSS scale transformation. It only transitioned border-radius, leaving the background page flat and static.
The Fix: Added a smooth transform: scale(...) transition to .Indent\ in .storybook/modules/drawer.module.css that dynamically reacts to the drawer's swipe progress. The background now beautifully "pushes back" and scales down when the drawer slides in.

 2. Resolve Windows Path 404 Errors on Website (Bonus Fix!)
- The Issue: On Windows systems, the documentation website threw 404: Not Found errors for all component pages. This occurred because website/velite.config.ts used regular expressions targeting forward slashes (`/pages/`) to extract page slugs. On Windows, file paths use backslashes (`\pages\`), which bypassed the regex and generated malformed absolute path slugs.
- The Fix: Normalized all metadata file paths by replacing backslashes with forward slashes before routing transforms are applied, restoring full Windows compatibility for local docs development.

---

 Verification & Testing
- Built the React package locally using Turborepo.
- Ran the documentation website using Bun on Windows 11.
- Verified that all component pages load successfully (no more 404s).
- Verified that the Indent Background example animates perfectly and transitions smoothly when the drawer is triggered.

Closes #3897