### PR TITLE
fix(react): composed ref stability

### DIFF
--- a/packages/react/src/components/color-picker/color-picker-content.tsx
+++ b/packages/react/src/components/color-picker/color-picker-content.tsx
@@ -2,7 +2,7 @@
 
 import { mergeProps } from '@zag-js/react'
 import { forwardRef } from 'react'
-import { composeRefs } from '../../utils/compose-refs.ts'
+import { useComposedRefs } from '../../utils/compose-refs.ts'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory.ts'
 import { usePresenceContext } from '../presence/index.ts'
 import { useColorPickerContext } from './use-color-picker-context.ts'
@@ -14,12 +14,13 @@ export const ColorPickerContent = forwardRef<HTMLDivElement, ColorPickerContentP
   const colorPicker = useColorPickerContext()
   const presence = usePresenceContext()
   const mergedProps = mergeProps(colorPicker.getContentProps(), presence.getPresenceProps(), props)
+  const composedRefs = useComposedRefs(presence.ref, ref)
 
   if (presence.unmounted) {
     return null
   }
 
-  return <ark.div {...mergedProps} ref={composeRefs(presence.ref, ref)} />
+  return <ark.div {...mergedProps} ref={composedRefs} />
 })
 
 ColorPickerContent.displayName = 'ColorPickerContent'

--- a/packages/react/src/components/combobox/combobox-content.tsx
+++ b/packages/react/src/components/combobox/combobox-content.tsx
@@ -2,7 +2,7 @@
 
 import { mergeProps } from '@zag-js/react'
 import { forwardRef } from 'react'
-import { composeRefs } from '../../utils/compose-refs.ts'
+import { useComposedRefs } from '../../utils/compose-refs.ts'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory.ts'
 import { usePresenceContext } from '../presence/index.ts'
 import { useComboboxContext } from './use-combobox-context.ts'
@@ -14,12 +14,13 @@ export const ComboboxContent = forwardRef<HTMLDivElement, ComboboxContentProps>(
   const combobox = useComboboxContext()
   const presence = usePresenceContext()
   const mergedProps = mergeProps(combobox.getContentProps(), presence.getPresenceProps(), props)
+  const composedRefs = useComposedRefs(presence.ref, ref)
 
   if (presence.unmounted) {
     return null
   }
 
-  return <ark.div {...mergedProps} ref={composeRefs(presence.ref, ref)} />
+  return <ark.div {...mergedProps} ref={composedRefs} />
 })
 
 ComboboxContent.displayName = 'ComboboxContent'

--- a/packages/react/src/components/date-picker/date-picker-content.tsx
+++ b/packages/react/src/components/date-picker/date-picker-content.tsx
@@ -2,7 +2,7 @@
 
 import { mergeProps } from '@zag-js/react'
 import { forwardRef } from 'react'
-import { composeRefs } from '../../utils/compose-refs.ts'
+import { useComposedRefs } from '../../utils/compose-refs.ts'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory.ts'
 import { usePresenceContext } from '../presence/index.ts'
 import { useDatePickerContext } from './use-date-picker-context.ts'
@@ -14,12 +14,13 @@ export const DatePickerContent = forwardRef<HTMLDivElement, DatePickerContentPro
   const datePicker = useDatePickerContext()
   const presence = usePresenceContext()
   const mergedProps = mergeProps(datePicker.getContentProps(), presence.getPresenceProps(), props)
+  const composedRefs = useComposedRefs(presence.ref, ref)
 
   if (presence.unmounted) {
     return null
   }
 
-  return <ark.div {...mergedProps} ref={composeRefs(presence.ref, ref)} />
+  return <ark.div {...mergedProps} ref={composedRefs} />
 })
 
 DatePickerContent.displayName = 'DatePickerContent'

--- a/packages/react/src/components/dialog/dialog-backdrop.tsx
+++ b/packages/react/src/components/dialog/dialog-backdrop.tsx
@@ -2,7 +2,7 @@
 
 import { mergeProps } from '@zag-js/react'
 import { forwardRef } from 'react'
-import { composeRefs } from '../../utils/compose-refs.ts'
+import { useComposedRefs } from '../../utils/compose-refs.ts'
 import { useRenderStrategyPropsContext } from '../../utils/render-strategy.ts'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory.ts'
 import { usePresence } from '../presence/index.ts'
@@ -16,12 +16,13 @@ export const DialogBackdrop = forwardRef<HTMLDivElement, DialogBackdropProps>((p
   const renderStrategyProps = useRenderStrategyPropsContext()
   const presence = usePresence({ ...renderStrategyProps, present: dialog.open })
   const mergedProps = mergeProps(dialog.getBackdropProps(), presence.getPresenceProps(), props)
+  const composedRefs = useComposedRefs(presence.ref, ref)
 
   if (presence.unmounted) {
     return null
   }
 
-  return <ark.div {...mergedProps} ref={composeRefs(presence.ref, ref)} />
+  return <ark.div {...mergedProps} ref={composedRefs} />
 })
 
 DialogBackdrop.displayName = 'DialogBackdrop'

--- a/packages/react/src/components/dialog/dialog-content.tsx
+++ b/packages/react/src/components/dialog/dialog-content.tsx
@@ -2,7 +2,7 @@
 
 import { mergeProps } from '@zag-js/react'
 import { forwardRef } from 'react'
-import { composeRefs } from '../../utils/compose-refs.ts'
+import { useComposedRefs } from '../../utils/compose-refs.ts'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory.ts'
 import { usePresenceContext } from '../presence/index.ts'
 import { useDialogContext } from './use-dialog-context.ts'
@@ -14,12 +14,13 @@ export const DialogContent = forwardRef<HTMLDivElement, DialogContentProps>((pro
   const dialog = useDialogContext()
   const presence = usePresenceContext()
   const mergedProps = mergeProps(dialog.getContentProps(), presence.getPresenceProps(), props)
+  const composedRefs = useComposedRefs(presence.ref, ref)
 
   if (presence.unmounted) {
     return null
   }
 
-  return <ark.div {...mergedProps} ref={composeRefs(presence.ref, ref)} />
+  return <ark.div {...mergedProps} ref={composedRefs} />
 })
 
 DialogContent.displayName = 'DialogContent'

--- a/packages/react/src/components/drawer/drawer-backdrop.tsx
+++ b/packages/react/src/components/drawer/drawer-backdrop.tsx
@@ -2,7 +2,7 @@
 
 import { mergeProps } from '@zag-js/react'
 import { forwardRef } from 'react'
-import { composeRefs } from '../../utils/compose-refs.ts'
+import { useComposedRefs } from '../../utils/compose-refs.ts'
 import { useRenderStrategyPropsContext } from '../../utils/render-strategy.ts'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory.ts'
 import { usePresence } from '../presence/index.ts'
@@ -16,12 +16,13 @@ export const DrawerBackdrop = forwardRef<HTMLDivElement, DrawerBackdropProps>((p
   const renderStrategyProps = useRenderStrategyPropsContext()
   const presence = usePresence({ ...renderStrategyProps, present: drawer.open })
   const mergedProps = mergeProps(drawer.getBackdropProps(), presence.getPresenceProps(), props)
+  const composedRefs = useComposedRefs(presence.ref, ref)
 
   if (presence.unmounted) {
     return null
   }
 
-  return <ark.div {...mergedProps} ref={composeRefs(presence.ref, ref)} />
+  return <ark.div {...mergedProps} ref={composedRefs} />
 })
 
 DrawerBackdrop.displayName = 'DrawerBackdrop'

--- a/packages/react/src/components/drawer/drawer-content.tsx
+++ b/packages/react/src/components/drawer/drawer-content.tsx
@@ -3,7 +3,7 @@
 import { mergeProps } from '@zag-js/react'
 import type { ContentProps } from '@zag-js/drawer'
 import { forwardRef } from 'react'
-import { composeRefs } from '../../utils/compose-refs.ts'
+import { useComposedRefs } from '../../utils/compose-refs.ts'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory.ts'
 import { usePresenceContext } from '../presence/index.ts'
 import { useDrawerContext } from './use-drawer-context.ts'
@@ -23,12 +23,13 @@ export const DrawerContent = forwardRef<HTMLDivElement, DrawerContentProps>((pro
     presence.getPresenceProps(),
     localProps,
   )
+  const composedRefs = useComposedRefs(presence.ref, ref)
 
   if (presence.unmounted) {
     return null
   }
 
-  return <ark.div {...mergedProps} ref={composeRefs(presence.ref, ref)} />
+  return <ark.div {...mergedProps} ref={composedRefs} />
 })
 
 DrawerContent.displayName = 'DrawerContent'

--- a/packages/react/src/components/factory.test.tsx
+++ b/packages/react/src/components/factory.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import user from '@testing-library/user-event'
+import { useCallback, useReducer } from 'react'
 import { ark } from './factory.ts'
 
 const ComponentUnderTest = () => (
@@ -68,5 +69,35 @@ describe('Ark Factory', () => {
       </ark.div>,
     )
     expect(screen.getByText('Ark UI')).not.toHaveAttribute('data-testid', 'parent')
+  })
+
+  it('should not detach stable asChild callback ref on parent re-render', async () => {
+    const callbackRef = vi.fn()
+
+    const AsChildTest = () => {
+      const [, rerender] = useReducer((count) => count + 1, 0)
+      const setRef = useCallback((node: HTMLSpanElement | null) => {
+        callbackRef(node)
+      }, [])
+
+      return (
+        <>
+          <ark.span ref={setRef} asChild>
+            <span data-testid="child">Ark UI</span>
+          </ark.span>
+          <button type="button" onClick={() => rerender()}>
+            re-render
+          </button>
+        </>
+      )
+    }
+
+    render(<AsChildTest />)
+    expect(callbackRef).toHaveBeenCalledWith(screen.getByTestId('child'))
+
+    const callsAfterMount = callbackRef.mock.calls.length
+    await user.click(screen.getByRole('button', { name: /re-render/i }))
+
+    expect(callbackRef).toHaveBeenCalledTimes(callsAfterMount)
   })
 })

--- a/packages/react/src/components/factory.ts
+++ b/packages/react/src/components/factory.ts
@@ -11,7 +11,7 @@ import {
   isValidElement,
   memo,
 } from 'react'
-import { composeRefs } from '../utils/compose-refs.ts'
+import { useComposedRefs } from '../utils/compose-refs.ts'
 
 export interface PolymorphicProps {
   /**
@@ -47,22 +47,22 @@ const withAsChild = (Component: React.ElementType) => {
   const Comp = memo(
     forwardRef<unknown, ArkPropsWithRef<typeof Component>>((props, ref) => {
       const { asChild, children, ...restProps } = props
+      const onlyChild =
+        asChild && isValidElement<Record<string, unknown>>(children) ? Children.only(children) : undefined
+      const childRef = onlyChild ? getRef(onlyChild) : undefined
+      const composedRef = useComposedRefs(ref, childRef)
 
       if (!asChild) {
         return createElement(Component, { ...restProps, ref }, children)
       }
 
-      if (!isValidElement<Record<string, unknown>>(children)) {
+      if (!onlyChild) {
         return null
       }
 
-      const onlyChild: React.ReactElement<Record<string, unknown>> = Children.only(children)
-
-      const childRef = getRef(onlyChild)
-
       return cloneElement(onlyChild, {
         ...mergeProps(restProps, onlyChild.props),
-        ref: ref ? composeRefs(ref, childRef) : childRef,
+        ref: ref ? composedRef : childRef,
       })
     }),
   )

--- a/packages/react/src/components/field/field-root.tsx
+++ b/packages/react/src/components/field/field-root.tsx
@@ -2,7 +2,7 @@
 
 import { mergeProps } from '@zag-js/react'
 import { forwardRef } from 'react'
-import { composeRefs } from '../../utils/compose-refs.ts'
+import { useComposedRefs } from '../../utils/compose-refs.ts'
 import { createSplitProps } from '../../utils/create-split-props.ts'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory.ts'
 import { type UseFieldProps, useField } from './use-field.ts'
@@ -26,10 +26,11 @@ export const FieldRoot = forwardRef<HTMLDivElement, FieldRootProps>((props, ref)
 
   const field = useField(useFieldProps)
   const mergedProps = mergeProps<HTMLProps<'div'>>(field.getRootProps(), localProps)
+  const composedRefs = useComposedRefs(ref, field.refs.rootRef)
 
   return (
     <FieldProvider value={field}>
-      <ark.div {...mergedProps} ref={composeRefs(ref, field.refs.rootRef)} />
+      <ark.div {...mergedProps} ref={composedRefs} />
     </FieldProvider>
   )
 })

--- a/packages/react/src/components/field/field-textarea.tsx
+++ b/packages/react/src/components/field/field-textarea.tsx
@@ -3,7 +3,7 @@
 import { autoresizeTextarea } from '@zag-js/auto-resize'
 import { mergeProps } from '@zag-js/react'
 import { forwardRef, useEffect, useRef } from 'react'
-import { composeRefs } from '../../utils/compose-refs.ts'
+import { useComposedRefs } from '../../utils/compose-refs.ts'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory.ts'
 import { useFieldContext } from './use-field-context.ts'
 
@@ -25,13 +25,14 @@ export const FieldTextarea = forwardRef<HTMLTextAreaElement, FieldTextareaProps>
     { style: { resize: autoresize ? 'none' : undefined } },
     textareaProps,
   )
+  const composedRefs = useComposedRefs(ref, textareaRef)
 
   useEffect(() => {
     if (!autoresize) return
     return autoresizeTextarea(textareaRef.current)
   }, [autoresize])
 
-  return <ark.textarea {...mergedProps} ref={composeRefs(ref, textareaRef)} />
+  return <ark.textarea {...mergedProps} ref={composedRefs} />
 })
 
 FieldTextarea.displayName = 'FieldTextarea'

--- a/packages/react/src/components/field/field.test.tsx
+++ b/packages/react/src/components/field/field.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import user from '@testing-library/user-event'
+import { useCallback, useReducer } from 'react'
 import { axe } from 'vitest-axe'
 import { Field } from '../index.ts'
 
@@ -56,6 +57,34 @@ describe('Field / Input', () => {
     render(<ComponentUnderTest />)
     await user.click(screen.getByText(/label/i))
     expect(screen.getByRole('textbox', { name: /label/i })).toHaveFocus()
+  })
+
+  it('should not detach stable textarea callback ref on parent re-render', async () => {
+    const callbackRef = vi.fn()
+
+    const TextareaTest = () => {
+      const [, rerender] = useReducer((count) => count + 1, 0)
+      const setRef = useCallback((node: HTMLTextAreaElement | null) => {
+        callbackRef(node)
+      }, [])
+
+      return (
+        <Field.Root>
+          <Field.Textarea ref={setRef} />
+          <button type="button" onClick={() => rerender()}>
+            re-render
+          </button>
+        </Field.Root>
+      )
+    }
+
+    render(<TextareaTest />)
+    await waitFor(() => expect(callbackRef).toHaveBeenCalledWith(expect.any(HTMLTextAreaElement)))
+
+    const callsAfterMount = callbackRef.mock.calls.length
+    await user.click(screen.getByRole('button', { name: /re-render/i }))
+
+    expect(callbackRef).toHaveBeenCalledTimes(callsAfterMount)
   })
 
   it('should not display error text when no error is present', async () => {

--- a/packages/react/src/components/field/field.test.tsx
+++ b/packages/react/src/components/field/field.test.tsx
@@ -59,34 +59,6 @@ describe('Field / Input', () => {
     expect(screen.getByRole('textbox', { name: /label/i })).toHaveFocus()
   })
 
-  it('should not detach stable textarea callback ref on parent re-render', async () => {
-    const callbackRef = vi.fn()
-
-    const TextareaTest = () => {
-      const [, rerender] = useReducer((count) => count + 1, 0)
-      const setRef = useCallback((node: HTMLTextAreaElement | null) => {
-        callbackRef(node)
-      }, [])
-
-      return (
-        <Field.Root>
-          <Field.Textarea ref={setRef} />
-          <button type="button" onClick={() => rerender()}>
-            re-render
-          </button>
-        </Field.Root>
-      )
-    }
-
-    render(<TextareaTest />)
-    await waitFor(() => expect(callbackRef).toHaveBeenCalledWith(expect.any(HTMLTextAreaElement)))
-
-    const callsAfterMount = callbackRef.mock.calls.length
-    await user.click(screen.getByRole('button', { name: /re-render/i }))
-
-    expect(callbackRef).toHaveBeenCalledTimes(callsAfterMount)
-  })
-
   it('should not display error text when no error is present', async () => {
     render(<ComponentUnderTest />)
     expect(screen.queryByText('Error Info')).not.toBeInTheDocument()
@@ -311,5 +283,35 @@ describe('Field / Item', () => {
         </Field.Item>,
       ),
     ).toThrow('Field.Item must be used within Field.Root')
+  })
+})
+
+describe('Field / Textarea', () => {
+  it('should not detach stable callback ref on parent re-render', async () => {
+    const callbackRef = vi.fn()
+
+    const TextareaTest = () => {
+      const [, rerender] = useReducer((count) => count + 1, 0)
+      const setRef = useCallback((node: HTMLTextAreaElement | null) => {
+        callbackRef(node)
+      }, [])
+
+      return (
+        <Field.Root>
+          <Field.Textarea ref={setRef} />
+          <button type="button" onClick={() => rerender()}>
+            re-render
+          </button>
+        </Field.Root>
+      )
+    }
+
+    render(<TextareaTest />)
+    await waitFor(() => expect(callbackRef).toHaveBeenCalledWith(expect.any(HTMLTextAreaElement)))
+
+    const callsAfterMount = callbackRef.mock.calls.length
+    await user.click(screen.getByRole('button', { name: /re-render/i }))
+
+    expect(callbackRef).toHaveBeenCalledTimes(callsAfterMount)
   })
 })

--- a/packages/react/src/components/fieldset/fieldset-root.tsx
+++ b/packages/react/src/components/fieldset/fieldset-root.tsx
@@ -2,7 +2,7 @@
 
 import { mergeProps } from '@zag-js/react'
 import { forwardRef } from 'react'
-import { composeRefs } from '../../utils/compose-refs.ts'
+import { useComposedRefs } from '../../utils/compose-refs.ts'
 import { createSplitProps } from '../../utils/create-split-props.ts'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory.ts'
 import { type UseFieldsetProps, useFieldset } from './use-fieldset.ts'
@@ -17,10 +17,11 @@ export const FieldsetRoot = forwardRef<HTMLFieldSetElement, FieldsetRootProps>((
   const [useFieldsetProps, localProps] = splitRootProps(props, ['id', 'disabled', 'invalid'])
   const fieldset = useFieldset(useFieldsetProps)
   const mergedProps = mergeProps<HTMLProps<'fieldset'>>(fieldset.getRootProps(), localProps)
+  const composedRefs = useComposedRefs(ref, fieldset.refs.rootRef)
 
   return (
     <FieldsetProvider value={fieldset}>
-      <ark.fieldset {...mergedProps} ref={composeRefs(ref, fieldset.refs.rootRef)} />
+      <ark.fieldset {...mergedProps} ref={composedRefs} />
     </FieldsetProvider>
   )
 })

--- a/packages/react/src/components/floating-panel/floating-panel-content.tsx
+++ b/packages/react/src/components/floating-panel/floating-panel-content.tsx
@@ -2,7 +2,7 @@
 
 import { mergeProps } from '@zag-js/react'
 import { forwardRef } from 'react'
-import { composeRefs } from '../../utils/compose-refs.ts'
+import { useComposedRefs } from '../../utils/compose-refs.ts'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory.ts'
 import { usePresenceContext } from '../presence/index.ts'
 import { useFloatingPanelContext } from './use-floating-panel-context.ts'
@@ -14,12 +14,13 @@ export const FloatingPanelContent = forwardRef<HTMLDivElement, FloatingPanelCont
   const floatingPanel = useFloatingPanelContext()
   const presence = usePresenceContext()
   const mergedProps = mergeProps(floatingPanel.getContentProps(), presence.getPresenceProps(), props)
+  const composedRefs = useComposedRefs(presence.ref, ref)
 
   if (presence.unmounted) {
     return null
   }
 
-  return <ark.div {...mergedProps} ref={composeRefs(presence.ref, ref)} />
+  return <ark.div {...mergedProps} ref={composedRefs} />
 })
 
 FloatingPanelContent.displayName = 'FloatingPanelContent'

--- a/packages/react/src/components/focus-trap/focus-trap.tsx
+++ b/packages/react/src/components/focus-trap/focus-trap.tsx
@@ -3,7 +3,7 @@
 import { type FocusTrapOptions, trapFocus } from '@zag-js/focus-trap'
 import { forwardRef, useRef } from 'react'
 import type { Assign } from '../../types.ts'
-import { composeRefs } from '../../utils/compose-refs.ts'
+import { useComposedRefs } from '../../utils/compose-refs.ts'
 import { createSplitProps } from '../../utils/create-split-props.ts'
 import { useSafeLayoutEffect } from '../../utils/use-safe-layout-effect.ts'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory.ts'
@@ -35,6 +35,7 @@ export const FocusTrap = forwardRef<HTMLDivElement, FocusTrapProps>((props, ref)
     'returnFocusOnDeactivate',
     'setReturnFocus',
   ])
+  const composedRefs = useComposedRefs(localRef, ref)
 
   useSafeLayoutEffect(() => {
     const node = localRef.current
@@ -42,7 +43,7 @@ export const FocusTrap = forwardRef<HTMLDivElement, FocusTrapProps>((props, ref)
     return trapFocus(node, trapProps)
   }, [ref, trapProps])
 
-  return <ark.div ref={composeRefs(localRef, ref)} {...localProps} />
+  return <ark.div ref={composedRefs} {...localProps} />
 })
 
 FocusTrap.displayName = 'FocusTrap'

--- a/packages/react/src/components/frame/frame.tsx
+++ b/packages/react/src/components/frame/frame.tsx
@@ -4,7 +4,7 @@ import { forwardRef, useEffect, useId, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { EnvironmentProvider } from '../../providers/index.ts'
 import type { Assign } from '../../types.ts'
-import { composeRefs } from '../../utils/compose-refs.ts'
+import { useComposedRefs } from '../../utils/compose-refs.ts'
 import { useSafeLayoutEffect } from '../../utils/use-safe-layout-effect.ts'
 import { FrameContent } from './frame-content.tsx'
 
@@ -35,6 +35,7 @@ export const Frame = forwardRef<HTMLIFrameElement, FrameProps>((props, ref) => {
 
   const [frameRef, setFrameRef] = useState<HTMLIFrameElement | null>(null)
   const [mountNode, setMountNode] = useState<HTMLElement | null>(null)
+  const composedRefs = useComposedRefs<HTMLIFrameElement>(ref, setFrameRef)
 
   useSafeLayoutEffect(() => {
     if (!frameRef) return
@@ -81,7 +82,7 @@ export const Frame = forwardRef<HTMLIFrameElement, FrameProps>((props, ref) => {
 
   return (
     <EnvironmentProvider value={() => frameRef?.contentDocument ?? document}>
-      <iframe title={`frame:${useId()}`} ref={composeRefs<HTMLIFrameElement>(ref, setFrameRef)} {...rest}>
+      <iframe title={`frame:${useId()}`} ref={composedRefs} {...rest}>
         {mountNode
           ? createPortal(
               <FrameContent onMount={onMount} onUnmount={onUnmount}>

--- a/packages/react/src/components/hover-card/hover-card-content.tsx
+++ b/packages/react/src/components/hover-card/hover-card-content.tsx
@@ -2,7 +2,7 @@
 
 import { mergeProps } from '@zag-js/react'
 import { forwardRef } from 'react'
-import { composeRefs } from '../../utils/compose-refs.ts'
+import { useComposedRefs } from '../../utils/compose-refs.ts'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory.ts'
 import { usePresenceContext } from '../presence/index.ts'
 import { useHoverCardContext } from './use-hover-card-context.ts'
@@ -14,12 +14,13 @@ export const HoverCardContent = forwardRef<HTMLDivElement, HoverCardContentProps
   const hoverCard = useHoverCardContext()
   const presence = usePresenceContext()
   const mergedProps = mergeProps(hoverCard.getContentProps(), presence.getPresenceProps(), props)
+  const composedRefs = useComposedRefs(presence.ref, ref)
 
   if (presence.unmounted) {
     return null
   }
 
-  return <ark.div {...mergedProps} ref={composeRefs(presence.ref, ref)} />
+  return <ark.div {...mergedProps} ref={composedRefs} />
 })
 
 HoverCardContent.displayName = 'HoverCardContent'

--- a/packages/react/src/components/menu/menu-content.tsx
+++ b/packages/react/src/components/menu/menu-content.tsx
@@ -2,7 +2,7 @@
 
 import { mergeProps } from '@zag-js/react'
 import { forwardRef } from 'react'
-import { composeRefs } from '../../utils/compose-refs.ts'
+import { useComposedRefs } from '../../utils/compose-refs.ts'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory.ts'
 import { usePresenceContext } from '../presence/index.ts'
 import { useMenuContext } from './use-menu-context.ts'
@@ -14,12 +14,13 @@ export const MenuContent = forwardRef<HTMLDivElement, MenuContentProps>((props, 
   const menu = useMenuContext()
   const presence = usePresenceContext()
   const mergedProps = mergeProps(menu.getContentProps(), presence.getPresenceProps(), props)
+  const composedRefs = useComposedRefs(presence.ref, ref)
 
   if (presence.unmounted) {
     return null
   }
 
-  return <ark.div {...mergedProps} ref={composeRefs(presence.ref, ref)} />
+  return <ark.div {...mergedProps} ref={composedRefs} />
 })
 
 MenuContent.displayName = 'MenuContent'

--- a/packages/react/src/components/navigation-menu/navigation-menu-content.tsx
+++ b/packages/react/src/components/navigation-menu/navigation-menu-content.tsx
@@ -4,7 +4,7 @@ import type { ContentProps } from '@zag-js/navigation-menu'
 import { mergeProps } from '@zag-js/react'
 import { forwardRef } from 'react'
 import type { Assign } from '../../types.ts'
-import { composeRefs } from '../../utils/compose-refs.ts'
+import { useComposedRefs } from '../../utils/compose-refs.ts'
 import { createSplitProps } from '../../utils/create-split-props.ts'
 import { useRenderStrategyPropsContext } from '../../utils/render-strategy.ts'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory.ts'
@@ -28,10 +28,11 @@ export const NavigationMenuContent = forwardRef<HTMLDivElement, NavigationMenuCo
   const renderStrategyProps = useRenderStrategyPropsContext()
   const presence = usePresence({ ...renderStrategyProps, present: api.value === value })
   const mergedProps = mergeProps(api.getContentProps(contentProps), presence.getPresenceProps(), localProps)
+  const composedRefs = useComposedRefs(presence.ref, ref)
 
   const content = (
     <PresenceProvider value={presence}>
-      {presence.unmounted ? null : <ark.div {...mergedProps} ref={composeRefs(presence.ref, ref)} />}
+      {presence.unmounted ? null : <ark.div {...mergedProps} ref={composedRefs} />}
     </PresenceProvider>
   )
 

--- a/packages/react/src/components/navigation-menu/navigation-menu-indicator.tsx
+++ b/packages/react/src/components/navigation-menu/navigation-menu-indicator.tsx
@@ -2,7 +2,7 @@
 
 import { mergeProps } from '@zag-js/react'
 import { forwardRef } from 'react'
-import { composeRefs } from '../../utils/compose-refs.ts'
+import { useComposedRefs } from '../../utils/compose-refs.ts'
 import { useRenderStrategyPropsContext } from '../../utils/render-strategy.ts'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory.ts'
 import { PresenceProvider, usePresence } from '../presence/index.ts'
@@ -16,10 +16,11 @@ export const NavigationMenuIndicator = forwardRef<HTMLDivElement, NavigationMenu
   const renderStrategyProps = useRenderStrategyPropsContext()
   const presence = usePresence({ ...renderStrategyProps, present: navigationMenu.open })
   const mergedProps = mergeProps(navigationMenu.getIndicatorProps(), presence.getPresenceProps(), props)
+  const composedRefs = useComposedRefs(presence.ref, ref)
 
   return (
     <PresenceProvider value={presence}>
-      {presence.unmounted ? null : <ark.div {...mergedProps} ref={composeRefs(presence.ref, ref)} />}
+      {presence.unmounted ? null : <ark.div {...mergedProps} ref={composedRefs} />}
     </PresenceProvider>
   )
 })

--- a/packages/react/src/components/navigation-menu/navigation-menu-viewport.tsx
+++ b/packages/react/src/components/navigation-menu/navigation-menu-viewport.tsx
@@ -2,7 +2,7 @@
 
 import { mergeProps } from '@zag-js/react'
 import { forwardRef } from 'react'
-import { composeRefs } from '../../utils/compose-refs.ts'
+import { useComposedRefs } from '../../utils/compose-refs.ts'
 import { useRenderStrategyPropsContext } from '../../utils/render-strategy.ts'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory.ts'
 import { PresenceProvider, usePresence } from '../presence/index.ts'
@@ -27,10 +27,11 @@ export const NavigationMenuViewport = forwardRef<HTMLDivElement, NavigationMenuV
     presence.getPresenceProps(),
     props,
   )
+  const composedRefs = useComposedRefs(presence.ref, ref)
 
   return (
     <PresenceProvider value={presence}>
-      {presence.unmounted ? null : <ark.div {...mergedProps} ref={composeRefs(presence.ref, ref)} />}
+      {presence.unmounted ? null : <ark.div {...mergedProps} ref={composedRefs} />}
     </PresenceProvider>
   )
 })

--- a/packages/react/src/components/popover/popover-content.tsx
+++ b/packages/react/src/components/popover/popover-content.tsx
@@ -2,7 +2,7 @@
 
 import { mergeProps } from '@zag-js/react'
 import { forwardRef } from 'react'
-import { composeRefs } from '../../utils/compose-refs.ts'
+import { useComposedRefs } from '../../utils/compose-refs.ts'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory.ts'
 import { usePresenceContext } from '../presence/index.ts'
 import { usePopoverContext } from './use-popover-context.ts'
@@ -14,12 +14,13 @@ export const PopoverContent = forwardRef<HTMLDivElement, PopoverContentProps>((p
   const popover = usePopoverContext()
   const presence = usePresenceContext()
   const mergedProps = mergeProps(popover.getContentProps(), presence.getPresenceProps(), props)
+  const composedRefs = useComposedRefs(presence.ref, ref)
 
   if (presence.unmounted) {
     return null
   }
 
-  return <ark.div {...mergedProps} ref={composeRefs(presence.ref, ref)} />
+  return <ark.div {...mergedProps} ref={composedRefs} />
 })
 
 PopoverContent.displayName = 'PopoverContent'

--- a/packages/react/src/components/presence/presence.tsx
+++ b/packages/react/src/components/presence/presence.tsx
@@ -1,5 +1,5 @@
 import { forwardRef } from 'react'
-import { composeRefs } from '../../utils/compose-refs.ts'
+import { useComposedRefs } from '../../utils/compose-refs.ts'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory.ts'
 import { splitPresenceProps } from './split-presence-props.ts'
 import { type UsePresenceProps, usePresence } from './use-presence.ts'
@@ -10,6 +10,7 @@ export interface PresenceProps extends HTMLProps<'div'>, PresenceBaseProps {}
 export const Presence = forwardRef<HTMLDivElement, PresenceProps>((props, ref) => {
   const [presenceProps, localProps] = splitPresenceProps(props)
   const presence = usePresence(presenceProps)
+  const composedRefs = useComposedRefs(presence.ref, ref)
 
   if (presence.unmounted) {
     return null
@@ -21,7 +22,7 @@ export const Presence = forwardRef<HTMLDivElement, PresenceProps>((props, ref) =
       {...presence.getPresenceProps()}
       data-scope="presence"
       data-part="root"
-      ref={composeRefs(presence.ref, ref)}
+      ref={composedRefs}
     />
   )
 })

--- a/packages/react/src/components/select/select-content.tsx
+++ b/packages/react/src/components/select/select-content.tsx
@@ -2,7 +2,7 @@
 
 import { mergeProps } from '@zag-js/react'
 import { forwardRef } from 'react'
-import { composeRefs } from '../../utils/compose-refs.ts'
+import { useComposedRefs } from '../../utils/compose-refs.ts'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory.ts'
 import { usePresenceContext } from '../presence/index.ts'
 import { useSelectContext } from './use-select-context.ts'
@@ -14,12 +14,13 @@ export const SelectContent = forwardRef<HTMLDivElement, SelectContentProps>((pro
   const select = useSelectContext()
   const presence = usePresenceContext()
   const mergedProps = mergeProps(select.getContentProps(), presence.getPresenceProps(), props)
+  const composedRefs = useComposedRefs(presence.ref, ref)
 
   if (presence.unmounted) {
     return null
   }
 
-  return <ark.div {...mergedProps} ref={composeRefs(presence.ref, ref)} />
+  return <ark.div {...mergedProps} ref={composedRefs} />
 })
 
 SelectContent.displayName = 'SelectContent'

--- a/packages/react/src/components/swap/swap-indicator.tsx
+++ b/packages/react/src/components/swap/swap-indicator.tsx
@@ -2,7 +2,7 @@
 
 import { mergeProps } from '@zag-js/react'
 import { forwardRef } from 'react'
-import { composeRefs } from '../../utils/compose-refs.ts'
+import { useComposedRefs } from '../../utils/compose-refs.ts'
 import type { HTMLProps, PolymorphicProps } from '../factory.ts'
 import { ark } from '../factory.ts'
 import { useSwapContext } from './use-swap-context.ts'
@@ -17,12 +17,13 @@ export const SwapIndicator = forwardRef<HTMLSpanElement, SwapIndicatorProps>((pr
   const { type, ...restProps } = props
   const swap = useSwapContext()
   const presence = type === 'on' ? swap.onPresence : swap.offPresence
+  const composedRefs = useComposedRefs(presence.ref, ref)
 
   if (presence.unmounted) return null
 
   const mergedProps = mergeProps(swap.getIndicatorProps({ type }), restProps)
 
-  return <ark.span {...mergedProps} ref={composeRefs(presence.ref, ref)} />
+  return <ark.span {...mergedProps} ref={composedRefs} />
 })
 
 SwapIndicator.displayName = 'SwapIndicator'

--- a/packages/react/src/components/tabs/tab-content.tsx
+++ b/packages/react/src/components/tabs/tab-content.tsx
@@ -3,7 +3,7 @@
 import { mergeProps } from '@zag-js/react'
 import type { ContentProps } from '@zag-js/tabs'
 import { forwardRef } from 'react'
-import { composeRefs } from '../../utils/compose-refs.ts'
+import { useComposedRefs } from '../../utils/compose-refs.ts'
 import { createSplitProps } from '../../utils/create-split-props.ts'
 import { useRenderStrategyPropsContext } from '../../utils/render-strategy.ts'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory.ts'
@@ -27,10 +27,11 @@ export const TabContent = forwardRef<HTMLDivElement, TabContentProps>((props, re
   })
 
   const mergedProps = mergeProps(tabs.getContentProps(contentProps), presence.getPresenceProps(), localProps)
+  const composedRefs = useComposedRefs(presence.ref, ref)
 
   return (
     <PresenceProvider value={presence}>
-      {presence.unmounted ? null : <ark.div {...mergedProps} ref={composeRefs(presence.ref, ref)} />}
+      {presence.unmounted ? null : <ark.div {...mergedProps} ref={composedRefs} />}
     </PresenceProvider>
   )
 })

--- a/packages/react/src/components/tooltip/tooltip-content.tsx
+++ b/packages/react/src/components/tooltip/tooltip-content.tsx
@@ -2,7 +2,7 @@
 
 import { mergeProps } from '@zag-js/react'
 import { forwardRef } from 'react'
-import { composeRefs } from '../../utils/compose-refs.ts'
+import { useComposedRefs } from '../../utils/compose-refs.ts'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory.ts'
 import { usePresenceContext } from '../presence/index.ts'
 import { useTooltipContext } from './use-tooltip-context.ts'
@@ -14,12 +14,13 @@ export const TooltipContent = forwardRef<HTMLDivElement, TooltipContentProps>((p
   const tooltip = useTooltipContext()
   const presence = usePresenceContext()
   const mergedProps = mergeProps(tooltip.getContentProps(), presence.getPresenceProps(), props)
+  const composedRefs = useComposedRefs(presence.ref, ref)
 
   if (presence.unmounted) {
     return null
   }
 
-  return <ark.div {...mergedProps} ref={composeRefs(presence.ref, ref)} />
+  return <ark.div {...mergedProps} ref={composedRefs} />
 })
 
 TooltipContent.displayName = 'TooltipContent'

--- a/packages/react/src/components/tour/tour-backdrop.tsx
+++ b/packages/react/src/components/tour/tour-backdrop.tsx
@@ -2,7 +2,7 @@
 
 import { mergeProps } from '@zag-js/react'
 import { forwardRef } from 'react'
-import { composeRefs } from '../../utils/compose-refs.ts'
+import { useComposedRefs } from '../../utils/compose-refs.ts'
 import { useRenderStrategyPropsContext } from '../../utils/render-strategy.ts'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory.ts'
 import { usePresence } from '../presence/index.ts'
@@ -19,12 +19,13 @@ export const TourBackdrop = forwardRef<HTMLDivElement, TourBackdropProps>((props
     present: tour.open,
   })
   const mergedProps = mergeProps(tour.getBackdropProps(), presence.getPresenceProps(), props)
+  const composedRefs = useComposedRefs(presence.ref, ref)
 
   if (presence.unmounted) {
     return null
   }
 
-  return <ark.div {...mergedProps} ref={composeRefs(presence.ref, ref)} hidden={!tour.step?.backdrop} />
+  return <ark.div {...mergedProps} ref={composedRefs} hidden={!tour.step?.backdrop} />
 })
 
 TourBackdrop.displayName = 'TourBackdrop'

--- a/packages/react/src/components/tour/tour-content.tsx
+++ b/packages/react/src/components/tour/tour-content.tsx
@@ -2,7 +2,7 @@
 
 import { mergeProps } from '@zag-js/react'
 import { forwardRef } from 'react'
-import { composeRefs } from '../../utils/compose-refs.ts'
+import { useComposedRefs } from '../../utils/compose-refs.ts'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory.ts'
 import { usePresenceContext } from '../presence/index.ts'
 import { useTourContext } from './use-tour-context.ts'
@@ -14,12 +14,13 @@ export const TourContent = forwardRef<HTMLDivElement, TourContentProps>((props, 
   const tour = useTourContext()
   const presence = usePresenceContext()
   const mergedProps = mergeProps(tour.getContentProps(), presence.getPresenceProps(), props)
+  const composedRefs = useComposedRefs(presence.ref, ref)
 
   if (presence.unmounted) {
     return null
   }
 
-  return <ark.div {...mergedProps} ref={composeRefs(presence.ref, ref)} />
+  return <ark.div {...mergedProps} ref={composedRefs} />
 })
 
 TourContent.displayName = 'TourContent'

--- a/packages/react/src/components/tour/tour-spotlight.tsx
+++ b/packages/react/src/components/tour/tour-spotlight.tsx
@@ -2,7 +2,7 @@
 
 import { mergeProps } from '@zag-js/react'
 import { forwardRef } from 'react'
-import { composeRefs } from '../../utils/compose-refs.ts'
+import { useComposedRefs } from '../../utils/compose-refs.ts'
 import { useRenderStrategyPropsContext } from '../../utils/render-strategy.ts'
 import { type HTMLProps, type PolymorphicProps, ark } from '../factory.ts'
 import { usePresence } from '../presence/index.ts'
@@ -20,12 +20,13 @@ export const TourSpotlight = forwardRef<HTMLDivElement, TourSpotlightProps>((pro
   })
   const mergedProps = mergeProps(tour.getSpotlightProps(), presence.getPresenceProps(), props)
   const hidden = !tour.open || !tour.step?.target?.()
+  const composedRefs = useComposedRefs(presence.ref, ref)
 
   if (presence.unmounted) {
     return null
   }
 
-  return <ark.div {...mergedProps} ref={composeRefs(presence.ref, ref)} hidden={hidden} />
+  return <ark.div {...mergedProps} ref={composedRefs} hidden={hidden} />
 })
 
 TourSpotlight.displayName = 'TourSpotlight'

--- a/packages/react/src/utils/compose-refs.test.tsx
+++ b/packages/react/src/utils/compose-refs.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from '@testing-library/react'
+import user from '@testing-library/user-event'
+import { useRef, useState } from 'react'
+import { composeRefs, useComposedRefs } from './compose-refs.ts'
+
+describe('Util: composeRefs', () => {
+  it('should compose callback and object refs', () => {
+    const node = document.createElement('div')
+    const callbackRef = vi.fn()
+    const objectRef = { current: null as HTMLDivElement | null }
+
+    composeRefs(callbackRef, objectRef)(node)
+
+    expect(callbackRef).toHaveBeenCalledWith(node)
+    expect(objectRef.current).toBe(node)
+  })
+
+  it('should run callback ref cleanups', () => {
+    const node = document.createElement('div')
+    const cleanup = vi.fn()
+    const callbackRef = vi.fn(() => cleanup)
+
+    const dispose = composeRefs(callbackRef)(node) as VoidFunction | undefined
+    dispose?.()
+
+    expect(cleanup).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('Util: useComposedRefs', () => {
+  it('should keep stable refs attached across re-renders', async () => {
+    const callbackRef = vi.fn()
+
+    const ComponentUnderTest = () => {
+      const [, setCount] = useState(0)
+      const objectRef = useRef<HTMLDivElement | null>(null)
+      const composedRefs = useComposedRefs(callbackRef, objectRef)
+
+      return (
+        <>
+          <div data-testid="node" ref={composedRefs} />
+          <button type="button" onClick={() => setCount((count) => count + 1)}>
+            re-render
+          </button>
+        </>
+      )
+    }
+
+    render(<ComponentUnderTest />)
+    expect(callbackRef).toHaveBeenCalledWith(screen.getByTestId('node'))
+
+    const callsAfterMount = callbackRef.mock.calls.length
+    await user.click(screen.getByRole('button', { name: /re-render/i }))
+
+    expect(callbackRef).toHaveBeenCalledTimes(callsAfterMount)
+  })
+
+  it('should reattach refs when a constituent callback ref changes', () => {
+    const firstRef = vi.fn()
+    const secondRef = vi.fn()
+
+    const ComponentUnderTest = (props: { callbackRef: (node: HTMLDivElement | null) => void }) => {
+      const composedRefs = useComposedRefs(props.callbackRef)
+      return <div data-testid="node" ref={composedRefs} />
+    }
+
+    const { rerender } = render(<ComponentUnderTest callbackRef={firstRef} />)
+    const node = screen.getByTestId('node')
+
+    rerender(<ComponentUnderTest callbackRef={secondRef} />)
+
+    expect(firstRef).toHaveBeenCalledWith(node)
+    expect(firstRef).toHaveBeenCalledWith(null)
+    expect(secondRef).toHaveBeenCalledWith(node)
+  })
+})

--- a/packages/react/src/utils/compose-refs.ts
+++ b/packages/react/src/utils/compose-refs.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import { useCallback } from 'react'
 import type { Ref, RefCallback } from 'react'
 

--- a/packages/react/src/utils/compose-refs.ts
+++ b/packages/react/src/utils/compose-refs.ts
@@ -1,8 +1,11 @@
-import type { Ref } from 'react'
+'use client'
+
+import { useCallback } from 'react'
+import type { Ref, RefCallback } from 'react'
 
 type PossibleRef<T> = Ref<T | null> | undefined
 
-export function composeRefs<T>(...refs: PossibleRef<T>[]): (node: T | null) => void {
+export function composeRefs<T>(...refs: PossibleRef<T>[]): RefCallback<T> {
   return (node) => {
     const cleanUps: VoidFunction[] = []
 
@@ -25,4 +28,9 @@ export function composeRefs<T>(...refs: PossibleRef<T>[]): (node: T | null) => v
       }
     }
   }
+}
+
+export function useComposedRefs<T>(...refs: PossibleRef<T>[]): RefCallback<T> {
+  // biome-ignore lint/correctness/useExhaustiveDependencies: refs is the dependency list for the composed callback
+  return useCallback(composeRefs(...refs), refs)
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a memoized `useComposedRefs` hook for React ref composition
- replace inline `composeRefs(...)` render calls across React components and the factory `asChild` path
- add regression coverage for stable callback refs in the utility, Field.Textarea, and factory asChild paths

## Tests
- `bun run react test:ci src/utils/compose-refs.test.tsx src/components/field/field.test.tsx src/components/factory.test.tsx`
- `bun run react typecheck`
- `bun run react lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6f454c92-cb6a-4c96-baa2-1b57b03086ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6f454c92-cb6a-4c96-baa2-1b57b03086ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

