### PR TITLE
fix(react): resolve Activity export at runtime

### DIFF
--- a/.changeset/fix-react-activity-import.md
+++ b/.changeset/fix-react-activity-import.md
@@ -1,0 +1,6 @@
+---
+'@ark-ui/react': patch
+---
+
+Fix Next.js 15 production builds failing because React's optional `Activity` export was imported statically. Ark now
+resolves `Activity` at runtime and falls back to `display-none` when the active React build does not expose it.

--- a/packages/react/src/components/collapsible/collapsible-gate.tsx
+++ b/packages/react/src/components/collapsible/collapsible-gate.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { Activity, type ReactNode } from 'react'
+import type { ReactNode } from 'react'
+import { Activity } from '../../utils/react-activity.ts'
 import type { UseCollapsibleReturn } from './use-collapsible.ts'
 
 export interface CollapsibleGateProps {
@@ -15,7 +16,7 @@ export const CollapsibleGate = (props: CollapsibleGateProps) => {
     return null
   }
 
-  if (collapsible.hideMode === 'activity') {
+  if (collapsible.hideMode === 'activity' && Activity) {
     return <Activity mode={collapsible.visible ? 'visible' : 'hidden'}>{children}</Activity>
   }
 

--- a/packages/react/src/components/collapsible/use-collapsible.ts
+++ b/packages/react/src/components/collapsible/use-collapsible.ts
@@ -2,12 +2,11 @@
 
 import * as collapsible from '@zag-js/collapsible'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/react'
-import { Activity, useId, useRef } from 'react'
+import { useId, useRef } from 'react'
 import { useEnvironmentContext, useLocaleContext } from '../../providers/index.ts'
 import type { Optional } from '../../types.ts'
+import { supportsActivity } from '../../utils/react-activity.ts'
 import type { HideMode, RenderStrategyProps } from '../../utils/render-strategy.ts'
-
-const supportsActivity = typeof Activity !== 'undefined'
 
 export interface UseCollapsibleProps
   extends Optional<Omit<collapsible.Props, 'dir' | 'getRootNode'>, 'id'>, RenderStrategyProps {}

--- a/packages/react/src/components/presence/presence-gate.tsx
+++ b/packages/react/src/components/presence/presence-gate.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { Activity, type ReactNode } from 'react'
+import type { ReactNode } from 'react'
+import { Activity } from '../../utils/react-activity.ts'
 import type { UsePresenceReturn } from './use-presence.ts'
 
 export interface PresenceGateProps {
@@ -15,7 +16,7 @@ export const PresenceGate = (props: PresenceGateProps) => {
     return null
   }
 
-  if (presence.hideMode === 'activity') {
+  if (presence.hideMode === 'activity' && Activity) {
     return <Activity mode={presence.present ? 'visible' : 'hidden'}>{children}</Activity>
   }
 

--- a/packages/react/src/components/presence/use-presence.ts
+++ b/packages/react/src/components/presence/use-presence.ts
@@ -2,12 +2,11 @@
 
 import * as presence from '@zag-js/presence'
 import { normalizeProps, useMachine } from '@zag-js/react'
-import { Activity, useRef } from 'react'
+import { useRef } from 'react'
 import type { Optional } from '../../types.ts'
+import { supportsActivity } from '../../utils/react-activity.ts'
 import type { HideMode, RenderStrategyProps } from '../../utils/render-strategy.ts'
 import { useEvent } from '../../utils/use-event.ts'
-
-const supportsActivity = typeof Activity !== 'undefined'
 
 export interface UsePresenceProps extends Optional<presence.Props, 'present'>, RenderStrategyProps {
   /**

--- a/packages/react/src/utils/react-activity.test.ts
+++ b/packages/react/src/utils/react-activity.test.ts
@@ -1,0 +1,13 @@
+import { getActivity } from './react-activity.ts'
+
+describe('getActivity', () => {
+  it('returns undefined when React does not export Activity', () => {
+    expect(getActivity({})).toBeUndefined()
+  })
+
+  it('returns Activity when React exports it', () => {
+    const Activity = vi.fn()
+
+    expect(getActivity({ Activity })).toBe(Activity)
+  })
+})

--- a/packages/react/src/utils/react-activity.ts
+++ b/packages/react/src/utils/react-activity.ts
@@ -1,0 +1,17 @@
+'use client'
+
+import * as React from 'react'
+import type { ComponentType, ReactNode } from 'react'
+
+interface ActivityProps {
+  children?: ReactNode | undefined
+  mode: 'visible' | 'hidden'
+}
+
+type ActivityComponent = ComponentType<ActivityProps>
+
+export const getActivity = (react: object): ActivityComponent | undefined =>
+  Reflect.get(react, 'Activity') as ActivityComponent | undefined
+
+export const Activity = getActivity(React)
+export const supportsActivity = Activity !== undefined


### PR DESCRIPTION
## Summary

- resolve React's optional `Activity` export at runtime instead of importing it statically
- share the capability check between Presence and Collapsible and guard both Activity boundaries
- add regression coverage for React builds that do not expose `Activity`

Fixes #3966.

## Why

Next.js 15 aliases React to a bundled build during production compilation. That build does not expose the stable `Activity` named export, so `@ark-ui/react@5.38.1` currently fails to compile before the existing `supportsActivity` fallback can run.

Using `Reflect.get` prevents webpack from requiring the optional named export at build time. React builds with `Activity` keep the existing behavior; builds without it fall back to `display-none` as intended.

## Testing

- `bun run --cwd packages/react test:ci` — 48 files, 382 passed, 5 skipped
- `bun run --cwd packages/react typecheck`
- `bun run --cwd packages/react lint`
- `bun run --cwd packages/react build`
- `bun check:exports`
- packed `@ark-ui/react` from this branch, installed it in a minimal Next.js 15.5.19 / React 19.2.6 app using Tabs with `hideMode="activity"`, and verified `next build` succeeds
