### PR TITLE
docs: add a pull request template and contributor setup guide

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,7 +5,7 @@
   "fixed": [],
   "linked": [],
   "access": "public",
-  "baseBranch": "main",
+  "baseBranch": "v6",
   "updateInternalDependencies": "patch",
   "ignore": ["@ark-ui/next-js", "@ark-ui/nuxt", "@ark-ui/solid-start", "svelte-kit", "@ark-ui/scripts"]
 }

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,54 @@
+<!---
+Thanks for opening a pull request 💜
+
+Before you submit:
+- Keep it to one type: feature, fix, docs, refactor, ci.
+- Keep it small. Big PRs sit in review longer.
+- New external dependencies need a reason in the description.
+- Title follows conventional commits (https://www.conventionalcommits.org).
+- Working on v6? Branch from `v6` and target `v6`, not `main`.
+-->
+
+Closes # <!-- GitHub issue # here -->
+
+## Description
+
+> What this changes, in a sentence or two. Lead with the point.
+
+## Current behavior
+
+> What happens today. Skip this if you're adding something new.
+
+## New behavior
+
+> What happens after this PR.
+
+## Frameworks
+
+> Ark keeps the same API across frameworks. Tick what this PR covers. If one is missing, say why here.
+
+- [ ] React
+- [ ] Solid
+- [ ] Svelte
+- [ ] Vue
+- [ ] Not framework-specific
+
+## Is this a breaking change (Yes/No):
+
+<!-- If Yes, describe the impact and the migration path for existing Ark users. -->
+
+## Checklist
+
+- [ ] Added a changeset for user-facing changes
+- [ ] Added or updated tests
+- [ ] Added an example for any new prop or part
+- [ ] Updated the docs
+
+## Additional information
+
+<!-- Tradeoffs, follow-ups, anything a reviewer should know. -->
+
+<!---
+Used AI tools on this? Make sure the code and this description reflect your own
+understanding, and write it in your own voice.
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,19 +11,19 @@ Before you submit:
 
 Closes # <!-- GitHub issue # here -->
 
-## Description
+## 📝 Description
 
 > What this changes, in a sentence or two. Lead with the point.
 
-## Current behavior
+## ⛳️ Current behavior
 
 > What happens today. Skip this if you're adding something new.
 
-## New behavior
+## 🚀 New behavior
 
 > What happens after this PR.
 
-## Frameworks
+## 🧩 Frameworks
 
 > Ark keeps the same API across frameworks. Tick what this PR covers. If one is missing, say why here.
 
@@ -33,18 +33,18 @@ Closes # <!-- GitHub issue # here -->
 - [ ] Vue
 - [ ] Not framework-specific
 
-## Is this a breaking change (Yes/No):
+## 💣 Is this a breaking change (Yes/No):
 
 <!-- If Yes, describe the impact and the migration path for existing Ark users. -->
 
-## Checklist
+## ✅ Checklist
 
 - [ ] Added a changeset for user-facing changes
 - [ ] Added or updated tests
 - [ ] Added an example for any new prop or part
 - [ ] Updated the docs
 
-## Additional information
+## 📝 Additional information
 
 <!-- Tradeoffs, follow-ups, anything a reviewer should know. -->
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,58 @@ We use GitHub issues to track public bugs. Report a bug by
 By contributing, you agree that your contributions will be licensed under its
 [License](https://github.com/chakra-ui/ark/blob/main/LICENSE).
 
+## Set up the repo
+
+Ark is a bun monorepo. You need [bun](https://bun.sh) installed.
+
+```bash
+bun install
+bun run build
+```
+
+Run a framework's Storybook on port 6006:
+
+```bash
+bun run react dev   # or: solid, svelte, vue
+```
+
+The checks CI runs:
+
+```bash
+bun run typecheck
+bun run test
+bun run lint
+bun run format
+```
+
+## Pick the right base branch
+
+Most work targets `main`.
+
+Work on the next major targets [`v6`](https://github.com/chakra-ui/ark/tree/v6). It's a long-lived branch that merges
+into `main` once, at the end, so branch from `v6` and open your PR against `v6`. See
+[the v6 roadmap](https://github.com/chakra-ui/ark/discussions/3997) for what's in scope.
+
+## Keep the frameworks in sync
+
+Ark ships the same component API for React, Solid, Svelte and Vue. A change to one framework usually belongs in the
+other three, in the same PR.
+
+If you can only do one, say so in the PR description and open an issue for the rest. A framework left behind is how
+components drift apart.
+
+## Add a changeset
+
+Any change users can see needs a changeset:
+
+```bash
+bun changeset
+```
+
+Pick the packages you touched, pick the bump, and write the entry as release notes — what changed and why it matters to
+someone upgrading, not what you did to the code. Skip it for changes with no user-facing effect, like CI or internal
+refactors.
+
 ## Discuss changes before starting to work on them
 
 Please first discuss the change you wish to make via issue, email, or any other method with the owners of this


### PR DESCRIPTION


## 📝 Description

Ark had no pull request template. This adds one, based on panda's, plus the setup and workflow bits contributors had to
guess at.

## ⛳️ Current behavior

No template, so descriptions are freeform. `CONTRIBUTING.md` covers bug reports and licensing, but nothing about running
the repo, base branches, framework parity, or changesets.

## 🚀 New behavior

- `.github/pull_request_template.md`, with two sections specific to Ark: **Frameworks**, since a change to one usually
  belongs in the other three, and a **Checklist**.
- `CONTRIBUTING.md`: repo setup, which base branch to use now `v6` is long-lived, framework parity, changesets.
- `.changeset/config.json`: `baseBranch` → `v6` on this branch, so changesets stops diffing against `main`. `main` keeps
  `main`, the same split panda uses with `v2`.

## 🧩 Frameworks

- [x] Not framework-specific

## 💣 Is this a breaking change (Yes/No):

No.

## ✅ Checklist

- [x] Updated the docs

Nothing here ships to a package, so no changeset, tests or examples.

## 📝 Additional information

Tests and Typecheck are red on `v6` while the major is in progress, not from this PR. Roadmap: #3997