### PR TITLE
chore: move feature requests to GitHub Discussions

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -1,0 +1,47 @@
+title: "🚀 Feature request: "
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an idea 😄! Please search open discussions before posting — someone might have asked the same thing before 😉.
+  - type: textarea
+    id: idea
+    attributes:
+      label: 💡 Your idea
+      description: Fill in the sections below — delete any that don't apply.
+      value: |
+        <!---
+        Thanks for filing an issue 😄!
+
+        Please search open/closed issues before submitting. Someone
+        might have asked the same thing before 😉!
+        -->
+
+        # 🚀 Feature request
+
+        > Please describe your request in one or two sentences.
+
+        ## 🧱 Problem Statement / Justification
+
+        > Please provide valid reason(s) why this should added.
+        >
+        > If this feaure is related to a problem you've noticed. Mention it as well
+
+        ## ✅ Proposed solution or API
+
+        > Please provide code snippets, gists, or links to the ideal design or API
+
+        ## ↩️ Alternatives
+
+        > What alternative solutions have you considered before making this request?
+
+        ## 🧢 Your Company/Team
+
+        <!-- Optional: Which company or team would benefit from this feature? (e.g., Acme/Dashboard) -->
+
+        ## 📝 Additional Information
+
+        > What resources (links, screenshots, etc.) do you have to assist this effort?
+    validations:
+      required: true

--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -26,7 +26,7 @@ body:
 
         > Please provide valid reason(s) why this should added.
         >
-        > If this feaure is related to a problem you've noticed. Mention it as well
+        > If this feature is related to a problem you've noticed. Mention it as well
 
         ## ✅ Proposed solution or API
 

--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -24,7 +24,7 @@ body:
 
         ## 🧱 Problem Statement / Justification
 
-        > Please provide valid reason(s) why this should added.
+        > Please provide valid reason(s) why this should be added.
         >
         > If this feature is related to a problem you've noticed. Mention it as well
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Feature Request
-    url: https://ark-ui.canny.io/
-    about: Request, vote and explore new features
+  - name: Request a feature or enhancement
+    url: https://github.com/chakra-ui/ark/discussions/new?category=ideas
+    about: Please post feature requests in GitHub Discussions
   - name: Questions & Discussions
     url: https://github.com/chakra-ui/ark/discussions
     about: Ask questions and discuss topics with other devlopers


### PR DESCRIPTION
Routes feature requests to the Discussions "ideas" category instead of the Canny board.