### PR TITLE
fix(tour): keep the backdrop hidden after the tour closes

### DIFF
--- a/.changeset/tour-backdrop-presence-hidden.md
+++ b/.changeset/tour-backdrop-presence-hidden.md
@@ -1,0 +1,6 @@
+---
+'@ark-ui/react': patch
+'@ark-ui/solid': patch
+---
+
+Fix issue where the tour backdrop stayed visible after the tour was closed

--- a/.changeset/tour-backdrop-presence-hidden.md
+++ b/.changeset/tour-backdrop-presence-hidden.md
@@ -1,6 +1,7 @@
 ---
 '@ark-ui/react': patch
 '@ark-ui/solid': patch
+'@ark-ui/svelte': patch
 ---
 
 Fix issue where the tour backdrop stayed visible after the tour was closed

--- a/packages/react/src/components/tour/tour-backdrop.tsx
+++ b/packages/react/src/components/tour/tour-backdrop.tsx
@@ -24,7 +24,7 @@ export const TourBackdrop = forwardRef<HTMLDivElement, TourBackdropProps>((props
 
   return (
     <PresenceGate presence={presence}>
-      <ark.div {...mergedProps} ref={composedRefs} hidden={!tour.step?.backdrop} />
+      <ark.div {...mergedProps} ref={composedRefs} hidden={mergedProps.hidden || !tour.step?.backdrop} />
     </PresenceGate>
   )
 })

--- a/packages/solid/src/components/tour/tour-backdrop.tsx
+++ b/packages/solid/src/components/tour/tour-backdrop.tsx
@@ -21,7 +21,11 @@ export const TourBackdrop = (props: TourBackdropProps) => {
 
   return (
     <Show when={!presence().unmounted}>
-      <ark.div {...mergedProps} hidden={!tour().step?.backdrop} ref={composeRefs(presence().ref, props.ref)} />
+      <ark.div
+        {...mergedProps}
+        hidden={mergedProps.hidden || !tour().step?.backdrop}
+        ref={composeRefs(presence().ref, props.ref)}
+      />
     </Show>
   )
 }

--- a/packages/svelte/src/lib/components/tour/tour-backdrop.svelte
+++ b/packages/svelte/src/lib/components/tour/tour-backdrop.svelte
@@ -29,5 +29,5 @@
 </script>
 
 {#if !presence().unmounted}
-  <Ark as="div" bind:ref {...mergedProps} {@attach setNode} hidden={!tour().step?.backdrop} />
+  <Ark as="div" bind:ref {...mergedProps} {@attach setNode} hidden={mergedProps.hidden || !tour().step?.backdrop} />
 {/if}


### PR DESCRIPTION
## Problem

`Tour.Backdrop` applies `hidden` *after* merging the presence props, so it discards the `hidden` that presence itself provides:

```tsx
const mergedProps = mergeProps(tour.getBackdropProps(), presence.getPresenceProps(), props)
…
<ark.div {...mergedProps} ref={composedRefs} hidden={!tour.step?.backdrop} />
```

With the default render strategy (`unmountOnExit: false`) the node stays mounted after the tour closes, and presence sets `hidden: true` on it. That value is dropped, and `!tour.step?.backdrop` is `false` at that point, because the machine keeps `step` after a dismiss — `DISMISS` no longer runs `clearStep` as of `@zag-js/tour@1.43.3`. So the backdrop stays on screen for good, while the content disappears (the machine sets `hidden` on that one itself).

Reproducible on the docs site with any tour that has a backdrop: start it, close it, and the dimming remains. Measured on the closed backdrop: `hidden="false"`, `data-state="closed"`, `data-type="tooltip"` (the retained step), `display: block`.

Up to `@ark-ui/react@5.37.2` the same line was harmless: closing the tour cleared `step`, so `!tour.step?.backdrop` happened to be `true` and hid the node.

## Fix

Keep both reasons to hide, rather than only the step's:

```tsx
hidden={mergedProps.hidden || !tour.step?.backdrop}
```

Reordering the merge so presence wins outright would break the other direction: for a step with `backdrop: false`, presence's `hidden: false` would take over while the tour is open, and the backdrop would appear where it shouldn't.

Solid has the same shape and gets the same change. Vue is unaffected: it renders through `v-if` and binds the merged props, so presence's `hidden` isn't overridden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)