### PR TITLE
fix(website): scroll the current page into view in the docs sidebar

### DIFF
--- a/website/src/components/navigation/docs/docs-sidebar.tsx
+++ b/website/src/components/navigation/docs/docs-sidebar.tsx
@@ -3,6 +3,7 @@ import { Collapsible } from '@ark-ui/react/collapsible'
 import { ChevronRightIcon } from 'lucide-react'
 import NextLink from 'next/link'
 import { usePathname } from 'next/navigation'
+import { useEffect, useRef } from 'react'
 import { Badge } from '~/components/ui/badge'
 import { Icon } from '~/components/ui/icon'
 import type { SidebarGroup } from '~/lib/sidebar'
@@ -17,6 +18,13 @@ interface Props {
 export const DocsSidebar = (props: Props) => {
   const { groups } = props
   const pathname = usePathname()
+  const currentRef = useRef<HTMLAnchorElement>(null)
+
+  // On load the sidebar starts at the top, so a page low in the list is scrolled out of sight.
+  // `nearest` brings it in without moving anything when it is already visible.
+  useEffect(() => {
+    currentRef.current?.scrollIntoView({ block: 'nearest' })
+  }, [])
 
   return (
     <nav>
@@ -34,11 +42,13 @@ export const DocsSidebar = (props: Props) => {
                 <ul>
                   {group.items.map((item) => {
                     const href = `/docs/${item.slug}`
+                    const isCurrent = pathname === href
                     return (
                       <li key={item.id}>
                         <NextLink
+                          ref={isCurrent ? currentRef : undefined}
                           href={href}
-                          aria-current={pathname === href ? 'page' : undefined}
+                          aria-current={isCurrent ? 'page' : undefined}
                           className={styles.link}
                         >
                           {item.title}

--- a/website/src/theme/recipes/layout.ts
+++ b/website/src/theme/recipes/layout.ts
@@ -20,6 +20,8 @@ export const layout = defineSlotRecipe({
       minWidth: '272px',
       overflow: 'auto',
       overscrollBehavior: 'contain',
+      // keeps the current page off the edge when it is scrolled into view on load
+      scrollPaddingBlock: '6rem',
       width: {
         base: '272px',
         lg: 'calc((100vw - (1440px - 64px)) / 2 + 272px - 32px)',


### PR DESCRIPTION
Open any docs page low in the sidebar and the sidebar shows the top of the list. The page you are on is not in view.

On `/docs/utilities/hotkeys` the current link sat at `y=2811` inside a scroller `998px` tall, with `scrollTop: 0`. Roughly 1800px below the fold. You cannot see where you are without scrolling to find yourself.

## Fix

Scroll the current link into view on mount.

```tsx
const currentRef = useRef<HTMLAnchorElement>(null)

useEffect(() => {
  currentRef.current?.scrollIntoView({ block: 'nearest' })
}, [])
```

Two choices worth calling out.

`nearest` rather than `center`, because it does nothing when the item is already visible. Pages near the top of the sidebar get no pointless jump on load.

Mount only, not on every pathname change. Navigating within the docs should not yank the sidebar under the pointer you just clicked with. On load it is orientation, mid-session it is interference.

## Scroll padding

`nearest` scrolls the minimum, so the link lands flush against the edge with nothing visible past it. `scrollPaddingBlock: '6rem'` on the aside fixes that, and `scrollIntoView` honors it natively with no JS math.

It went on the `aside` slot in `theme/recipes/layout.ts` rather than the shared `.scroller` class, so the table of contents is unaffected. `Block` rather than `top` so it applies from either direction.

## Measured

On `/docs/utilities/hotkeys`, viewport 998px:

| | before | after |
|---|---|---|
| aside `scrollTop` | 0 | 1942 |
| current link visible | no | yes |
| gap below the link | 0 | 96px |
| `window.scrollY` | 0 | 0 |

The page itself does not move, only the sidebar.
