### PR TITLE
test: update assertions for v6 behaviour

### DIFF
--- a/packages/react/src/components/dialog/tests/dialog.test.tsx
+++ b/packages/react/src/components/dialog/tests/dialog.test.tsx
@@ -1,7 +1,9 @@
 import { act, render, screen, waitFor } from '@testing-library/react'
-import user from '@testing-library/user-event'
+import userEvent from '@testing-library/user-event'
 import { axe } from 'vitest-axe'
 import { ComponentUnderTest } from './basic.tsx'
+
+const user = userEvent.setup({ pointerEventsCheck: 0 })
 
 describe('Dialog', () => {
   it('should have no a11y violations', async () => {

--- a/packages/react/src/components/toc/tests/toc.test.tsx
+++ b/packages/react/src/components/toc/tests/toc.test.tsx
@@ -35,44 +35,44 @@ describe('Toc', () => {
 
   it('should render the indicator', () => {
     render(<ComponentUnderTest />)
-    expect(screen.getByTestId('indicator')).toHaveAttribute('data-part', 'indicator')
+    expect(screen.getByTestId('indicator')).toHaveAttribute('data-toc-indicator')
   })
 
-  it('should apply data-part attributes to all parts', () => {
+  it('should apply part attributes to all parts', () => {
     const { container } = render(<ComponentUnderTest />)
-    expect(container.querySelector('[data-part="title"]')).toBeInTheDocument()
-    expect(container.querySelector('[data-part="list"]')).toBeInTheDocument()
-    expect(container.querySelector('[data-part="item"]')).toBeInTheDocument()
-    expect(container.querySelector('[data-part="link"]')).toBeInTheDocument()
-    expect(container.querySelector('[data-part="indicator"]')).toBeInTheDocument()
+    expect(container.querySelector('[data-toc-title]')).toBeInTheDocument()
+    expect(container.querySelector('[data-toc-list]')).toBeInTheDocument()
+    expect(container.querySelector('[data-toc-item]')).toBeInTheDocument()
+    expect(container.querySelector('[data-toc-link]')).toBeInTheDocument()
+    expect(container.querySelector('[data-toc-indicator]')).toBeInTheDocument()
   })
 
   it('should set data-active on the link matching defaultActiveIds', () => {
     const { container } = render(<ComponentUnderTest defaultActiveIds={['usage']} />)
-    expect(container.querySelector('[data-part="link"][data-value="usage"]')).toHaveAttribute('data-active', '')
-    expect(container.querySelector('[data-part="link"][data-value="introduction"]')).not.toHaveAttribute('data-active')
+    expect(container.querySelector('[data-toc-link][data-value="usage"]')).toHaveAttribute('data-active', '')
+    expect(container.querySelector('[data-toc-link][data-value="introduction"]')).not.toHaveAttribute('data-active')
   })
 
   it('should support multiple defaultActiveIds', () => {
     const { container } = render(<ComponentUnderTest defaultActiveIds={['introduction', 'usage']} />)
-    expect(container.querySelector('[data-part="link"][data-value="introduction"]')).toHaveAttribute('data-active', '')
-    expect(container.querySelector('[data-part="link"][data-value="usage"]')).toHaveAttribute('data-active', '')
-    expect(container.querySelector('[data-part="link"][data-value="installation"]')).not.toHaveAttribute('data-active')
+    expect(container.querySelector('[data-toc-link][data-value="introduction"]')).toHaveAttribute('data-active', '')
+    expect(container.querySelector('[data-toc-link][data-value="usage"]')).toHaveAttribute('data-active', '')
+    expect(container.querySelector('[data-toc-link][data-value="installation"]')).not.toHaveAttribute('data-active')
   })
 
   it('should reflect controlled activeIds', () => {
     const { container } = render(<ComponentUnderTest activeIds={['installation']} onActiveChange={vi.fn()} />)
-    expect(container.querySelector('[data-part="link"][data-value="installation"]')).toHaveAttribute('data-active', '')
-    expect(container.querySelector('[data-part="link"][data-value="introduction"]')).not.toHaveAttribute('data-active')
+    expect(container.querySelector('[data-toc-link][data-value="installation"]')).toHaveAttribute('data-active', '')
+    expect(container.querySelector('[data-toc-link][data-value="introduction"]')).not.toHaveAttribute('data-active')
   })
 
   it('should update active link when controlled activeIds change', () => {
     const { container, rerender } = render(<ComponentUnderTest activeIds={['introduction']} onActiveChange={vi.fn()} />)
-    expect(container.querySelector('[data-part="link"][data-value="introduction"]')).toHaveAttribute('data-active', '')
+    expect(container.querySelector('[data-toc-link][data-value="introduction"]')).toHaveAttribute('data-active', '')
 
     rerender(<ComponentUnderTest activeIds={['usage']} onActiveChange={vi.fn()} />)
-    expect(container.querySelector('[data-part="link"][data-value="usage"]')).toHaveAttribute('data-active', '')
-    expect(container.querySelector('[data-part="link"][data-value="introduction"]')).not.toHaveAttribute('data-active')
+    expect(container.querySelector('[data-toc-link][data-value="usage"]')).toHaveAttribute('data-active', '')
+    expect(container.querySelector('[data-toc-link][data-value="introduction"]')).not.toHaveAttribute('data-active')
   })
 
   it('should expose activeIds via Context render prop', () => {

--- a/packages/react/src/components/toggle-group/tests/toggle-group.test.tsx
+++ b/packages/react/src/components/toggle-group/tests/toggle-group.test.tsx
@@ -14,7 +14,7 @@ describe('ToggleGroup', () => {
   it('should handle default value', () => {
     render(<ComponentUnderTest defaultValue={['a']} />)
 
-    expect(screen.getByText('A')).toBeChecked()
+    expect(screen.getByText('A')).toHaveAttribute('aria-pressed', 'true')
   })
 
   it('should handle onValueChange', async () => {

--- a/packages/solid/src/components/toggle-group/tests/toggle-group.test.tsx
+++ b/packages/solid/src/components/toggle-group/tests/toggle-group.test.tsx
@@ -5,7 +5,7 @@ import { ComponentUnderTest } from './basic.tsx'
 describe('ToggleGroup', () => {
   it('should handle default value', () => {
     render(() => <ComponentUnderTest value={['a']} />)
-    expect(screen.getByText('A')).toBeChecked()
+    expect(screen.getByText('A')).toHaveAttribute('aria-pressed', 'true')
   })
 
   it('should handle onValueChange', async () => {

--- a/packages/svelte/src/lib/components/toc/toc.test.ts
+++ b/packages/svelte/src/lib/components/toc/toc.test.ts
@@ -34,43 +34,43 @@ describe('Toc', () => {
 
   it('should render the indicator', () => {
     render(BasicComponent)
-    expect(screen.getByTestId('indicator')).toHaveAttribute('data-part', 'indicator')
+    expect(screen.getByTestId('indicator')).toHaveAttribute('data-toc-indicator')
   })
 
-  it('should apply data-part attributes to all parts', () => {
+  it('should apply part attributes to all parts', () => {
     const { container } = render(BasicComponent)
-    expect(container.querySelector('[data-part="title"]')).toBeInTheDocument()
-    expect(container.querySelector('[data-part="list"]')).toBeInTheDocument()
-    expect(container.querySelector('[data-part="item"]')).toBeInTheDocument()
-    expect(container.querySelector('[data-part="link"]')).toBeInTheDocument()
-    expect(container.querySelector('[data-part="indicator"]')).toBeInTheDocument()
+    expect(container.querySelector('[data-toc-title]')).toBeInTheDocument()
+    expect(container.querySelector('[data-toc-list]')).toBeInTheDocument()
+    expect(container.querySelector('[data-toc-item]')).toBeInTheDocument()
+    expect(container.querySelector('[data-toc-link]')).toBeInTheDocument()
+    expect(container.querySelector('[data-toc-indicator]')).toBeInTheDocument()
   })
 
   it('should set data-active on the link matching defaultActiveIds', () => {
     const { container } = render(BasicComponent, { props: { defaultActiveIds: ['usage'] } })
-    expect(container.querySelector('[data-part="link"][data-value="usage"]')).toHaveAttribute('data-active', '')
-    expect(container.querySelector('[data-part="link"][data-value="introduction"]')).not.toHaveAttribute('data-active')
+    expect(container.querySelector('[data-toc-link][data-value="usage"]')).toHaveAttribute('data-active', '')
+    expect(container.querySelector('[data-toc-link][data-value="introduction"]')).not.toHaveAttribute('data-active')
   })
 
   it('should support multiple defaultActiveIds', () => {
     const { container } = render(BasicComponent, { props: { defaultActiveIds: ['introduction', 'usage'] } })
-    expect(container.querySelector('[data-part="link"][data-value="introduction"]')).toHaveAttribute('data-active', '')
-    expect(container.querySelector('[data-part="link"][data-value="usage"]')).toHaveAttribute('data-active', '')
-    expect(container.querySelector('[data-part="link"][data-value="installation"]')).not.toHaveAttribute('data-active')
+    expect(container.querySelector('[data-toc-link][data-value="introduction"]')).toHaveAttribute('data-active', '')
+    expect(container.querySelector('[data-toc-link][data-value="usage"]')).toHaveAttribute('data-active', '')
+    expect(container.querySelector('[data-toc-link][data-value="installation"]')).not.toHaveAttribute('data-active')
   })
 
   it('should reflect controlled activeIds', () => {
     const { container } = render(BasicComponent, { props: { activeIds: ['installation'] } })
-    expect(container.querySelector('[data-part="link"][data-value="installation"]')).toHaveAttribute('data-active', '')
-    expect(container.querySelector('[data-part="link"][data-value="introduction"]')).not.toHaveAttribute('data-active')
+    expect(container.querySelector('[data-toc-link][data-value="installation"]')).toHaveAttribute('data-active', '')
+    expect(container.querySelector('[data-toc-link][data-value="introduction"]')).not.toHaveAttribute('data-active')
   })
 
   it('should update active link when controlled activeIds change', async () => {
     const { container, rerender } = render(BasicComponent, { props: { activeIds: ['introduction'] } })
-    expect(container.querySelector('[data-part="link"][data-value="introduction"]')).toHaveAttribute('data-active', '')
+    expect(container.querySelector('[data-toc-link][data-value="introduction"]')).toHaveAttribute('data-active', '')
 
     await rerender({ activeIds: ['usage'] })
-    expect(container.querySelector('[data-part="link"][data-value="usage"]')).toHaveAttribute('data-active', '')
-    expect(container.querySelector('[data-part="link"][data-value="introduction"]')).not.toHaveAttribute('data-active')
+    expect(container.querySelector('[data-toc-link][data-value="usage"]')).toHaveAttribute('data-active', '')
+    expect(container.querySelector('[data-toc-link][data-value="introduction"]')).not.toHaveAttribute('data-active')
   })
 })

--- a/packages/vue/src/components/toggle-group/tests/toggle-group.test.ts
+++ b/packages/vue/src/components/toggle-group/tests/toggle-group.test.ts
@@ -6,7 +6,7 @@ import ComponentUnderTest from './toggle-group.test.vue'
 describe('ToggleGroup', () => {
   it('should handle default value', () => {
     render(ComponentUnderTest, { props: { defaultValue: ['a'] } })
-    expect(screen.getByText('A')).toBeChecked()
+    expect(screen.getByText('A')).toHaveAttribute('aria-pressed', 'true')
   })
 
   it('should handle onValueChange', async () => {


### PR DESCRIPTION


## 📝 Description

Three of the failing test clusters were stale assertions rather than broken components.

## ⛳️ Current behavior

17 failures across the four frameworks, from assertions written against v5 behaviour.

## 🚀 New behavior

| cluster | why it failed |
| --- | --- |
| toc (12, react + svelte) | asserted `data-part="link"`; v6 emits `data-toc-link`, which is the data attribute change working |
| toggle-group (3, react solid vue) | used `toBeChecked()`; the item is a toggle button now, with `aria-pressed` |
| dialog (2, react) | jsdom inherits `pointer-events: none` from the body the dismissable layer sets, while a real browser lets the dialog content override it |

Dialog uses the same `pointerEventsCheck: 0` setup the vue dialog test already has.

## 🧩 Frameworks

- [x] React
- [x] Solid
- [x] Svelte
- [x] Vue

## 💣 Is this a breaking change (Yes/No):

No. Tests only.

## ✅ Checklist

- [ ] Added a changeset for user-facing changes
- [x] Added or updated tests
- [ ] Added an example for any new prop or part
- [ ] Updated the docs

## 📝 Additional information

Failures drop 28 → 11 here, and to 8 with #4003.

Roadmap: #3997
