### PR TITLE
feat: expose DOM attribute utilities

### DIFF
--- a/.changeset/expose-dom-attribute-utils.md
+++ b/.changeset/expose-dom-attribute-utils.md
@@ -1,0 +1,8 @@
+---
+'@ark-ui/react': patch
+'@ark-ui/solid': patch
+'@ark-ui/svelte': patch
+'@ark-ui/vue': patch
+---
+
+Expose `ariaAttr` and `dataAttr` from the package root.

--- a/packages/react/src/components/field/use-field.ts
+++ b/packages/react/src/components/field/use-field.ts
@@ -1,8 +1,8 @@
 'use client'
 
-import { ariaAttr, dataAttr } from '@zag-js/dom-query'
 import { useId, useMemo, useRef, useState } from 'react'
 import { useEnvironmentContext } from '../../providers/index.ts'
+import { ariaAttr, dataAttr } from '../../utils/attr.ts'
 import { useSafeLayoutEffect } from '../../utils/use-safe-layout-effect.ts'
 import type { HTMLProps } from '../factory.ts'
 import { useFieldsetContext } from '../fieldset/use-fieldset-context.ts'

--- a/packages/react/src/components/fieldset/use-fieldset.ts
+++ b/packages/react/src/components/fieldset/use-fieldset.ts
@@ -1,8 +1,8 @@
 'use client'
 
-import { dataAttr } from '@zag-js/dom-query'
 import { useId, useRef, useState } from 'react'
 import { useEnvironmentContext } from '../../providers/index.ts'
+import { dataAttr } from '../../utils/attr.ts'
 import { useSafeLayoutEffect } from '../../utils/use-safe-layout-effect.ts'
 import type { HTMLProps } from '../factory.ts'
 import { parts } from './fieldset.anatomy.ts'

--- a/packages/react/src/utils/attr.ts
+++ b/packages/react/src/utils/attr.ts
@@ -1,0 +1,1 @@
+export { ariaAttr, dataAttr } from '@zag-js/dom-query'

--- a/packages/react/src/utils/index.ts
+++ b/packages/react/src/utils/index.ts
@@ -1,2 +1,3 @@
+export { ariaAttr, dataAttr } from './attr.ts'
 export { createContext } from './create-context.ts'
 export { mergeProps } from '@zag-js/core'

--- a/packages/solid/src/components/field/use-field.ts
+++ b/packages/solid/src/components/field/use-field.ts
@@ -1,6 +1,6 @@
-import { ariaAttr, dataAttr } from '@zag-js/dom-query'
 import { createMemo, createSignal, createUniqueId, mergeProps, onCleanup, onMount } from 'solid-js'
 import { useEnvironmentContext } from '../../providers/index.tsx'
+import { ariaAttr, dataAttr } from '../../utils/attr.ts'
 import type { MaybeAccessor } from '../../types.ts'
 import { useFieldsetContext } from '../fieldset/index.tsx'
 import type { UseFieldsetReturn } from '../fieldset/use-fieldset.ts'

--- a/packages/solid/src/components/fieldset/use-fieldset.ts
+++ b/packages/solid/src/components/fieldset/use-fieldset.ts
@@ -1,6 +1,6 @@
-import { dataAttr } from '@zag-js/dom-query'
 import { createMemo, createSignal, createUniqueId, mergeProps, onCleanup, onMount } from 'solid-js'
 import { useEnvironmentContext } from '../../providers/index.tsx'
+import { dataAttr } from '../../utils/attr.ts'
 import type { MaybeAccessor } from '../../types.ts'
 import { runIfFn } from '../../utils/run-if-fn.ts'
 import { parts } from './fieldset.anatomy.ts'

--- a/packages/solid/src/utils/attr.ts
+++ b/packages/solid/src/utils/attr.ts
@@ -1,0 +1,1 @@
+export { ariaAttr, dataAttr } from '@zag-js/dom-query'

--- a/packages/solid/src/utils/index.tsx
+++ b/packages/solid/src/utils/index.tsx
@@ -1,2 +1,3 @@
+export { ariaAttr, dataAttr } from './attr.ts'
 export { createContext } from './create-context.ts'
 export { mergeProps } from '@zag-js/core'

--- a/packages/svelte/src/lib/components/field/use-field.svelte.ts
+++ b/packages/svelte/src/lib/components/field/use-field.svelte.ts
@@ -1,8 +1,8 @@
 import { useEnvironmentContext } from '$lib/providers'
 import type { HTMLProps } from '$lib/types'
-import { ariaAttr, dataAttr } from '@zag-js/dom-query'
 import { type MaybeFunction, ensureProps, runIfFn } from '@zag-js/utils'
 import { onMount } from 'svelte'
+import { ariaAttr, dataAttr } from '../../utils/attr.ts'
 import { useFieldsetContext } from '../fieldset/use-fieldset-context.ts'
 import { parts } from './field.anatomy.ts'
 

--- a/packages/svelte/src/lib/components/fieldset/use-fieldset.svelte.ts
+++ b/packages/svelte/src/lib/components/fieldset/use-fieldset.svelte.ts
@@ -1,9 +1,9 @@
 import { useEnvironmentContext } from '$lib/providers'
 import type { HTMLProps } from '$lib/types'
 import { runIfFn } from '$lib/utils/run-if-fn'
-import { dataAttr } from '@zag-js/dom-query'
 import { type MaybeFunction, ensureProps } from '@zag-js/utils'
 import { onMount } from 'svelte'
+import { dataAttr } from '../../utils/attr.ts'
 import { parts } from './fieldset.anatomy.ts'
 
 export interface UseFieldsetProps {

--- a/packages/svelte/src/lib/utils/attr.ts
+++ b/packages/svelte/src/lib/utils/attr.ts
@@ -1,0 +1,1 @@
+export { ariaAttr, dataAttr } from '@zag-js/dom-query'

--- a/packages/svelte/src/lib/utils/index.ts
+++ b/packages/svelte/src/lib/utils/index.ts
@@ -1,2 +1,3 @@
+export { ariaAttr, dataAttr } from './attr.ts'
 export { createContext } from './create-context.ts'
 export { mergeProps } from '@zag-js/core'

--- a/packages/vue/src/components/field/use-field.ts
+++ b/packages/vue/src/components/field/use-field.ts
@@ -1,4 +1,3 @@
-import { ariaAttr, dataAttr } from '@zag-js/dom-query'
 import {
   type HTMLAttributes,
   type MaybeRef,
@@ -12,6 +11,7 @@ import {
 } from 'vue'
 import { useEnvironmentContext } from '../../providers/index.ts'
 import { DEFAULT_ENVIRONMENT } from '../../providers/environment/use-environment-context.ts'
+import { ariaAttr, dataAttr } from '../../utils/attr.ts'
 import { unrefElement } from '../../utils/unref-element.ts'
 import { parts } from './field.anatomy.ts'
 import type { ElementIds } from './field.types.ts'

--- a/packages/vue/src/components/fieldset/use-fieldset.ts
+++ b/packages/vue/src/components/fieldset/use-fieldset.ts
@@ -1,4 +1,3 @@
-import { dataAttr } from '@zag-js/dom-query'
 import {
   type FieldsetHTMLAttributes,
   type HTMLAttributes,
@@ -12,6 +11,7 @@ import {
   useId,
 } from 'vue'
 import { DEFAULT_ENVIRONMENT, useEnvironmentContext } from '../../providers/index.ts'
+import { dataAttr } from '../../utils/attr.ts'
 import { unrefElement } from '../../utils/unref-element.ts'
 import { parts } from './fieldset.anatomy.ts'
 

--- a/packages/vue/src/utils/attr.ts
+++ b/packages/vue/src/utils/attr.ts
@@ -1,0 +1,1 @@
+export { ariaAttr, dataAttr } from '@zag-js/dom-query'

--- a/packages/vue/src/utils/index.ts
+++ b/packages/vue/src/utils/index.ts
@@ -1,3 +1,4 @@
+export { ariaAttr, dataAttr } from './attr.ts'
 export { createContext } from './create-context.ts'
 export { mergeProps } from '@zag-js/core'
 export { useEmitAsProps } from './use-emits-as-props.ts'


### PR DESCRIPTION
## Summary

- expose `ariaAttr` and `dataAttr` from each framework package root through Ark-owned `utils/attr.ts` modules
- use the local utility modules in existing field and fieldset implementations
- add patch changesets for React, Solid, Svelte, and Vue