### PR TITLE
fix(website): migrate the docs site to the v6 api

### DIFF
--- a/.storybook/modules/tree-view.module.css
+++ b/.storybook/modules/tree-view.module.css
@@ -149,9 +149,7 @@
     }
   }
 
-  &[data-type='selected'],
-  &[data-type='checked'],
-  &[data-type='indeterminate'] {
+  &[data-type='selected'] {
     color: var(--demo-coral-solid);
   }
 

--- a/website/src/components/auth/verify-otp-dialog.tsx
+++ b/website/src/components/auth/verify-otp-dialog.tsx
@@ -69,7 +69,7 @@ export const VerfiyOtpDialog = (props: Props) => {
             <Card.Body>
               <form onSubmit={handleSubmit}>
                 <Stack gap="3">
-                  <PinInput otp value={otp} length={6} onValueChange={(e) => setOtp(e.value)} />
+                  <PinInput otp value={otp} count={6} onValueChange={(e) => setOtp(e.value)} />
                   <Button type="submit" loading={loading}>
                     Submit
                   </Button>

--- a/website/src/components/navigation/mobile-navbar.tsx
+++ b/website/src/components/navigation/mobile-navbar.tsx
@@ -25,7 +25,6 @@ export const MobileNavbar = (props: PropsWithChildren) => {
         overflowPadding: 0,
         offset: { mainAxis: 12 },
       }}
-      portalled
     >
       <Popover.Trigger asChild>
         <IconButton aria-label="Open Menu" variant="ghost">

--- a/website/src/components/ui/primitives/tree-view.tsx
+++ b/website/src/components/ui/primitives/tree-view.tsx
@@ -13,7 +13,7 @@ export const treeView = sva({
       width: 'full',
       color: 'fg.default',
     },
-    branchContent: {
+    nodeGroupContent: {
       position: 'relative',
       overflow: 'hidden',
       transitionProperty: 'padding-bottom',
@@ -26,7 +26,7 @@ export const treeView = sva({
         animation: 'collapse-out',
       },
     },
-    branchIndentGuide: {
+    indentGuide: {
       height: '100%',
       width: '1px',
       bg: 'border.default',
@@ -36,18 +36,14 @@ export const treeView = sva({
         left: '3',
       },
     },
-    branchControl: {
+    node: {
       alignItems: 'center',
       borderRadius: 'l2',
+      cursor: 'pointer',
       display: 'flex',
       gap: '1.5',
-      ps: 'calc((var(--depth) - 1) * 22px)',
       py: '1.5',
-      cursor: 'pointer',
       userSelect: 'none',
-      "&[data-depth='1']": {
-        ps: '1',
-      },
       _hover: {
         background: 'gray.a2',
         color: 'fg.default',
@@ -55,54 +51,51 @@ export const treeView = sva({
       _selected: {
         color: 'colorPalette.default!',
       },
-    },
-    branchIndicator: {
-      color: 'colorPalette.default',
-      transformOrigin: 'center',
-      transitionDuration: 'normal',
-      transitionProperty: 'transform',
-      transitionTimingFunction: 'default',
-
-      _open: {
-        transform: 'rotate(90deg)',
+      '&[data-branch]': {
+        ps: 'calc((var(--depth) - 1) * 22px)',
+        "&[data-depth='1']": {
+          ps: '1',
+        },
+      },
+      '&:not([data-branch])': {
+        gap: '2',
+        position: 'relative',
+        ps: 'calc(((var(--depth) - 1) * 22px) + 22px)',
+        "&[data-depth='1']": {
+          ps: '6',
+          color: 'fg.default',
+        },
       },
     },
-    item: {
+    cell: {
       display: 'flex',
       alignItems: 'center',
       gap: '2',
-      borderRadius: 'l2',
-      cursor: 'pointer',
-      position: 'relative',
-      ps: 'calc(((var(--depth) - 1) * 22px) + 22px)',
-      py: '1.5',
-      "&[data-depth='1']": {
-        ps: '6',
-        color: 'fg.default',
+      flex: '1',
+      minWidth: '0',
+    },
+    nodeIndicator: {
+      "&[data-type='expanded']": {
+        color: 'colorPalette.default',
+        transformOrigin: 'center',
+        transitionDuration: 'normal',
+        transitionProperty: 'transform',
+        transitionTimingFunction: 'default',
+        _open: {
+          transform: 'rotate(90deg)',
+        },
       },
-      _hover: {
-        background: 'gray.a2',
-        color: 'fg.default',
-      },
-      _selected: {
-        color: 'colorPalette.default!',
+      "&[data-type='selected']": {
+        _icon: {
+          width: '3',
+          height: '3',
+        },
       },
     },
-    itemText: {
+    nodeText: {
       display: 'flex',
       alignItems: 'center',
       gap: '2',
-    },
-    branchText: {
-      display: 'flex',
-      alignItems: 'center',
-      gap: '2',
-    },
-    itemIndicator: {
-      _icon: {
-        width: '3',
-        height: '3',
-      },
     },
     tree: {
       display: 'flex',
@@ -130,55 +123,45 @@ export const Root = withProvider<
   Assign<Assign<HTMLStyledProps<'div'>, TreeView.RootBaseProps<TreeNode>>, TreeViewVariantProps>
 >(TreeView.Root, 'root')
 
-export const BranchContent = withContext<
+export const NodeGroupContent = withContext<
   HTMLDivElement,
-  Assign<HTMLStyledProps<'div'>, TreeView.BranchContentBaseProps>
->(TreeView.BranchContent, 'branchContent')
+  Assign<HTMLStyledProps<'div'>, TreeView.NodeGroupContentBaseProps>
+>(TreeView.NodeGroupContent, 'nodeGroupContent')
 
-export const BranchIndentGuide = withContext<
-  HTMLDivElement,
-  Assign<HTMLStyledProps<'div'>, TreeView.BranchIndentGuideBaseProps>
->(TreeView.BranchIndentGuide, 'branchIndentGuide')
-
-export const BranchControl = withContext<
-  HTMLDivElement,
-  Assign<HTMLStyledProps<'div'>, TreeView.BranchControlBaseProps>
->(TreeView.BranchControl, 'branchControl')
-
-export const BranchIndicator = withContext<
-  HTMLDivElement,
-  Assign<HTMLStyledProps<'div'>, TreeView.BranchIndicatorBaseProps>
->(TreeView.BranchIndicator, 'branchIndicator')
-
-export const Branch = withContext<HTMLDivElement, Assign<HTMLStyledProps<'div'>, TreeView.BranchBaseProps>>(
-  TreeView.Branch,
-  'branch',
+export const IndentGuide = withContext<HTMLDivElement, Assign<HTMLStyledProps<'div'>, TreeView.IndentGuideBaseProps>>(
+  TreeView.IndentGuide,
+  'indentGuide',
 )
 
-export const BranchText = withContext<HTMLSpanElement, Assign<HTMLStyledProps<'span'>, TreeView.BranchTextBaseProps>>(
-  TreeView.BranchText,
-  'branchText',
+export const Node = withContext<HTMLDivElement, Assign<HTMLStyledProps<'div'>, TreeView.NodeBaseProps>>(
+  TreeView.Node,
+  'node',
 )
 
-export const BranchTrigger = withContext<
+export const Cell = withContext<HTMLDivElement, Assign<HTMLStyledProps<'div'>, TreeView.CellBaseProps>>(
+  TreeView.Cell,
+  'cell',
+)
+
+export const NodeIndicator = withContext<
   HTMLDivElement,
-  Assign<HTMLStyledProps<'div'>, TreeView.BranchTriggerBaseProps>
->(TreeView.BranchTrigger, 'branchTrigger')
+  Assign<HTMLStyledProps<'div'>, TreeView.NodeIndicatorBaseProps>
+>(TreeView.NodeIndicator, 'nodeIndicator')
 
-export const ItemIndicator = withContext<
+export const NodeGroup = withContext<HTMLDivElement, Assign<HTMLStyledProps<'div'>, TreeView.NodeGroupBaseProps>>(
+  TreeView.NodeGroup,
+  'nodeGroup',
+)
+
+export const NodeText = withContext<HTMLSpanElement, Assign<HTMLStyledProps<'span'>, TreeView.NodeTextBaseProps>>(
+  TreeView.NodeText,
+  'nodeText',
+)
+
+export const NodeExpandTrigger = withContext<
   HTMLDivElement,
-  Assign<HTMLStyledProps<'div'>, TreeView.ItemIndicatorBaseProps>
->(TreeView.ItemIndicator, 'itemIndicator')
-
-export const Item = withContext<HTMLDivElement, Assign<HTMLStyledProps<'div'>, TreeView.ItemBaseProps>>(
-  TreeView.Item,
-  'item',
-)
-
-export const ItemText = withContext<HTMLSpanElement, Assign<HTMLStyledProps<'span'>, TreeView.ItemTextBaseProps>>(
-  TreeView.ItemText,
-  'itemText',
-)
+  Assign<HTMLStyledProps<'div'>, TreeView.NodeExpandTriggerBaseProps>
+>(TreeView.NodeExpandTrigger, 'nodeExpandTrigger')
 
 export const Label = withContext<HTMLHeadingElement, Assign<HTMLStyledProps<'h3'>, TreeView.LabelBaseProps>>(
   TreeView.Label,

--- a/website/src/components/ui/tree-view.tsx
+++ b/website/src/components/ui/tree-view.tsx
@@ -4,12 +4,18 @@ import { ChevronRightIcon, FileIcon, FolderIcon, FolderOpenIcon } from 'lucide-r
 import { forwardRef } from 'react'
 import * as ArkTreeView from './primitives/tree-view'
 
+interface NodeData {
+  id: string
+  name: string
+  children?: NodeData[]
+}
+
 export const TreeView = forwardRef<HTMLDivElement, ArkTreeView.RootProps>((props, ref) => {
+  const rootNodes: NodeData[] = props.collection.rootNode.children ?? []
   return (
     <ArkTreeView.Root ref={ref} {...props}>
       <ArkTreeView.Tree>
-        {/* @ts-expect-error */}
-        {props.collection.rootNode.children.map((node, index) => (
+        {rootNodes.map((node, index) => (
           <TreeNode key={node.id} node={node} indexPath={[index]} />
         ))}
       </ArkTreeView.Tree>
@@ -25,34 +31,41 @@ function BranchIcon() {
 }
 
 const TreeNode = (props: ArkTreeView.NodeProviderProps) => {
-  const { node, indexPath } = props
+  const { indexPath } = props
+  const node: NodeData = props.node
+  const children = node.children
   return (
     <ArkTreeView.NodeProvider key={node.id} node={node} indexPath={indexPath}>
-      {node.children ? (
-        <ArkTreeView.Branch>
-          <ArkTreeView.BranchControl>
-            <ArkTreeView.BranchIndicator>
-              <ChevronRightIcon />
-            </ArkTreeView.BranchIndicator>
-            <ArkTreeView.BranchText>
-              <BranchIcon /> {node.name}
-            </ArkTreeView.BranchText>
-          </ArkTreeView.BranchControl>
-          <ArkTreeView.BranchContent>
-            <ArkTreeView.BranchIndentGuide />
-            {/* @ts-expect-error */}
-            {node.children.map((child, index) => (
+      {children ? (
+        <ArkTreeView.NodeGroup>
+          <ArkTreeView.Node>
+            <ArkTreeView.Cell>
+              <ArkTreeView.NodeExpandTrigger>
+                <ArkTreeView.NodeIndicator type="expanded">
+                  <ChevronRightIcon />
+                </ArkTreeView.NodeIndicator>
+              </ArkTreeView.NodeExpandTrigger>
+              <ArkTreeView.NodeText>
+                <BranchIcon /> {node.name}
+              </ArkTreeView.NodeText>
+            </ArkTreeView.Cell>
+          </ArkTreeView.Node>
+          <ArkTreeView.NodeGroupContent>
+            <ArkTreeView.IndentGuide />
+            {children.map((child, index) => (
               <TreeNode key={child.id} node={child} indexPath={[...indexPath, index]} />
             ))}
-          </ArkTreeView.BranchContent>
-        </ArkTreeView.Branch>
+          </ArkTreeView.NodeGroupContent>
+        </ArkTreeView.NodeGroup>
       ) : (
-        <ArkTreeView.Item>
-          <ArkTreeView.ItemText>
-            <FileIcon />
-            {node.name}
-          </ArkTreeView.ItemText>
-        </ArkTreeView.Item>
+        <ArkTreeView.Node>
+          <ArkTreeView.Cell>
+            <ArkTreeView.NodeText>
+              <FileIcon />
+              {node.name}
+            </ArkTreeView.NodeText>
+          </ArkTreeView.Cell>
+        </ArkTreeView.Node>
       )}
     </ArkTreeView.NodeProvider>
   )

--- a/website/src/demos/carousel.demo.tsx
+++ b/website/src/demos/carousel.demo.tsx
@@ -11,7 +11,7 @@ export const Demo = (props: Carousel.RootProps) => {
     'https://tinyurl.com/yp4rfum7',
   ]
   return (
-    <Carousel.Root {...props} slideCount={images.length} position="relative">
+    <Carousel.Root {...props} count={images.length} position="relative">
       <Carousel.ItemGroup>
         {images.map((image, index) => (
           <Carousel.Item key={index} index={index}>

--- a/website/src/demos/floating-panel.demo.tsx
+++ b/website/src/demos/floating-panel.demo.tsx
@@ -63,7 +63,7 @@ const recipe = sva({
   },
 })
 
-const axes = ['n', 's', 'e', 'w', 'ne', 'nw', 'se', 'sw'] as const
+const placements = ['n', 's', 'e', 'w', 'ne', 'nw', 'se', 'sw'] as const
 
 export const Demo = (props: FloatingPanel.RootProps) => {
   const classNames = recipe()
@@ -109,8 +109,8 @@ export const Demo = (props: FloatingPanel.RootProps) => {
               <p>Drag me around</p>
             </FloatingPanel.Body>
 
-            {axes.map((axis) => (
-              <FloatingPanel.ResizeTrigger key={axis} axis={axis} className={classNames.resizeTrigger} />
+            {placements.map((placement) => (
+              <FloatingPanel.ResizeTrigger key={placement} placement={placement} className={classNames.resizeTrigger} />
             ))}
           </FloatingPanel.Content>
         </FloatingPanel.Positioner>

--- a/website/src/demos/image-cropper.demo.tsx
+++ b/website/src/demos/image-cropper.demo.tsx
@@ -167,8 +167,8 @@ export const Demo = (props: ImageCropper.RootProps) => {
           alt="Sample"
         />
         <ImageCropper.Selection className={classNames.selection}>
-          {ImageCropper.handles.map((position) => (
-            <ImageCropper.Handle className={classNames.handle} key={position} position={position}>
+          {ImageCropper.placements.map((placement) => (
+            <ImageCropper.Handle className={classNames.handle} key={placement} placement={placement}>
               <div />
             </ImageCropper.Handle>
           ))}

--- a/website/src/theme/recipes/tree-view.ts
+++ b/website/src/theme/recipes/tree-view.ts
@@ -3,13 +3,13 @@ import { defineSlotRecipe } from '@pandacss/dev'
 
 export const treeView = defineSlotRecipe({
   className: 'treeView',
-  slots: [...treeViewAnatomy.keys(), 'branchIndentGuide'],
+  slots: treeViewAnatomy.keys(),
   base: {
     root: {
       width: 'full',
     },
-    branch: {
-      "&[data-depth='1'] > [data-part='branch-content']": {
+    nodeGroup: {
+      "&[data-depth='1'] > [data-tree-view-node-group-content]": {
         _before: {
           bg: 'border.default',
           content: '""',
@@ -21,92 +21,85 @@ export const treeView = defineSlotRecipe({
         },
       },
     },
-    branchContent: {
+    nodeGroupContent: {
       position: 'relative',
     },
-    branchIndentGuide: {},
-    branchControl: {
+    indentGuide: {},
+    node: {
       alignItems: 'center',
       borderRadius: 'l2',
       color: 'fg.muted',
+      cursor: 'pointer',
       display: 'flex',
       fontWeight: 'medium',
       gap: '1.5',
-      ps: 'calc((var(--depth) - 1) * 22px)',
       py: '1.5',
       textStyle: 'sm',
       transitionDuration: 'normal',
       transitionProperty: 'background, color',
       transitionTimingFunction: 'default',
-      "&[data-depth='1']": {
-        ps: '1',
-      },
-      "&[data-depth='1'] > [data-part='branch-text'] ": {
-        fontWeight: 'semibold',
-        color: 'fg.default',
-      },
       _hover: {
         background: 'gray.a2',
         color: 'fg.default',
       },
-    },
-    branchIndicator: {
-      color: 'accent.default',
-      transformOrigin: 'center',
-      transitionDuration: 'normal',
-      transitionProperty: 'transform',
-      transitionTimingFunction: 'default',
-      '& svg': {
-        fontSize: 'md',
-        width: '4',
-        height: '4',
-      },
-      _open: {
-        transform: 'rotate(90deg)',
-      },
-    },
-    item: {
-      borderRadius: 'l2',
-      color: 'fg.muted',
-      cursor: 'pointer',
-      fontWeight: 'medium',
-      position: 'relative',
-      ps: 'calc(((var(--depth) - 1) * 22px) + 22px)',
-      py: '1.5',
-      textStyle: 'sm',
-      transitionDuration: 'normal',
-      transitionProperty: 'background, color',
-      transitionTimingFunction: 'default',
-      "&[data-depth='1']": {
-        ps: '6',
-        fontWeight: 'semibold',
-        color: 'fg.default',
-        _selected: {
-          _before: {
-            bg: 'transparent',
+      '&[data-branch]': {
+        ps: 'calc((var(--depth) - 1) * 22px)',
+        "&[data-depth='1']": {
+          ps: '1',
+          '& [data-tree-view-node-text]': {
+            fontWeight: 'semibold',
+            color: 'fg.default',
           },
         },
       },
-      _hover: {
-        background: 'gray.a2',
-        color: 'fg.default',
-      },
-      _selected: {
-        background: 'accent.a2',
-        color: 'accent.text',
-        _hover: {
+      '&:not([data-branch])': {
+        gap: '2',
+        position: 'relative',
+        ps: 'calc(((var(--depth) - 1) * 22px) + 22px)',
+        "&[data-depth='1']": {
+          ps: '6',
+          fontWeight: 'semibold',
+          color: 'fg.default',
+          _selected: {
+            _before: {
+              bg: 'transparent',
+            },
+          },
+        },
+        _selected: {
           background: 'accent.a2',
           color: 'accent.text',
+          _hover: {
+            background: 'accent.a2',
+            color: 'accent.text',
+          },
+          _before: {
+            content: '""',
+            position: 'absolute',
+            left: '3',
+            top: '0',
+            width: '2px',
+            height: 'full',
+            bg: 'accent.default',
+            zIndex: '1',
+          },
         },
-        _before: {
-          content: '""',
-          position: 'absolute',
-          left: '3',
-          top: '0',
-          width: '2px',
-          height: 'full',
-          bg: 'accent.default',
-          zIndex: '1',
+      },
+    },
+    nodeIndicator: {
+      "&[data-type='expanded']": {
+        color: 'accent.default',
+        transformOrigin: 'center',
+        transitionDuration: 'normal',
+        transitionProperty: 'transform',
+        transitionTimingFunction: 'default',
+        '& svg': {
+          fontSize: 'md',
+          width: '4',
+          height: '4',
+        },
+        _open: {
+          transform: 'rotate(90deg)',
         },
       },
     },


### PR DESCRIPTION
Closes #

## 📝 Description

The docs site had 40 type errors and its build has failed since June, so the preview deployment on every v6 PR was red.
This migrates it. `bun run build` passes.

Draft — for a visual pass before review.

## ⛳️ Current behavior

`next build` fails. 40 type errors, 31 of them in the site's own tree-view primitive.

## 🚀 New behavior

**Tree-view (31 of the 40).** The site wraps every part in its own primitive, so the v6 restructure lands in one place.
Both the primitive and the panda recipe styled branch rows and leaf rows as separate slots (`branchControl` vs `item`,
with different padding and selected styles). Those are one `node` slot in v6, so they now split on `data-branch`, which
zag sets on branch nodes:

```
'&[data-branch]':       { ps: 'calc((var(--depth) - 1) * 22px)' }
'&:not([data-branch])': { ps: 'calc(((var(--depth) - 1) * 22px) + 22px)', _selected: { ... } }
```

Raw `[data-part='...']` selectors move to the v6 attributes (`[data-tree-view-node-group-content]`,
`[data-tree-view-node-text]`), checked against a rendered tree rather than inferred. Those would have silently stopped
matching with no type error.

**The rest are the same renames the packages took:** pin-input `length` to `count`, carousel `slideCount` to `count`,
floating-panel `axis` to `placement`, image-cropper `handles` to `placements` and `position` to `placement`, popover
drops `portalled`.

**The second commit fixes a v6 regression found while testing.** The tree-view checkbox rendered a coral tick on the
coral filled checkbox, so a checked node looked like a plain orange square. `NodeIndicator` set `color: coral-solid` for
selected, checked and indeterminate alike, but checked and indeterminate render inside `NodeCheckbox`, which fills with
that same coral and already sets a contrast colour for its icon. v5 had a separate `NodeCheckboxIndicator` part with its
own styles; folding it into `NodeIndicator` brought the row colour with it. Only `selected` needs coral.

That stylesheet is aliased as `styles` by the site and shared with every framework's storybook, so the fix lands in both.

## 🧩 Frameworks

- [x] Not framework-specific

## 💣 Is this a breaking change (Yes/No):

No. Docs site and storybook styles only.

## ✅ Checklist

- [ ] Added a changeset for user-facing changes
- [ ] Added or updated tests
- [ ] Added an example for any new prop or part
- [x] Updated the docs

Nothing here ships to a package, so no changeset.

## 📝 Additional information

**To test:** `bun run web dev`, then

- `/docs/components/tree-view` — indentation is the thing to check. Nested folders and files should line up, selected
  files keep their left accent bar, and the checkbox example should show a white tick on orange.
- `/docs/utilities/json-tree-view`, `/docs/components/image-cropper`, `/docs/components/floating-panel`,
  `/docs/components/carousel`, `/docs/components/pin-input`

Two things I could not verify: the mobile navbar popover, which needs a narrow viewport, and the OTP dialog, which is
behind auth and needs a `.env`.

One type error is left and predates v6: `css-module-transform.test.ts` cannot resolve `bun:test`, because `@types/bun`
is only a root devDependency. That file and the tsconfig are identical to `main`, so it fails there too.

Roadmap: #3997
