### PR TITLE
feat(vue): add the render slot to the factory

### DIFF
--- a/packages/vue/src/components/factory.test.tsx
+++ b/packages/vue/src/components/factory.test.tsx
@@ -11,6 +11,90 @@ const ComponentUnderTest = (
   </ark.div>
 )
 
+describe('Factory / render slot', () => {
+  it('should render the slot with the forwarded props', async () => {
+    const onClick = vi.fn()
+    render(
+      defineComponent(
+        () => () =>
+          h(
+            ark.button,
+            { 'data-part': 'trigger', onClick },
+            {
+              render: ({ props }: { props: Record<string, unknown> }) =>
+                h('button', { ...props, 'data-testid': 'child' }, 'Ark UI'),
+            },
+          ),
+      ),
+    )
+
+    const child = screen.getByTestId('child')
+    expect(child.dataset['part']).toBe('trigger')
+
+    await user.click(child)
+    expect(onClick).toHaveBeenCalled()
+  })
+
+  it('should forward the state', () => {
+    render(
+      defineComponent(
+        () => () =>
+          h(
+            ark.button,
+            { state: { open: true } },
+            {
+              render: ({ props, state }: { props: Record<string, unknown>; state: { open: boolean } }) =>
+                h('button', { ...props, 'data-testid': 'child' }, state.open ? 'Open' : 'Closed'),
+            },
+          ),
+      ),
+    )
+
+    expect(screen.getByTestId('child')).toHaveTextContent('Open')
+  })
+
+  it('should default the state to an empty object', () => {
+    const spy = vi.fn()
+    render(
+      defineComponent(
+        () => () =>
+          h(
+            ark.button,
+            {},
+            {
+              render: ({ props, state }: { props: Record<string, unknown>; state: unknown }) => {
+                spy(state)
+                return h('button', { ...props, 'data-testid': 'child' })
+              },
+            },
+          ),
+      ),
+    )
+
+    expect(spy).toHaveBeenCalledWith({})
+  })
+
+  it('should take precedence over asChild', () => {
+    render(
+      defineComponent(
+        () => () =>
+          h(
+            ark.button,
+            { asChild: true },
+            {
+              default: () => h('span', { 'data-testid': 'as-child' }, 'as child'),
+              render: ({ props }: { props: Record<string, unknown> }) =>
+                h('button', { ...props, 'data-testid': 'child' }, 'render'),
+            },
+          ),
+      ),
+    )
+
+    expect(screen.getByTestId('child')).toBeVisible()
+    expect(screen.queryByTestId('as-child')).toBeNull()
+  })
+})
+
 describe('Factory', () => {
   it('should render only the child', () => {
     render(ComponentUnderTest)

--- a/packages/vue/src/components/factory.ts
+++ b/packages/vue/src/components/factory.ts
@@ -3,6 +3,7 @@ import {
   type ComponentCustomProps,
   type ExtractPropTypes,
   type IntrinsicElementAttributes,
+  type VNode,
   type VNodeProps,
   defineComponent,
   h,
@@ -12,11 +13,40 @@ import { Dynamic } from '../utils/dynamic.ts'
 type DOMElements = keyof IntrinsicElementAttributes
 type ElementType = Parameters<typeof h>[0]
 
+export type EmptyState = Record<never, never>
+
+// intentionally `any`: the props are bound onto arbitrary user components, `unknown` would break that
+export type RenderProps = Record<string, any>
+
+export interface RenderSlotScope<State = EmptyState> {
+  /**
+   * The part's props, to bind onto your own element.
+   */
+  props: RenderProps
+  /**
+   * The part's state.
+   */
+  state: State
+}
+
 export interface PolymorphicProps {
   /**
    * Use the provided child element as the default rendered element, combining their props and behavior.
+   *
+   * @deprecated Use the `render` slot instead. `asChild` will be removed in the next major.
    */
   asChild?: boolean
+}
+
+export interface PolymorphicSlots<State = EmptyState> {
+  default?: () => VNode[]
+  /**
+   * Render the part as a custom element, combining their props and behavior.
+   *
+   * Vue templates cannot take an element as a prop value, so this is a scoped slot rather than
+   * react's `render` prop.
+   */
+  render?: (scope: RenderSlotScope<State>) => VNode[]
 }
 
 export type AsChildComponent<
@@ -33,6 +63,7 @@ export type AsChildComponent<
         : Record<never, never>) &
       P &
       PolymorphicProps
+    $slots: PolymorphicSlots
   }
 }
 
@@ -47,6 +78,7 @@ export type HTMLPolymorphicProps<T extends ElementType> = Omit<
   'ref'
 > & {
   asChild?: boolean
+  state?: unknown
 }
 
 export type HTMLArkProps<T extends DOMElements> = HTMLPolymorphicProps<T>
@@ -55,7 +87,9 @@ export type HTMLArkProps<T extends DOMElements> = HTMLPolymorphicProps<T>
 const SELF_CLOSING_TAGS = 'br, hr, img, input, area, textarea'.split(', ')
 const isSelfClosingTag = (tag: unknown) => typeof tag === 'string' && SELF_CLOSING_TAGS.includes(tag)
 
-const withAsChild = (component: ElementType) => {
+const EMPTY_STATE: EmptyState = Object.freeze({})
+
+const withRender = (component: ElementType) => {
   return defineComponent({
     name: 'Polymorphic',
     inheritAttrs: false,
@@ -64,10 +98,18 @@ const withAsChild = (component: ElementType) => {
         type: Boolean,
         default: false,
       },
+      state: {
+        type: null,
+        default: undefined,
+      },
     },
     setup(props, { attrs, slots }) {
-      if (!props.asChild) return () => h(component, attrs, isSelfClosingTag(component) ? undefined : slots.default?.())
-      return () => h(Dynamic, attrs, slots)
+      return () => {
+        // the slot binds the props itself, so it owns the merge
+        if (slots.render) return slots.render({ props: attrs, state: props.state ?? EMPTY_STATE })
+        if (props.asChild) return h(Dynamic, attrs, slots)
+        return h(component, attrs, isSelfClosingTag(component) ? undefined : slots.default?.())
+      }
     },
   })
 }
@@ -75,13 +117,13 @@ const withAsChild = (component: ElementType) => {
 export function jsxFactory() {
   const cache = new Map()
 
-  const factory = new Proxy(withAsChild, {
+  const factory = new Proxy(withRender, {
     apply(_target, _thisArg, argArray) {
-      return withAsChild(argArray[0])
+      return withRender(argArray[0])
     },
     get(_, element) {
       if (!cache.has(element)) {
-        cache.set(element, withAsChild(element as ElementType))
+        cache.set(element, withRender(element as ElementType))
       }
       return cache.get(element)
     },


### PR DESCRIPTION
Closes #

## 📝 Description

Brings vue's factory to v6. A template can't take an element as a prop value, so `render` is a scoped slot rather than react's prop — the same shape as the `Context` components:

```vue
<ark.button :state="{ open }">
  <template #render="{ props, state }">
    <MyButton v-bind="props">{{ state.open ? 'Open' : 'Closed' }}</MyButton>
  </template>
</ark.button>
```

`asChild` still works and is marked deprecated. The render slot wins if both are given.

## ⛳️ Current behavior

Vue is still on the v5 factory — `asChild` as a boolean, no render slot, no `state`.

## 🚀 New behavior

The `render` slot above, plus `state` forwarded to it and defaulting to `{}`.

Two things worth a look in review:

`state` stays off `PolymorphicProps` and lives only on the factory's own props. Components extend `PolymorphicProps`, and zag's progress `ViewProps` already has a `state`, so the two collide otherwise. React keeps the same split for the same reason.

The branches move inside the returned render function. They were decided once in `setup` before, so a reactive `asChild` never took effect.

## 🧩 Frameworks

- [x] Vue

React and solid are done. Svelte is left, and its `asChild` is already a snippet taking a props function.

## 💣 Is this a breaking change (Yes/No):

No. `asChild` is untouched, the render slot is additive.

## ✅ Checklist

- [ ] Added a changeset for user-facing changes
- [x] Added or updated tests
- [ ] Added an example for any new prop or part
- [ ] Updated the docs

No changeset yet, v6 has no release pipeline. Docs land with the composition guide once all four factories are in.

## 📝 Additional information

Tests cover prop forwarding, state forwarding, the empty-state default, and render winning over asChild. The eleven existing asChild tests are unchanged.

Typecheck clean, build passes. The package's two remaining failures are the known color-picker parity difference and one zag hotkeys bug.

Roadmap: #3997
