### PR TITLE
feat(svelte): add the render snippet to the factory

### DIFF
--- a/packages/svelte/src/lib/components/factory/examples/render.svelte
+++ b/packages/svelte/src/lib/components/factory/examples/render.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import Ark from '../factory.svelte'
+
+  interface Props {
+    onClickParent?: () => void
+    onClickChild?: () => void
+    state?: unknown
+  }
+
+  const { onClickParent, onClickChild, state }: Props = $props()
+</script>
+
+<Ark
+  as="div"
+  data-part="trigger"
+  data-testid="parent"
+  class="parent"
+  style="background: red"
+  onclick={onClickParent}
+  {state}
+>
+  {#snippet render(props, snapshot)}
+    <button
+      {...props({ class: 'child', style: 'color: blue', onclick: onClickChild })}
+      type="button"
+      data-testid="child"
+    >
+      {(snapshot as { open?: boolean })?.open ? 'Open' : 'Ark UI'}
+    </button>
+  {/snippet}
+</Ark>

--- a/packages/svelte/src/lib/components/factory/factory.svelte
+++ b/packages/svelte/src/lib/components/factory/factory.svelte
@@ -1,12 +1,12 @@
 <script lang="ts" generics="T extends keyof SvelteHTMLElements">
-  import type { HTMLProps, PolymorphicProps, PropsFn } from '$lib/types'
+  import type { EmptyState, HTMLProps, PolymorphicProps, PropsFn } from '$lib/types'
   import { isVoidHTMLTag, isVoidSVGTag } from '$lib/utils/tags'
   import { mergeProps } from '@zag-js/svelte'
   import type { SvelteHTMLElements } from 'svelte/elements'
   import Svg from './svg-factory.svelte'
 
   type Props = HTMLProps<T> &
-    PolymorphicProps<T> & {
+    PolymorphicProps<T, any> & {
       /**
        * The HTML tag of the component.
        */
@@ -15,15 +15,23 @@
        * The bindable ref of the component.
        */
       ref?: Element | null
+      /**
+       * The state of the part, forwarded to the `render` snippet. Set by the component, not the consumer.
+       */
+      state?: unknown
     }
 
-  let { asChild, children, as, ref = $bindable(null), ...rest }: Props = $props()
+  let { asChild, render, children, as, state, ref = $bindable(null), ...rest }: Props = $props()
+
+  const EMPTY_STATE: EmptyState = Object.freeze({})
 
   const propsFn: PropsFn<T> = (props) => mergeProps(rest, props ?? {})
 </script>
 
-{#if asChild}
-  {@render asChild?.(propsFn)}
+{#if render}
+  {@render render(propsFn, state ?? EMPTY_STATE)}
+{:else if asChild}
+  {@render asChild(propsFn)}
 {:else if isVoidSVGTag(as)}
   <Svg {as} {...rest} bind:ref />
 {:else if isVoidHTMLTag(as)}

--- a/packages/svelte/src/lib/components/factory/factory.test.ts
+++ b/packages/svelte/src/lib/components/factory/factory.test.ts
@@ -2,6 +2,46 @@ import { render, screen } from '@testing-library/svelte'
 import user from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 import ComponentUnderTest from './examples/basic.svelte'
+import RenderTest from './examples/render.svelte'
+
+describe('Ark Factory / render', () => {
+  it('should render the snippet with the forwarded props', async () => {
+    const onClickParent = vi.fn()
+    const onClickChild = vi.fn()
+    render(RenderTest, { onClickParent, onClickChild })
+
+    const child = screen.getByTestId('child')
+    // biome-ignore lint/complexity/useLiteralKeys: intentional
+    expect(child.dataset['part']).toBe('trigger')
+
+    await user.click(child)
+    expect(onClickParent).toHaveBeenCalled()
+    expect(onClickChild).toHaveBeenCalled()
+  })
+
+  it('should merge styles and classes', () => {
+    render(RenderTest)
+    const child = screen.getByTestId('child')
+    expect(child).toHaveStyle({ background: 'red' })
+    expect(child).toHaveStyle({ color: 'rgb(0, 0, 255)' })
+    expect(child).toHaveClass('child parent')
+  })
+
+  it('should not render the default element', () => {
+    render(RenderTest)
+    expect(() => screen.getByTestId('parent')).toThrow()
+  })
+
+  it('should forward the state', () => {
+    render(RenderTest, { state: { open: true } })
+    expect(screen.getByTestId('child')).toHaveTextContent('Open')
+  })
+
+  it('should default the state to an empty object', () => {
+    render(RenderTest)
+    expect(screen.getByTestId('child')).toHaveTextContent('Ark UI')
+  })
+})
 
 describe('Ark Factory', () => {
   it('should render only the child', () => {

--- a/packages/svelte/src/lib/types.ts
+++ b/packages/svelte/src/lib/types.ts
@@ -10,15 +10,27 @@ export type PropsFn<T extends HTMLTag> = (props?: HTMLProps<T>) => HTMLAttribute
 
 export type HTMLProps<T extends HTMLTag> = SvelteHTMLElements[T]
 
-export type PolymorphicProps<T extends HTMLTag> = {
+export type EmptyState = Record<never, never>
+
+export type PolymorphicProps<T extends HTMLTag, State = EmptyState> = {
   /**
    * The children snippet of the component.
    */
   children?: Snippet
   /**
    * Use the provided child element as the default rendered element, combining their props and behavior.
+   *
+   * @deprecated Use the `render` snippet instead. It also receives the part's state.
+   * `asChild` will be removed in the next major.
    */
   asChild?: Snippet<[PropsFn<T>]>
+  /**
+   * Render the part as a custom element, combining their props and behavior.
+   *
+   * A template can't take an element as a prop value, so this is a snippet rather than react's
+   * `render` prop. It receives the props to bind and the part's state.
+   */
+  render?: Snippet<[PropsFn<T>, State]>
 }
 
 export interface RefAttribute<T extends Element = Element> {


### PR DESCRIPTION
Closes #

## 📝 Description

Completes the v6 factory. `render` now exists in all four frameworks.

A template can't take an element as a prop value, so svelte's is a snippet taking the props to bind and the part's state:

```svelte
<Popover.Trigger>
  {#snippet render(props, state)}
    <button {...props()}>{state.open ? 'Close' : 'Open'}</button>
  {/snippet}
</Popover.Trigger>
```

## ⛳️ Current behavior

Svelte is still on the v5 factory — an `asChild` snippet, no `render`, no `state`.

## 🚀 New behavior

The `render` snippet above. It keeps the props-function shape `asChild` already used, so you can still merge your own props with `props({ class: 'mine' })` rather than adopting react's plain-object shape.

`asChild` still works and is marked deprecated. The render snippet wins if both are given.

`state` stays off `PolymorphicProps` and lives on the factory's own props. Components extend `PolymorphicProps`, and zag's progress `ViewProps` already has a `state`, so the two collide otherwise. React and vue keep the same split for the same reason.

## 🧩 Frameworks

- [x] Svelte

With this, `render` is in all four:

| framework | shape |
| --- | --- |
| React | `render={<Button/>}` or `render={(props, state) => …}` |
| Solid | `render={MyButton}` or `render={(props, state) => …}` |
| Vue | `<template #render="{ props, state }">` |
| Svelte | `{#snippet render(props, state)}` |

## 💣 Is this a breaking change (Yes/No):

No. `asChild` is untouched, the render snippet is additive.

## ✅ Checklist

- [ ] Added a changeset for user-facing changes
- [x] Added or updated tests
- [ ] Added an example for any new prop or part
- [x] Updated the docs

No changeset yet, v6 has no release pipeline. Examples and the composition guide follow in their own PR, now that all four frameworks can be documented together.

## 📝 Additional information

Five new tests cover prop forwarding, style and class merging, not rendering the default element, state forwarding, and the empty-state default. The four existing `asChild` tests are unchanged.

Typecheck 0 errors, build passes, root typecheck exits 0. The package's one remaining failure is the known zag hotkeys bug.

Roadmap: #3997
