### PR TITLE
feat(solid): add the render prop to the factory

### DIFF
--- a/packages/solid/src/components/factory.test.tsx
+++ b/packages/solid/src/components/factory.test.tsx
@@ -81,6 +81,22 @@ describe('Ark Factory', () => {
       expect(container).toBeEmptyDOMElement()
     })
 
+    it('should accept a component reference', async () => {
+      const onClick = vi.fn()
+      render(() => (
+        <ark.button class="merged" onClick={onClick} render={MyButton}>
+          Open
+        </ark.button>
+      ))
+
+      const child = screen.getByTestId('child')
+      expect(child).toHaveTextContent('Open')
+      expect(child).toHaveClass('merged')
+
+      await user.click(child)
+      expect(onClick).toHaveBeenCalled()
+    })
+
     it('should not pass ref to the render fn', () => {
       const spy = vi.fn()
       let el: HTMLButtonElement | undefined

--- a/packages/solid/src/components/factory.test.tsx
+++ b/packages/solid/src/components/factory.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@solidjs/testing-library'
 import user from '@testing-library/user-event'
+import type { JSX } from 'solid-js'
 import { ark } from './factory.tsx'
 
 const ComponentUnderTest = () => (
@@ -23,52 +24,126 @@ const ComponentUnderTest = () => (
   </ark.div>
 )
 
+const MyButton = (props: { children?: JSX.Element } & JSX.HTMLAttributes<HTMLButtonElement>) => (
+  <button type="button" {...props} data-testid="child" />
+)
+
 describe('Ark Factory', () => {
-  it('should render only the child', () => {
-    render(() => <ComponentUnderTest />)
-    expect(screen.getByText('Child')).toBeVisible()
+  describe('render as function', () => {
+    it('should render the returned element with the forwarded props', async () => {
+      const onClick = vi.fn()
+      render(() => (
+        <ark.button data-part="trigger" onClick={onClick} render={(props) => <MyButton {...props}>Ark UI</MyButton>} />
+      ))
+
+      const child = screen.getByTestId('child')
+      expect(child.dataset['part']).toBe('trigger')
+
+      await user.click(child)
+      expect(onClick).toHaveBeenCalled()
+    })
+
+    it('should not double-apply props the render fn did not spread', async () => {
+      const onClick = vi.fn()
+      render(() => <ark.button onClick={onClick} render={(props) => <MyButton {...props} />} />)
+
+      await user.click(screen.getByTestId('child'))
+      expect(onClick).toHaveBeenCalledTimes(1)
+    })
+
+    it('should forward the state', () => {
+      render(() => (
+        <ark.button
+          state={{ open: true }}
+          render={(props, state: { open: boolean }) => <MyButton {...props}>{state.open ? 'Open' : 'Closed'}</MyButton>}
+        />
+      ))
+
+      expect(screen.getByTestId('child')).toHaveTextContent('Open')
+    })
+
+    it('should default the state to an empty object', () => {
+      const spy = vi.fn()
+      render(() => (
+        <ark.button
+          render={(props, state) => {
+            spy(state)
+            return <MyButton {...props} />
+          }}
+        />
+      ))
+
+      expect(spy).toHaveBeenCalledWith({})
+    })
+
+    it('should not render anything when the fn returns null', () => {
+      const { container } = render(() => <ark.button render={() => null} />)
+      expect(container).toBeEmptyDOMElement()
+    })
+
+    it('should not pass ref to the render fn', () => {
+      const spy = vi.fn()
+      let el: HTMLButtonElement | undefined
+      render(() => (
+        <ark.button
+          ref={el}
+          render={(props) => {
+            spy(Object.keys(props))
+            return <MyButton {...props} />
+          }}
+        />
+      ))
+      expect(spy.mock.calls[0][0]).not.toContain('ref')
+    })
   })
 
-  it('should merge styles', () => {
-    render(() => <ComponentUnderTest />)
-    expect(screen.getByText('Child')).toHaveStyle({ color: 'rgb(0, 0, 255)', background: 'red' })
-  })
+  describe('asChild (deprecated)', () => {
+    it('should render only the child', () => {
+      render(() => <ComponentUnderTest />)
+      expect(screen.getByText('Child')).toBeVisible()
+    })
 
-  it('should merge classes', () => {
-    render(() => <ComponentUnderTest />)
-    expect(screen.getByText('Child')).toHaveClass('child parent')
-  })
+    it('should merge styles', () => {
+      render(() => <ComponentUnderTest />)
+      expect(screen.getByText('Child')).toHaveStyle({ color: 'rgb(0, 0, 255)', background: 'red' })
+    })
 
-  it('should merge events', async () => {
-    const onClickParent = vi.fn()
-    const onClickChild = vi.fn()
-    render(() => (
-      <ark.div
-        data-testid="parent"
-        onClick={onClickParent}
-        asChild={(props) => <ark.span {...props({ onClick: onClickChild })} data-testid="child" />}
-      >
-        Parent
-      </ark.div>
-    ))
-    await user.click(screen.getByTestId('child'))
-    expect(onClickParent).toHaveBeenCalled()
-    expect(onClickChild).toHaveBeenCalled()
-  })
+    it('should merge classes', () => {
+      render(() => <ComponentUnderTest />)
+      expect(screen.getByText('Child')).toHaveClass('child parent')
+    })
 
-  it('should stop propagate asChild', async () => {
-    render(() => (
-      <ark.div
-        data-testid="parent"
-        asChild={(props) => (
-          <ark.span {...props()}>
-            <ark.span>Child</ark.span>
-          </ark.span>
-        )}
-      >
-        Parent
-      </ark.div>
-    ))
-    expect(screen.getByText('Child')).not.toHaveAttribute('data-testid', 'parent')
+    it('should merge events', async () => {
+      const onClickParent = vi.fn()
+      const onClickChild = vi.fn()
+      render(() => (
+        <ark.div
+          data-testid="parent"
+          onClick={onClickParent}
+          asChild={(props) => <ark.span {...props({ onClick: onClickChild })} data-testid="child" />}
+        >
+          Parent
+        </ark.div>
+      ))
+      await user.click(screen.getByTestId('child'))
+      expect(onClickParent).toHaveBeenCalled()
+      expect(onClickChild).toHaveBeenCalled()
+    })
+
+    it('should stop propagate asChild', async () => {
+      render(() => (
+        <ark.div
+          data-testid="parent"
+          asChild={(props) => (
+            <ark.span {...props()}>
+              <ark.span>Child</ark.span>
+            </ark.span>
+          )}
+        >
+          Parent
+        </ark.div>
+      ))
+      expect(screen.getByText('Child')).not.toHaveAttribute('data-testid', 'parent')
+    })
   })
 })

--- a/packages/solid/src/components/factory.tsx
+++ b/packages/solid/src/components/factory.tsx
@@ -11,31 +11,64 @@ type JsxElements = {
 
 type ParentProps<T extends ElementType> = (userProps?: JSX.IntrinsicElements[T]) => JSX.HTMLAttributes<any>
 
-export type PolymorphicProps<T extends ElementType> = {
+export type EmptyState = Record<never, never>
+
+// intentionally `any`: the props are spread onto arbitrary user components, `unknown` would break that
+export type RenderProps = Record<string, any>
+
+export type RenderFn<State> = (props: RenderProps, state: State) => JSX.Element
+
+export type PolymorphicProps<T extends ElementType, State = EmptyState> = {
   /**
    * Use the provided child element as the default rendered element, combining their props and behavior.
+   *
+   * @deprecated Use `render` instead. `render` receives the props to spread and the part's state.
+   * `asChild` will be removed in the next major.
    */
   asChild?: (props: ParentProps<T>) => JSX.Element
+  /**
+   * Render the part as a custom element, combining their props and behavior.
+   *
+   * Solid compiles JSX to a thunk that closes over its props, so there is nothing to merge into
+   * after the fact. Unlike react, `render` takes a function rather than an element.
+   */
+  render?: RenderFn<State>
 }
 export type HTMLProps<E extends ElementType> = JSX.IntrinsicElements[E]
 export type HTMLArkProps<E extends ElementType> = Assign<ComponentProps<E>, PolymorphicProps<E>>
 
-type ArkComponent<E extends ElementType> = (props: HTMLArkProps<E>) => JSX.Element
+interface ArkProps<T extends ElementType> extends PolymorphicProps<T, any> {
+  /**
+   * The state of the part, forwarded to the `render` function. Set by the component, not the consumer.
+   */
+  state?: unknown
+}
 
-const withAsProp = <T extends ElementType>(Component: T) => {
+type ArkComponent<E extends ElementType> = (props: HTMLArkProps<E> & ArkProps<E>) => JSX.Element
+
+const EMPTY_STATE: EmptyState = Object.freeze({})
+
+const withRender = <T extends ElementType>(Component: T) => {
   const ArkComponent: ArkComponent<T> = (props) => {
-    const [localProps, parentProps] = splitProps(props, ['asChild'])
+    const [localProps, parentProps] = splitProps(props as ArkProps<T>, ['asChild', 'render', 'state'])
+
+    if (process.env.NODE_ENV !== 'production' && localProps.asChild && localProps.render) {
+      throw new Error('[ark-ui] `asChild` and `render` cannot be used together. Prefer `render`.')
+    }
+
+    // the render fn applies the props itself, so only the ref is left to the caller
+    const [, restProps] = splitProps(parentProps as JSX.IntrinsicElements[T], ['ref'])
+
+    if (localProps.render) {
+      return localProps.render(restProps as RenderProps, localProps.state ?? EMPTY_STATE)
+    }
 
     if (localProps.asChild) {
-      // @ts-expect-error
-      const propsFn = (userProps) => {
-        const [, restProps] = splitProps(parentProps, ['ref'])
-        return mergeProps(restProps, userProps)
-      }
-      return localProps.asChild(propsFn)
+      const propsFn = (userProps?: JSX.IntrinsicElements[T]) => mergeProps(restProps, userProps ?? {})
+      return localProps.asChild(propsFn as ParentProps<T>)
     }
-    // @ts-expect-error
-    return <Dynamic component={Component} {...parentProps} />
+
+    return <Dynamic component={Component} {...(parentProps as JSX.IntrinsicElements[T])} />
   }
 
   return ArkComponent
@@ -44,14 +77,14 @@ const withAsProp = <T extends ElementType>(Component: T) => {
 function jsxFactory() {
   const cache = new Map()
 
-  return new Proxy(withAsProp, {
+  return new Proxy(withRender, {
     apply(_target, _thisArg, argArray) {
-      return withAsProp(argArray[0])
+      return withRender(argArray[0])
     },
     get(_, element) {
       const asElement = element as ElementType
       if (!cache.has(asElement)) {
-        cache.set(asElement, withAsProp(asElement))
+        cache.set(asElement, withRender(asElement))
       }
       return cache.get(asElement)
     },

--- a/packages/solid/src/components/factory.tsx
+++ b/packages/solid/src/components/factory.tsx
@@ -29,8 +29,8 @@ export type PolymorphicProps<T extends ElementType, State = EmptyState> = {
   /**
    * Render the part as a custom element, combining their props and behavior.
    *
-   * Solid compiles JSX to a thunk that closes over its props, so there is nothing to merge into
-   * after the fact. Unlike react, `render` takes a function rather than an element.
+   * Takes a function, or a component, since a solid component is a function of its props:
+   * `render={MyButton}` and `render={(props) => <MyButton {...props} />}` both work.
    */
   render?: RenderFn<State>
 }


### PR DESCRIPTION
Closes #

## 📝 Description

Brings solid's factory to v6. `render` takes the props to spread and the part's state, matching react:

```tsx
<ark.button state={{ open }} render={(props, state) => <MyButton {...props} />} />
```

A solid component is itself a function of its props, so a component reference works too:

```tsx
<ark.button render={MyButton} variant="ghost">Open</ark.button>
```

That covers what react's element form is for — children go outside, props merge from the ark element.

`asChild` still works and is marked deprecated. Passing both throws in development.

## ⛳️ Current behavior

Solid is still on the v5 factory — `asChild` taking a props callback, no `render`, no `state`.

## 🚀 New behavior

`render` as above, plus `state` forwarded as the second argument and defaulting to `{}`.

The one form solid can't take is a constructed element, `render={<MyButton />}`. JSX there compiles to a thunk that has already closed over its props, so there is nothing to merge into afterwards, and there is no `cloneElement`. Kobalte's `as` takes a tag, a component or a callback for the same reason. The type only accepts a function, so it's a compile error rather than props silently going missing, and the component form above is the replacement.

## 🧩 Frameworks

- [x] Solid

Vue is done and follows next. Svelte's `asChild` is already a snippet taking a props function, so it is close to the same shape.

## 💣 Is this a breaking change (Yes/No):

No. `asChild` is untouched, `render` is additive.

## ✅ Checklist

- [ ] Added a changeset for user-facing changes
- [x] Added or updated tests
- [ ] Added an example for any new prop or part
- [ ] Updated the docs

No changeset yet, v6 has no release pipeline. Docs land with the composition guide once all four factories are in.

## 📝 Additional information

Tests cover prop forwarding, the component-reference form, not double-applying what the fn didn't spread, state forwarding, the empty-state default, returning null, and keeping `ref` out of the props handed to the fn. The five existing `asChild` tests are unchanged.

Typecheck clean, build passes. The package's two remaining test failures are the pre-existing zag hotkeys bugs.

Roadmap: #3997
