### PR TITLE
chore: add changeset for vue presence detached DOM fix (#3929)

### DIFF
--- a/.changeset/vue-presence-detached-dom.md
+++ b/.changeset/vue-presence-detached-dom.md
@@ -1,0 +1,7 @@
+---
+"@ark-ui/vue": patch
+---
+
+Fixed Presence-based components (Dialog, Popover, Menu, Tooltip, etc.) leaking detached DOM
+nodes after each open/close cycle when `lazyMount`/`unmountOnExit` is used. The machine's
+`node` and `styles` refs are now cleared when the element unmounts.


### PR DESCRIPTION
Adds the missing changeset for #3929 (merged in 85b8aa5), which fixed Presence-based components leaking detached DOM nodes after close in `@ark-ui/vue`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)