### PR TITLE
docs(website): fix Windows path separator compatibility in velite

### DIFF
--- a/website/velite.config.ts
+++ b/website/velite.config.ts
@@ -47,12 +47,13 @@ const pages = defineCollection({
       }),
     })
     .transform((data, { meta }) => {
+      const path = (meta.path as string).replace(/\\/g, '/')
       if (data.id === 'changelog') {
         return {
           ...data,
           slug: 'overview/changelog',
           category: 'overview',
-          framework: (meta.path as string).replace(/.*\/packages\//, '').replace(/\/[^/]*$/, ''),
+          framework: path.replace(/.*\/packages\//, '').replace(/\/[^/]*$/, ''),
           toc: data.toc
             .flatMap((entry) => (entry.url.includes('ark-ui') ? entry.items : [entry]))
             .map((entry) => ({ ...entry, items: [] })),
@@ -60,8 +61,8 @@ const pages = defineCollection({
       }
       return {
         ...data,
-        slug: (meta.path as string).replace(/.*\/pages\//, '').replace(/\.mdx$/, ''),
-        category: (meta.path as string).replace(/.*\/pages\//, '').replace(/\/[^/]*$/, ''),
+        slug: path.replace(/.*\/pages\//, '').replace(/\.mdx$/, ''),
+        category: path.replace(/.*\/pages\//, '').replace(/\/[^/]*$/, ''),
       }
     }),
 })
@@ -82,11 +83,14 @@ const blogs = defineCollection({
       toc: s.toc(),
       code: s.mdx(),
     })
-    .transform((data, { meta }) => ({
-      ...data,
-      slug: (meta.path as string).replace(/.*\/blog\//, '').replace(/\.mdx$/, ''),
-      category: 'blog',
-    })),
+    .transform((data, { meta }) => {
+      const path = (meta.path as string).replace(/\\/g, '/')
+      return {
+        ...data,
+        slug: path.replace(/.*\/blog\//, '').replace(/\.mdx$/, ''),
+        category: 'blog',
+      }
+    }),
 })
 
 const showcases = defineCollection({
@@ -120,11 +124,14 @@ const types = defineCollection({
         emits: s.record(s.string(), PropDefintion).optional(),
       }),
     )
-    .transform((data, { meta }) => ({
-      parts: data,
-      component: (meta.basename as string)?.split('.')[0] ?? '',
-      framework: (meta.path as string).replace(/.*\/types\//, '').replace(/\/[^/]*$/, ''),
-    })),
+    .transform((data, { meta }) => {
+      const path = (meta.path as string).replace(/\\/g, '/')
+      return {
+        parts: data,
+        component: (meta.basename as string)?.split('.')[0] ?? '',
+        framework: path.replace(/.*\/types\//, '').replace(/\/[^/]*$/, ''),
+      }
+    }),
 })
 
 export default defineConfig({

--- a/website/velite.config.ts
+++ b/website/velite.config.ts
@@ -14,6 +14,8 @@ import remarkRemoveFirstHeading from './src/lib/remark-remove-first-heading'
 import { defineCollection, defineConfig, s } from 'velite'
 import { replaceComponentTypes, replaceContextType, replaceExample } from './src/lib/mdx-transform'
 
+const normalizePath = (path: string) => path.replace(/\\/g, '/')
+
 const pages = defineCollection({
   name: 'Pages',
   pattern: ['pages/**/*.mdx', '../../../packages/*/CHANGELOG.md'],
@@ -32,7 +34,7 @@ const pages = defineCollection({
       code: s.mdx(),
       llm: s.custom<string>().transform((_data, { meta }) => {
         const content = meta.content as string
-        const path = meta.path as string
+        const path = normalizePath(meta.path as string)
         const isChangelog = path.includes('CHANGELOG.md')
         const component = isChangelog
           ? ''
@@ -47,7 +49,7 @@ const pages = defineCollection({
       }),
     })
     .transform((data, { meta }) => {
-      const path = (meta.path as string).replace(/\\/g, '/')
+      const path = normalizePath(meta.path as string)
       if (data.id === 'changelog') {
         return {
           ...data,
@@ -84,7 +86,7 @@ const blogs = defineCollection({
       code: s.mdx(),
     })
     .transform((data, { meta }) => {
-      const path = (meta.path as string).replace(/\\/g, '/')
+      const path = normalizePath(meta.path as string)
       return {
         ...data,
         slug: path.replace(/.*\/blog\//, '').replace(/\.mdx$/, ''),
@@ -125,7 +127,7 @@ const types = defineCollection({
       }),
     )
     .transform((data, { meta }) => {
-      const path = (meta.path as string).replace(/\\/g, '/')
+      const path = normalizePath(meta.path as string)
       return {
         parts: data,
         component: (meta.basename as string)?.split('.')[0] ?? '',


### PR DESCRIPTION
Hi maintainers! 

While setting up the project locally to debug a separate issue on my Windows machine, I encountered a cross-platform routing bug that caused `404: Not Found` errors for all component documentation pages. 

This PR resolves that issue to make local docs development a seamless experience for Windows developers:

  The Fix: Resolve Windows Path 404 Errors on Website
- The Issue:`website/velite.config.ts` used regular expressions targeting forward slashes (`/pages/`, `/blog/`, and `/types/`) to extract page slugs and metadata. Since Windows systems use backslashes (`\pages\`, `\blog\`, and `\types\`) for file paths, the regex failed to match, leaving malformed absolute Windows paths as slugs and causing Next.js to return 404s.
- The Fix: Normalized all metadata file paths by replacing backslashes (`\`) with forward slashes (`/`) before slug and framework resolutions are performed, resolving the routing mismatch.

 Verification & Testing
- Built the React package locally using Turborepo.
- Ran the documentation website using Bun on Windows 11.
- Verified that all documentation pages (including Accordion, Drawer, etc.) now load successfully and correctly on Windows!

Note: This clean PR was opened following a review and request by @segunadebayo in a previous PR (#3900).