### PR TITLE
fix(ci): rename changesets action inputs for v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,9 +37,9 @@ jobs:
         id: changesets
         uses: changesets/action@v2.1.1
         with:
-          version: bun run version
-          publish: bun run release
-          title: 'chore: release packages'
-          commit: 'chore: release packages'
+          version-script: bun run version
+          publish-script: bun run release
+          pr-title: 'chore: release packages'
+          commit-message: 'chore: release packages'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Releases have been failing on `main` since #3975 bumped `changesets/action` to v2:

```
Error: The following inputs have been renamed:
- "publish" -> "publish-script"
- "version" -> "version-script"
- "commit"  -> "commit-message"
- "title"   -> "pr-title"
```

v2 renamed every input this workflow passes. Renovate bumped the version string but cannot rewrite the `with:` block, so the action rejected all four.

This renames them. No behaviour change otherwise.

The publish path is unaffected: there is no `NPM_TOKEN` here, so v2's removal of `.npmrc` handling does not apply, and auth still goes through npm OIDC via `id-token: write` and `setup-node`'s `registry-url`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0133qcH6rpUR3edEeGJSxsF1