### PR TITLE
fix(react): fix compose refs

### DIFF
--- a/packages/react/src/utils/compose-refs.test.tsx
+++ b/packages/react/src/utils/compose-refs.test.tsx
@@ -15,15 +15,37 @@ describe('Util: composeRefs', () => {
     expect(objectRef.current).toBe(node)
   })
 
-  it('should run callback ref cleanups', () => {
+  it('should clean up mixed refs: cleanup callback, plain callback, and object ref', () => {
     const node = document.createElement('div')
     const cleanup = vi.fn()
-    const callbackRef = vi.fn(() => cleanup)
+    const refWithCleanup = vi.fn(() => cleanup)
+    const refWithoutCleanup = vi.fn()
+    const objectRef = { current: null as HTMLDivElement | null }
 
-    const dispose = composeRefs(callbackRef)(node) as VoidFunction | undefined
+    const dispose = composeRefs(refWithCleanup, refWithoutCleanup, objectRef)(node) as VoidFunction | undefined
+    expect(dispose).toBeTypeOf('function')
+
     dispose?.()
 
     expect(cleanup).toHaveBeenCalledTimes(1)
+    expect(refWithoutCleanup).toHaveBeenCalledWith(null)
+    expect(objectRef.current).toBeNull()
+  })
+
+  it('should not return a cleanup function when no ref provides one', () => {
+    const node = document.createElement('div')
+    const refWithoutCleanup = vi.fn()
+    const objectRef = { current: null as HTMLDivElement | null }
+
+    const composed = composeRefs(refWithoutCleanup, objectRef)
+
+    const dispose = composed(node)
+    expect(dispose).toBeUndefined()
+
+    composed(null)
+
+    expect(refWithoutCleanup).toHaveBeenCalledWith(null)
+    expect(objectRef.current).toBeNull()
   })
 })
 

--- a/packages/react/src/utils/compose-refs.ts
+++ b/packages/react/src/utils/compose-refs.ts
@@ -6,19 +6,26 @@ type PossibleRef<T> = Ref<T | null> | undefined
 export function composeRefs<T>(...refs: PossibleRef<T>[]): RefCallback<T> {
   return (node) => {
     const cleanUps: VoidFunction[] = []
+    let hasCustomCleanUp = false
 
     for (const ref of refs) {
       if (typeof ref === 'function') {
         const cb = ref(node)
         if (typeof cb === 'function') {
+          hasCustomCleanUp = true
           cleanUps.push(cb)
+        } else {
+          cleanUps.push(() => ref(null))
         }
       } else if (ref) {
         ref.current = node
+        cleanUps.push(() => {
+          ref.current = null
+        })
       }
     }
 
-    if (cleanUps.length) {
+    if (hasCustomCleanUp) {
       return () => {
         for (const cleanUp of cleanUps) {
           cleanUp()


### PR DESCRIPTION
Closes #3961 

## 📝 Description

`composeRefs` doesn't reset all refs when composed with a React 19 cleanup-returning ref.

Track whether any ref actually supplied a cleanup function. If none did, return undefined from the composed callback (preserving legacy behavior/back-compat with pre-React 19, where React re-invokes the same callback with null). If at least one ref did supply a cleanup, return a single dispose function that resets all refs: invoking real cleanups, calling plain callback refs with null, and nulling out object refs.

## ⛳️ Current behavior (updates)

Plain callback refs and object refs are not cleaned up, only `refWithCleanup`'s returned cleanup runs.

## 🚀 New behavior

Plain callback refs and object refs are not cleanup up correctly.
