### PR TITLE
fix: call anatomy attrs so parts emit their data attributes

### DIFF
--- a/packages/react/src/components/carousel/carousel-autoplay-indicator.tsx
+++ b/packages/react/src/components/carousel/carousel-autoplay-indicator.tsx
@@ -19,7 +19,7 @@ export const CarouselAutoplayIndicator = forwardRef<HTMLSpanElement, CarouselAut
   const { children, fallback, ...restProps } = props
   const carousel = useCarouselContext()
   return (
-    <ark.span ref={ref} {...parts.autoplayIndicator.attrs} {...restProps}>
+    <ark.span ref={ref} {...parts.autoplayIndicator.attrs('')} {...restProps}>
       {carousel.isPlaying ? children : fallback}
     </ark.span>
   )

--- a/packages/react/src/components/carousel/carousel-progress-text.tsx
+++ b/packages/react/src/components/carousel/carousel-progress-text.tsx
@@ -20,7 +20,7 @@ export const CarouselProgressText = forwardRef<HTMLSpanElement, CarouselProgress
   }, [carousel.page, carousel.pageSnapPoints.length])
 
   return (
-    <ark.span ref={ref} {...parts.progressText.attrs} {...props}>
+    <ark.span ref={ref} {...parts.progressText.attrs('')} {...props}>
       {props.children || progressText}
     </ark.span>
   )

--- a/packages/react/src/components/combobox/combobox-empty.tsx
+++ b/packages/react/src/components/combobox/combobox-empty.tsx
@@ -17,7 +17,7 @@ export const ComboboxEmpty = forwardRef<HTMLDivElement, ComboboxEmptyProps>((pro
     return null
   }
 
-  return <ark.div {...parts.empty.attrs} {...props} role="presentation" ref={ref} />
+  return <ark.div {...parts.empty.attrs('')} {...props} role="presentation" ref={ref} />
 })
 
 ComboboxEmpty.displayName = 'ComboboxEmpty'

--- a/packages/react/src/components/listbox/listbox-empty.tsx
+++ b/packages/react/src/components/listbox/listbox-empty.tsx
@@ -17,7 +17,7 @@ export const ListboxEmpty = forwardRef<HTMLDivElement, ListboxEmptyProps>((props
     return null
   }
 
-  return <ark.div {...parts.empty.attrs} {...props} role="presentation" ref={ref} />
+  return <ark.div {...parts.empty.attrs('')} {...props} role="presentation" ref={ref} />
 })
 
 ListboxEmpty.displayName = 'ListboxEmpty'

--- a/packages/react/src/components/swap/use-swap.ts
+++ b/packages/react/src/components/swap/use-swap.ts
@@ -54,7 +54,7 @@ export const useSwap = (props: UseSwapProps = {}): UseSwapReturn => {
     offPresence,
     getRootProps() {
       return {
-        ...parts.root.attrs,
+        ...parts.root.attrs(''),
         'data-swap': swap ? 'on' : 'off',
         style: { display: 'inline-grid' },
       }
@@ -62,7 +62,7 @@ export const useSwap = (props: UseSwapProps = {}): UseSwapReturn => {
     getIndicatorProps({ type }) {
       const presence = type === 'on' ? onPresence : offPresence
       return {
-        ...parts.indicator.attrs,
+        ...parts.indicator.attrs(''),
         ...presence.getPresenceProps(),
         'data-type': type,
         style: { gridArea: '1 / 1', display: 'inline-flex' },

--- a/packages/solid/src/components/carousel/carousel-autoplay-indicator.tsx
+++ b/packages/solid/src/components/carousel/carousel-autoplay-indicator.tsx
@@ -16,7 +16,7 @@ export interface CarouselAutoplayIndicatorProps extends HTMLProps<'span'>, Carou
 export const CarouselAutoplayIndicator = (props: CarouselAutoplayIndicatorProps) => {
   const api = useCarouselContext()
   return (
-    <ark.span {...parts.autoplayIndicator.attrs} {...props}>
+    <ark.span {...parts.autoplayIndicator.attrs('')} {...props}>
       <Show when={api().isPlaying} fallback={props.fallback}>
         {props.children}
       </Show>

--- a/packages/solid/src/components/carousel/carousel-progress-text.tsx
+++ b/packages/solid/src/components/carousel/carousel-progress-text.tsx
@@ -18,7 +18,7 @@ export const CarouselProgressText = (props: CarouselProgressTextProps) => {
   })
 
   return (
-    <ark.span {...parts.progressText.attrs} {...props}>
+    <ark.span {...parts.progressText.attrs('')} {...props}>
       {props.children || progressText()}
     </ark.span>
   )

--- a/packages/solid/src/components/combobox/combobox-empty.tsx
+++ b/packages/solid/src/components/combobox/combobox-empty.tsx
@@ -14,7 +14,7 @@ export const ComboboxEmpty = (props: ComboboxEmptyProps) => {
 
   return (
     <Show when={size() === 0}>
-      <ark.div {...parts.empty.attrs} {...props} role="presentation" />
+      <ark.div {...parts.empty.attrs('')} {...props} role="presentation" />
     </Show>
   )
 }

--- a/packages/solid/src/components/listbox/listbox-empty.tsx
+++ b/packages/solid/src/components/listbox/listbox-empty.tsx
@@ -14,7 +14,7 @@ export const ListboxEmpty = (props: ListboxEmptyProps) => {
 
   return (
     <Show when={size() === 0}>
-      <ark.div {...parts.empty.attrs} {...props} role="presentation" />
+      <ark.div {...parts.empty.attrs('')} {...props} role="presentation" />
     </Show>
   )
 }

--- a/packages/solid/src/components/swap/use-swap.ts
+++ b/packages/solid/src/components/swap/use-swap.ts
@@ -71,7 +71,7 @@ export const useSwap = (props: MaybeAccessor<UseSwapProps> = {}): Accessor<UseSw
       offPresence,
       getRootProps() {
         return {
-          ...parts.root.attrs,
+          ...parts.root.attrs(''),
           'data-swap': swap ? 'on' : 'off',
           style: { display: 'inline-grid' },
         }
@@ -79,7 +79,7 @@ export const useSwap = (props: MaybeAccessor<UseSwapProps> = {}): Accessor<UseSw
       getIndicatorProps({ type }) {
         const presence = type === 'on' ? onPresence() : offPresence()
         return {
-          ...parts.indicator.attrs,
+          ...parts.indicator.attrs(''),
           ...presence.presenceProps,
           'data-type': type,
           style: { 'grid-area': '1 / 1', display: 'inline-flex' },

--- a/packages/svelte/src/lib/components/carousel/carousel-autoplay-indicator.svelte
+++ b/packages/svelte/src/lib/components/carousel/carousel-autoplay-indicator.svelte
@@ -28,7 +28,7 @@
   const carousel = useCarouselContext()
 </script>
 
-<Ark as="span" bind:ref {...parts.autoplayIndicator.attrs} {...props}>
+<Ark as="span" bind:ref {...parts.autoplayIndicator.attrs('')} {...props}>
   {#if carousel().isPlaying}
     {@render children?.()}
   {:else}

--- a/packages/svelte/src/lib/components/carousel/carousel-progress-text.svelte
+++ b/packages/svelte/src/lib/components/carousel/carousel-progress-text.svelte
@@ -23,7 +23,7 @@
   })
 </script>
 
-<Ark as="span" bind:ref {...parts.progressText.attrs} {...props}>
+<Ark as="span" bind:ref {...parts.progressText.attrs('')} {...props}>
   {#if children}
     {@render children()}
   {:else}

--- a/packages/svelte/src/lib/components/combobox/combobox-empty.svelte
+++ b/packages/svelte/src/lib/components/combobox/combobox-empty.svelte
@@ -19,5 +19,5 @@
 </script>
 
 {#if isEmpty}
-  <Ark as="div" bind:ref {...parts.empty.attrs} {...props} role="presentation" />
+  <Ark as="div" bind:ref {...parts.empty.attrs('')} {...props} role="presentation" />
 {/if}

--- a/packages/svelte/src/lib/components/field/field-item.svelte
+++ b/packages/svelte/src/lib/components/field/field-item.svelte
@@ -27,11 +27,10 @@
     const controlId = `${parent.ids.root}::item::${value}`
     const labelId = `${controlId}::label`
 
-    const getControlProps = () =>
-      ({
-        ...parent.getInputProps(),
-        id: controlId,
-      }) as HTMLProps<'input'>
+    const getControlProps = <T extends object>(getParentProps: () => T) => ({
+      ...getParentProps(),
+      id: controlId,
+    })
 
     return {
       ...parent,
@@ -48,18 +47,18 @@
         }) as HTMLProps<'label'>,
       getInputProps: () =>
         ({
-          ...getControlProps(),
-          ...parts.input.attrs,
+          ...getControlProps(parent.getInputProps),
+          ...parts.input.attrs(controlId),
         }) as HTMLProps<'input'>,
       getSelectProps: () =>
         ({
-          ...getControlProps(),
-          ...parts.select.attrs,
+          ...getControlProps(parent.getSelectProps),
+          ...parts.select.attrs(controlId),
         }) as HTMLProps<'select'>,
       getTextareaProps: () =>
         ({
-          ...getControlProps(),
-          ...parts.textarea.attrs,
+          ...getControlProps(parent.getTextareaProps),
+          ...parts.textarea.attrs(controlId),
         }) as HTMLProps<'textarea'>,
     }
   })

--- a/packages/svelte/src/lib/components/field/tests/field-item.test.ts
+++ b/packages/svelte/src/lib/components/field/tests/field-item.test.ts
@@ -26,9 +26,9 @@ describe('Field / Item', () => {
     await waitFor(() => {
       const root = container.firstElementChild!
       const structure = formatFieldParts([
-        { name: 'label', element: root.querySelector('[data-part=label]'), attrs: ['id', 'for'] },
-        { name: 'Field.Select', element: root.querySelector('[data-part=select]') },
-        { name: 'Field.Input', element: root.querySelector('[data-part=input]') },
+        { name: 'label', element: root.querySelector('[data-field-label]'), attrs: ['id', 'for'] },
+        { name: 'Field.Select', element: root.querySelector('[data-field-select]') },
+        { name: 'Field.Input', element: root.querySelector('[data-field-input]') },
       ])
       expect(structure).toMatchInlineSnapshot(`
         "label (id=field::c1::label, for=field::c1::item::amount)
@@ -49,9 +49,9 @@ describe('Field / Item', () => {
     await waitFor(() => {
       const root = container.firstElementChild!
       const structure = formatFieldParts([
-        { name: 'label', element: root.querySelector('[data-part=label]'), attrs: ['id', 'for'] },
-        { name: 'Field.Select', element: root.querySelector('[data-part=select]') },
-        { name: 'Field.Input', element: root.querySelector('[data-part=input]') },
+        { name: 'label', element: root.querySelector('[data-field-label]'), attrs: ['id', 'for'] },
+        { name: 'Field.Select', element: root.querySelector('[data-field-select]') },
+        { name: 'Field.Input', element: root.querySelector('[data-field-input]') },
       ])
       expect(structure).toMatchInlineSnapshot(`
         "label (id=field::c3::label, for=field::c3::control)
@@ -69,9 +69,9 @@ describe('Field / Item', () => {
     await waitFor(() => {
       const root = container.firstElementChild!
       const structure = formatFieldParts([
-        { name: 'label', element: root.querySelector('[data-part=label]'), attrs: ['id', 'for'] },
-        { name: 'Field.Select', element: root.querySelector('[data-part=select]') },
-        { name: 'Field.Input', element: root.querySelector('[data-part=input]') },
+        { name: 'label', element: root.querySelector('[data-field-label]'), attrs: ['id', 'for'] },
+        { name: 'Field.Select', element: root.querySelector('[data-field-select]') },
+        { name: 'Field.Input', element: root.querySelector('[data-field-input]') },
       ])
       expect(structure).toMatchInlineSnapshot(`
         "label (id=field::c4::label, for=field::c4::item::currency)

--- a/packages/svelte/src/lib/components/field/use-field.svelte.ts
+++ b/packages/svelte/src/lib/components/field/use-field.svelte.ts
@@ -102,7 +102,7 @@ export const useField = (inProps: MaybeFunction<UseFieldProps> = {}) => {
 
   const getRootProps = () =>
     ({
-      ...parts.root.attrs,
+      ...parts.root.attrs(id),
       id: rootId,
       role: 'group',
       'data-disabled': dataAttr(disabled),
@@ -114,7 +114,7 @@ export const useField = (inProps: MaybeFunction<UseFieldProps> = {}) => {
 
   const getLabelProps = () =>
     ({
-      ...parts.label.attrs,
+      ...parts.label.attrs(id),
       id: labelId,
       'data-disabled': dataAttr(disabled),
       'data-invalid': dataAttr(invalid),
@@ -140,39 +140,39 @@ export const useField = (inProps: MaybeFunction<UseFieldProps> = {}) => {
   const getInputProps = () =>
     ({
       ...getControlProps(),
-      ...parts.input.attrs,
+      ...parts.input.attrs(id),
     }) as HTMLProps<'input'>
 
   const getTextareaProps = () =>
     ({
       ...getControlProps(),
-      ...parts.textarea.attrs,
+      ...parts.textarea.attrs(id),
     }) as HTMLProps<'textarea'>
 
   const getSelectProps = () =>
     ({
       ...getControlProps(),
-      ...parts.select.attrs,
+      ...parts.select.attrs(id),
     }) as HTMLProps<'select'>
 
   const getHelperTextProps = () =>
     ({
       id: helperTextId,
-      ...parts.helperText.attrs,
+      ...parts.helperText.attrs(id),
       'data-disabled': dataAttr(disabled),
     }) as HTMLProps<'span'>
 
   const getErrorTextProps = () =>
     ({
       id: errorTextId,
-      ...parts.errorText.attrs,
+      ...parts.errorText.attrs(id),
       'aria-live': 'polite',
     }) as HTMLProps<'span'>
 
   const getRequiredIndicatorProps = () =>
     ({
       'aria-hidden': true,
-      ...parts.requiredIndicator.attrs,
+      ...parts.requiredIndicator.attrs(id),
     }) as HTMLProps<'span'>
 
   const api = $derived({

--- a/packages/svelte/src/lib/components/fieldset/use-fieldset.svelte.ts
+++ b/packages/svelte/src/lib/components/fieldset/use-fieldset.svelte.ts
@@ -77,7 +77,7 @@ export const useFieldset = (inProps: MaybeFunction<UseFieldsetProps> = {}) => {
 
   const getRootProps = () =>
     ({
-      ...parts.root.attrs,
+      ...parts.root.attrs(id),
       disabled,
       'data-disabled': dataAttr(disabled),
       'data-invalid': dataAttr(invalid),
@@ -88,7 +88,7 @@ export const useFieldset = (inProps: MaybeFunction<UseFieldsetProps> = {}) => {
   const getLegendProps = () =>
     ({
       id: legendId,
-      ...parts.legend.attrs,
+      ...parts.legend.attrs(id),
       'data-disabled': dataAttr(disabled),
       'data-invalid': dataAttr(invalid),
     }) as HTMLProps<'legend'>
@@ -96,13 +96,13 @@ export const useFieldset = (inProps: MaybeFunction<UseFieldsetProps> = {}) => {
   const getHelperTextProps = () =>
     ({
       id: helperTextId,
-      ...parts.helperText.attrs,
+      ...parts.helperText.attrs(id),
     }) as HTMLProps<'span'>
 
   const getErrorTextProps = () =>
     ({
       id: errorTextId,
-      ...parts.errorText.attrs,
+      ...parts.errorText.attrs(id),
       'aria-live': 'polite',
     }) as HTMLProps<'span'>
 

--- a/packages/svelte/src/lib/components/listbox/listbox-empty.svelte
+++ b/packages/svelte/src/lib/components/listbox/listbox-empty.svelte
@@ -19,5 +19,5 @@
 </script>
 
 {#if isEmpty}
-  <Ark as="div" bind:ref {...parts.empty.attrs} {...props} role="presentation" />
+  <Ark as="div" bind:ref {...parts.empty.attrs('')} {...props} role="presentation" />
 {/if}

--- a/packages/svelte/src/lib/components/segment-group/segment-group-indicator.svelte
+++ b/packages/svelte/src/lib/components/segment-group/segment-group-indicator.svelte
@@ -14,7 +14,7 @@
   let { ref = $bindable(null), ...props }: SegmentGroupIndicatorProps = $props()
 
   const segmentGroup = useSegmentGroupContext()
-  const mergedProps = $derived(mergeProps(segmentGroup().getIndicatorProps(), parts.indicator.attrs, props))
+  const mergedProps = $derived(mergeProps(segmentGroup().getIndicatorProps(), props))
 </script>
 
 <Ark as="div" bind:ref {...mergedProps} />

--- a/packages/svelte/src/lib/components/segment-group/segment-group-item-control.svelte
+++ b/packages/svelte/src/lib/components/segment-group/segment-group-item-control.svelte
@@ -17,9 +17,7 @@
   const segmentGroup = useSegmentGroupContext()
   const itemProps = useSegmentGroupItemPropsContext()
 
-  const mergedProps = $derived(
-    mergeProps(segmentGroup().getItemControlProps(itemProps()), parts.itemControl.attrs, props),
-  )
+  const mergedProps = $derived(mergeProps(segmentGroup().getItemControlProps(itemProps()), props))
 </script>
 
 <Ark as="div" bind:ref {...mergedProps} />

--- a/packages/svelte/src/lib/components/segment-group/segment-group-item-text.svelte
+++ b/packages/svelte/src/lib/components/segment-group/segment-group-item-text.svelte
@@ -16,7 +16,7 @@
   const segmentGroup = useSegmentGroupContext()
   const itemProps = useSegmentGroupItemPropsContext()
 
-  const mergedProps = $derived(mergeProps(segmentGroup().getItemTextProps(itemProps()), parts.itemText.attrs, props))
+  const mergedProps = $derived(mergeProps(segmentGroup().getItemTextProps(itemProps()), props))
 </script>
 
 <Ark as="span" bind:ref {...mergedProps} />

--- a/packages/svelte/src/lib/components/segment-group/segment-group-item.svelte
+++ b/packages/svelte/src/lib/components/segment-group/segment-group-item.svelte
@@ -22,7 +22,7 @@
   const segmentGroup = useSegmentGroupContext()
 
   const itemState = $derived(segmentGroup().getItemState(itemProps))
-  const mergedProps = $derived(mergeProps(segmentGroup().getItemProps(itemProps), parts.item.attrs, localProps))
+  const mergedProps = $derived(mergeProps(segmentGroup().getItemProps(itemProps), localProps))
 
   SegmentGroupItemProvider(() => itemState)
   SegmentGroupItemPropsProvider(() => itemProps)

--- a/packages/svelte/src/lib/components/segment-group/segment-group-label.svelte
+++ b/packages/svelte/src/lib/components/segment-group/segment-group-label.svelte
@@ -14,7 +14,7 @@
   let { ref = $bindable(null), ...props }: SegmentGroupLabelProps = $props()
 
   const segmentGroup = useSegmentGroupContext()
-  const mergedProps = $derived(mergeProps(segmentGroup().getLabelProps(), parts.label.attrs, props))
+  const mergedProps = $derived(mergeProps(segmentGroup().getLabelProps(), props))
 </script>
 
 <Ark as="span" bind:ref {...mergedProps} />

--- a/packages/svelte/src/lib/components/segment-group/segment-group-root-provider.svelte
+++ b/packages/svelte/src/lib/components/segment-group/segment-group-root-provider.svelte
@@ -18,7 +18,7 @@
 
   let { ref = $bindable(null), value, ...props }: SegmentGroupRootProviderProps = $props()
 
-  const mergedProps = $derived(mergeProps(value().getRootProps(), parts.root.attrs, props))
+  const mergedProps = $derived(mergeProps(value().getRootProps(), props))
 
   SegmentGroupProvider(() => value())
 </script>

--- a/packages/svelte/src/lib/components/segment-group/segment-group-root.svelte
+++ b/packages/svelte/src/lib/components/segment-group/segment-group-root.svelte
@@ -35,7 +35,7 @@
   })
 
   const segmentGroup = useSegmentGroup(() => resolvedProps)
-  const mergedProps = $derived(mergeProps(segmentGroup().getRootProps(), parts.root.attrs, localProps))
+  const mergedProps = $derived(mergeProps(segmentGroup().getRootProps(), localProps))
 
   SegmentGroupProvider(segmentGroup)
 </script>

--- a/packages/svelte/src/lib/components/swap/use-swap.svelte.ts
+++ b/packages/svelte/src/lib/components/swap/use-swap.svelte.ts
@@ -63,7 +63,7 @@ export const useSwap = (props: MaybeFunction<UseSwapProps> = {}): Accessor<UseSw
     offPresence,
     getRootProps() {
       return {
-        ...parts.root.attrs,
+        ...parts.root.attrs(''),
         'data-swap': swap ? 'on' : 'off',
         style: 'display: inline-grid',
       }
@@ -71,7 +71,7 @@ export const useSwap = (props: MaybeFunction<UseSwapProps> = {}): Accessor<UseSw
     getIndicatorProps({ type }: IndicatorProps) {
       const presence = type === 'on' ? onPresence() : offPresence()
       return {
-        ...parts.indicator.attrs,
+        ...parts.indicator.attrs(''),
         ...presence.getPresenceProps(),
         'data-type': type,
         style: 'grid-area: 1 / 1; display: inline-flex',

--- a/packages/vue/src/components/carousel/carousel-autoplay-indicator.vue
+++ b/packages/vue/src/components/carousel/carousel-autoplay-indicator.vue
@@ -32,7 +32,7 @@ useForwardExpose()
 </script>
 
 <template>
-  <ark.span v-bind="parts.autoplayIndicator.attrs" :as-child="asChild">
+  <ark.span v-bind="parts.autoplayIndicator.attrs('')" :as-child="asChild">
     <template v-if="carousel.isPlaying">
       <slot />
     </template>

--- a/packages/vue/src/components/carousel/carousel-progress-text.vue
+++ b/packages/vue/src/components/carousel/carousel-progress-text.vue
@@ -34,7 +34,7 @@ useForwardExpose()
 </script>
 
 <template>
-  <ark.span v-bind="parts.progressText.attrs" :as-child="asChild">
+  <ark.span v-bind="parts.progressText.attrs('')" :as-child="asChild">
     <slot>{{ progressText }}</slot>
   </ark.span>
 </template>

--- a/packages/vue/src/components/combobox/combobox-empty.vue
+++ b/packages/vue/src/components/combobox/combobox-empty.vue
@@ -29,7 +29,7 @@ useForwardExpose()
 </script>
 
 <template>
-  <ark.div v-if="isEmpty" v-bind="parts.empty.attrs" role="presentation" :as-child="asChild">
+  <ark.div v-if="isEmpty" v-bind="parts.empty.attrs('')" role="presentation" :as-child="asChild">
     <slot />
   </ark.div>
 </template>

--- a/packages/vue/src/components/listbox/listbox-empty.vue
+++ b/packages/vue/src/components/listbox/listbox-empty.vue
@@ -29,7 +29,7 @@ useForwardExpose()
 </script>
 
 <template>
-  <ark.div v-if="isEmpty" v-bind="parts.empty.attrs" role="presentation" :as-child="asChild">
+  <ark.div v-if="isEmpty" v-bind="parts.empty.attrs('')" role="presentation" :as-child="asChild">
     <slot />
   </ark.div>
 </template>

--- a/packages/vue/src/components/swap/use-swap.ts
+++ b/packages/vue/src/components/swap/use-swap.ts
@@ -73,7 +73,7 @@ export const useSwap = (props: MaybeRef<UseSwapProps>): UseSwapReturn => {
     offPresence,
     getRootProps() {
       return {
-        ...parts.root.attrs,
+        ...parts.root.attrs(''),
         'data-swap': swap.value ? 'on' : 'off',
         style: { display: 'inline-grid' },
       }
@@ -81,7 +81,7 @@ export const useSwap = (props: MaybeRef<UseSwapProps>): UseSwapReturn => {
     getIndicatorProps({ type }) {
       const presence = type === 'on' ? onPresence : offPresence
       return {
-        ...parts.indicator.attrs,
+        ...parts.indicator.attrs(''),
         ...presence.value.presenceProps,
         'data-type': type,
         style: { 'grid-area': '1 / 1', display: 'inline-flex' },

--- a/scripts/src/check-anatomy.ts
+++ b/scripts/src/check-anatomy.ts
@@ -69,6 +69,32 @@ async function checkPackage(packageName: string): Promise<AnatomyCheck> {
   }
 }
 
+interface UncalledAttrs {
+  file: string
+  line: number
+  text: string
+}
+
+async function findUncalledAttrs(): Promise<UncalledAttrs[]> {
+  const files = await glob(`packages/{${packages.join(',')}}/src/**/*.{ts,tsx,svelte,vue}`, {
+    cwd: join(import.meta.dir, '../..'),
+    absolute: true,
+  })
+
+  const hits: UncalledAttrs[] = []
+
+  for (const file of files) {
+    const source = await Bun.file(file).text()
+    source.split('\n').forEach((text, index) => {
+      if (/parts\.[a-zA-Z]+\.attrs(?!\s*\()/.test(text)) {
+        hits.push({ file, line: index + 1, text: text.trim() })
+      }
+    })
+  }
+
+  return hits
+}
+
 async function main() {
   console.log('🔍 Checking anatomy exports across all packages...\n')
 
@@ -102,6 +128,24 @@ async function main() {
     }
 
     console.log()
+  }
+
+  const uncalled = await findUncalledAttrs()
+
+  console.log('🔍 Checking anatomy attrs are called...\n')
+
+  if (uncalled.length > 0) {
+    hasIssues = true
+    console.log(`   ❌ ${uncalled.length} anatomy attrs spread without being called:`)
+    uncalled.forEach(({ file, line, text }) => {
+      console.log(`      - ${file.split('/packages/')[1]}:${line}`)
+      console.log(`        ${text}`)
+    })
+    console.log('\n   Zag v2 takes the scope id: parts.root.attrs(id). Spreading the')
+    console.log('   function contributes nothing and the part renders without its attribute.')
+    console.log()
+  } else {
+    console.log('   ✅ All anatomy attrs are called\n')
   }
 
   if (hasIssues) {


### PR DESCRIPTION


## 📝 Description

Zag v2 changed anatomy `attrs` from an object to a function taking the scope id:

```
1.43.3   attrs: Record<"data-scope" | "data-part", string>
2.x      attrs(id)
```

Every `...parts.x.attrs` spread became a no-op, so those parts render with no data attributes at all. Spreading a
function is legal TypeScript, so nothing caught it.

## ⛳️ Current behavior

`Swap` emits only `data-swap`. Svelte's `Field` emits nothing at all, where react emits `data-field-root`,
`data-field-label` and `data-field-input` for the same tree.

## 🚀 New behavior

Field and fieldset were updated for this in react, solid and vue. Missed everywhere else:

| component | frameworks |
| --- | --- |
| swap, listbox `empty`, combobox `empty`, carousel `progressText` / `autoplayIndicator` | all four |
| field, fieldset | svelte |

Those first parts have no machine and no scope id, and nothing references them by id, so they pass an empty string. The
attribute is the point; the value carries nothing there.

Two more svelte fixes alongside it:

- `Field.Item` gave every control the parent's **input** props, so a `<select>` carried `data-field-input` next to
  `data-field-select`. It takes the matching parent getter now, the way react does.
- segment-group spread these next to the zag props that already carry the same attributes. React doesn't, and they
  contributed nothing, so they're gone.

A third commit adds a check so this can't come back. `check:anatomy` now fails on any `parts.x.attrs` that isn't
called, with the file and line. It runs in a CI step that already exists. It catches this one mistake rather than
proving every part reaches the DOM — that wants a render harness per framework, worth doing separately.

## 🧩 Frameworks

- [x] React
- [x] Solid
- [x] Svelte
- [x] Vue

## 💣 Is this a breaking change (Yes/No):

No, but it changes rendered output — these parts gain the attributes they were always meant to have. Anyone who worked
around their absence will see the difference.

## ✅ Checklist

- [ ] Added a changeset for user-facing changes
- [ ] Added or updated tests
- [ ] Added an example for any new prop or part
- [ ] Updated the docs

No changeset yet, v6 has no release pipeline.

## 📝 Additional information

Found via svelte's field-item tests, which were producing empty snapshots. Those pass now.

All four packages typecheck at zero. Test failures drop 28 → 11 with #4004.

Roadmap: #3997
