### PR TITLE
docs: document the render prop in the composition guide

### DIFF
--- a/packages/react/src/components/popover/examples/render.tsx
+++ b/packages/react/src/components/popover/examples/render.tsx
@@ -1,0 +1,10 @@
+import { Popover } from '@ark-ui/react/popover'
+
+export const Render = () => (
+  <Popover.Root>
+    <Popover.Trigger render={<button type="button">Open Popover</button>} />
+    <Popover.Positioner>
+      <Popover.Content>Content</Popover.Content>
+    </Popover.Positioner>
+  </Popover.Root>
+)

--- a/packages/solid/src/components/popover/examples/render.tsx
+++ b/packages/solid/src/components/popover/examples/render.tsx
@@ -1,0 +1,10 @@
+import { Popover } from '@ark-ui/solid/popover'
+
+export const Render = () => (
+  <Popover.Root>
+    <Popover.Trigger render={(props) => <button type="button" {...props} />}>Open Popover</Popover.Trigger>
+    <Popover.Positioner>
+      <Popover.Content>Content</Popover.Content>
+    </Popover.Positioner>
+  </Popover.Root>
+)

--- a/packages/svelte/src/lib/components/factory/examples/render.svelte
+++ b/packages/svelte/src/lib/components/factory/examples/render.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import Ark from '../factory.svelte'
+
+  interface Props {
+    onClickParent?: () => void
+    onClickChild?: () => void
+    state?: unknown
+  }
+
+  const { onClickParent, onClickChild, state }: Props = $props()
+</script>
+
+<Ark
+  as="div"
+  data-part="trigger"
+  data-testid="parent"
+  class="parent"
+  style="background: red"
+  onclick={onClickParent}
+  {state}
+>
+  {#snippet render(props, snapshot)}
+    <button
+      {...props({ class: 'child', style: 'color: blue', onclick: onClickChild })}
+      type="button"
+      data-testid="child"
+    >
+      {(snapshot as { open?: boolean })?.open ? 'Open' : 'Ark UI'}
+    </button>
+  {/snippet}
+</Ark>

--- a/packages/svelte/src/lib/components/factory/factory.svelte
+++ b/packages/svelte/src/lib/components/factory/factory.svelte
@@ -1,12 +1,12 @@
 <script lang="ts" generics="T extends keyof SvelteHTMLElements">
-  import type { HTMLProps, PolymorphicProps, PropsFn } from '$lib/types'
+  import type { EmptyState, HTMLProps, PolymorphicProps, PropsFn } from '$lib/types'
   import { isVoidHTMLTag, isVoidSVGTag } from '$lib/utils/tags'
   import { mergeProps } from '@zag-js/svelte'
   import type { SvelteHTMLElements } from 'svelte/elements'
   import Svg from './svg-factory.svelte'
 
   type Props = HTMLProps<T> &
-    PolymorphicProps<T> & {
+    PolymorphicProps<T, any> & {
       /**
        * The HTML tag of the component.
        */
@@ -15,15 +15,23 @@
        * The bindable ref of the component.
        */
       ref?: Element | null
+      /**
+       * The state of the part, forwarded to the `render` snippet. Set by the component, not the consumer.
+       */
+      state?: unknown
     }
 
-  let { asChild, children, as, ref = $bindable(null), ...rest }: Props = $props()
+  let { asChild, render, children, as, state, ref = $bindable(null), ...rest }: Props = $props()
+
+  const EMPTY_STATE: EmptyState = Object.freeze({})
 
   const propsFn: PropsFn<T> = (props) => mergeProps(rest, props ?? {})
 </script>
 
-{#if asChild}
-  {@render asChild?.(propsFn)}
+{#if render}
+  {@render render(propsFn, state ?? EMPTY_STATE)}
+{:else if asChild}
+  {@render asChild(propsFn)}
 {:else if isVoidSVGTag(as)}
   <Svg {as} {...rest} bind:ref />
 {:else if isVoidHTMLTag(as)}

--- a/packages/svelte/src/lib/components/factory/factory.test.ts
+++ b/packages/svelte/src/lib/components/factory/factory.test.ts
@@ -2,6 +2,46 @@ import { render, screen } from '@testing-library/svelte'
 import user from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 import ComponentUnderTest from './examples/basic.svelte'
+import RenderTest from './examples/render.svelte'
+
+describe('Ark Factory / render', () => {
+  it('should render the snippet with the forwarded props', async () => {
+    const onClickParent = vi.fn()
+    const onClickChild = vi.fn()
+    render(RenderTest, { onClickParent, onClickChild })
+
+    const child = screen.getByTestId('child')
+    // biome-ignore lint/complexity/useLiteralKeys: intentional
+    expect(child.dataset['part']).toBe('trigger')
+
+    await user.click(child)
+    expect(onClickParent).toHaveBeenCalled()
+    expect(onClickChild).toHaveBeenCalled()
+  })
+
+  it('should merge styles and classes', () => {
+    render(RenderTest)
+    const child = screen.getByTestId('child')
+    expect(child).toHaveStyle({ background: 'red' })
+    expect(child).toHaveStyle({ color: 'rgb(0, 0, 255)' })
+    expect(child).toHaveClass('child parent')
+  })
+
+  it('should not render the default element', () => {
+    render(RenderTest)
+    expect(() => screen.getByTestId('parent')).toThrow()
+  })
+
+  it('should forward the state', () => {
+    render(RenderTest, { state: { open: true } })
+    expect(screen.getByTestId('child')).toHaveTextContent('Open')
+  })
+
+  it('should default the state to an empty object', () => {
+    render(RenderTest)
+    expect(screen.getByTestId('child')).toHaveTextContent('Ark UI')
+  })
+})
 
 describe('Ark Factory', () => {
   it('should render only the child', () => {

--- a/packages/svelte/src/lib/components/popover/examples/render.svelte
+++ b/packages/svelte/src/lib/components/popover/examples/render.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import { Popover } from '@ark-ui/svelte/popover'
+</script>
+
+<Popover.Root>
+  <Popover.Trigger>
+    {#snippet render(props)}
+      <button type="button" {...props()}>Open Popover</button>
+    {/snippet}
+  </Popover.Trigger>
+  <Popover.Positioner>
+    <Popover.Content>Content</Popover.Content>
+  </Popover.Positioner>
+</Popover.Root>

--- a/packages/svelte/src/lib/types.ts
+++ b/packages/svelte/src/lib/types.ts
@@ -10,15 +10,27 @@ export type PropsFn<T extends HTMLTag> = (props?: HTMLProps<T>) => HTMLAttribute
 
 export type HTMLProps<T extends HTMLTag> = SvelteHTMLElements[T]
 
-export type PolymorphicProps<T extends HTMLTag> = {
+export type EmptyState = Record<never, never>
+
+export type PolymorphicProps<T extends HTMLTag, State = EmptyState> = {
   /**
    * The children snippet of the component.
    */
   children?: Snippet
   /**
    * Use the provided child element as the default rendered element, combining their props and behavior.
+   *
+   * @deprecated Use the `render` snippet instead. It also receives the part's state.
+   * `asChild` will be removed in the next major.
    */
   asChild?: Snippet<[PropsFn<T>]>
+  /**
+   * Render the part as a custom element, combining their props and behavior.
+   *
+   * A template can't take an element as a prop value, so this is a snippet rather than react's
+   * `render` prop. It receives the props to bind and the part's state.
+   */
+  render?: Snippet<[PropsFn<T>, State]>
 }
 
 export interface RefAttribute<T extends Element = Element> {

--- a/packages/vue/src/components/popover/examples/render.vue
+++ b/packages/vue/src/components/popover/examples/render.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import { Popover } from '@ark-ui/vue/popover'
+</script>
+
+<template>
+  <Popover.Root>
+    <Popover.Trigger>
+      <template #render="{ props }">
+        <button type="button" v-bind="props">Open Popover</button>
+      </template>
+    </Popover.Trigger>
+    <Popover.Positioner>
+      <Popover.Content>Content</Popover.Content>
+    </Popover.Positioner>
+  </Popover.Root>
+</template>

--- a/website/src/content/pages/guides/composition.mdx
+++ b/website/src/content/pages/guides/composition.mdx
@@ -4,17 +4,36 @@ title: Composition
 description: Learn how to compose default components with custom elements
 ---
 
+## The render Prop
+
+Every Ark part renders a sensible default element. When you want your own — a design system `Button`, a router `Link` —
+`render` puts it there instead, and hands you the part's props to apply.
+
+<ExampleCode id="render" component="popover" />
+
+The `Popover.Trigger` no longer renders its own `button`. Yours takes its place, with the trigger's props, event
+handlers and ARIA attributes applied to it.
+
+Each framework spells this the way that framework composes:
+
+| Framework | Shape                                             |
+| --------- | ------------------------------------------------- |
+| React     | a `render` prop, taking an element or a function  |
+| Solid     | a `render` prop, taking a component or a function |
+| Vue       | a `render` slot                                   |
+| Svelte    | a `render` snippet                                |
+
+The capability is the same in all four. Only the spelling differs, because a template can't take an element as a prop
+value the way JSX can.
+
 ## The asChild Prop
 
-In Ark UI, the `asChild` prop lets you integrate custom components, ensuring consistent styling and behavior while
-promoting flexibility and reusability. All Ark components that render a DOM element accept the `asChild` prop.
-
-Here's an example using `asChild` to integrate a custom `Button` component within a `Popover`:
+`asChild` does the same job by wrapping the element as a child instead of passing it to `render`.
 
 <ExampleCode id="as-child" component="popover" />
 
-In this example, the `asChild` prop allows the `Button` to be used as the trigger for the `Popover`, inheriting its
-behaviors from Popover.Trigger.
+It still works, and it is deprecated. Prefer `render` in new code — it is explicit about which element is being
+replaced, and it doesn't change how children are interpreted.
 
 ## The Ark Factory
 
@@ -28,8 +47,8 @@ The factory renders the child element in place of the `span`, so this produces:
 <a href="#">Ark UI</a>
 ```
 
-Any props you pass to `ark.span` are merged onto the child element, which is how the factory forwards styling and behavior to
-whatever you render.
+Any props you pass to `ark.span` are merged onto the child element, which is how the factory forwards styling and
+behavior to whatever you render.
 
 ## ID Composition
 
@@ -65,9 +84,12 @@ attributes and interaction behavior.
 
 ## Limitations
 
-When using the `asChild` prop, ensure you pass only a single child element. Passing multiple children may cause
-rendering issues.
+Render one element. `render` and `asChild` both replace a single element, so returning a fragment or several siblings
+will not work.
 
 Certain components, such as `Checkbox.Root` or `RadioGroup.Item`, have specific requirements for their child elements.
 For instance, they may require a label element as a child. If you change the underlying element type, ensure it remains
 accessible and functional.
+
+Pass one or the other. Giving a part both `render` and `asChild` is a mistake. React throws in development, Solid warns,
+and Vue and Svelte use the `render` form.

--- a/website/src/lib/example-registry.ts
+++ b/website/src/lib/example-registry.ts
@@ -396,6 +396,7 @@ import * as Popover_Modal from '@examples/popover/examples/modal'
 import * as Popover_MultipleTriggers from '@examples/popover/examples/multiple-triggers'
 import * as Popover_Nested from '@examples/popover/examples/nested'
 import * as Popover_Positioning from '@examples/popover/examples/positioning'
+import * as Popover_Render from '@examples/popover/examples/render'
 import * as Popover_RootProvider from '@examples/popover/examples/root-provider'
 import * as Popover_SameWidth from '@examples/popover/examples/same-width'
 import * as Popover_WithDialog from '@examples/popover/examples/with-dialog'
@@ -1024,6 +1025,7 @@ const exampleModules: Record<string, ExampleModule> = {
   'popover/multiple-triggers': Popover_MultipleTriggers,
   'popover/nested': Popover_Nested,
   'popover/positioning': Popover_Positioning,
+  'popover/render': Popover_Render,
   'popover/root-provider': Popover_RootProvider,
   'popover/same-width': Popover_SameWidth,
   'popover/with-dialog': Popover_WithDialog,


### PR DESCRIPTION
Closes #

Stacked on #4010 — the svelte example needs that factory. Base retargets to `v6` once it merges.

## 📝 Description

Adds a popover `render` example for each framework and rewrites the composition guide to lead with `render` rather than `asChild`.

## ⛳️ Current behavior

The guide only documents `asChild`. There is no `render` example anywhere.

## 🚀 New behavior

A `render` example per framework, and a guide section above the `asChild` one.

The guide's prose is shared across frameworks while `render` is spelled four different ways, so it describes the capability once and puts the spelling in a table:

| Framework | Shape |
| --- | --- |
| React | a `render` prop, taking an element or a function |
| Solid | a `render` prop, taking a component or a function |
| Vue | a `render` slot |
| Svelte | a `render` snippet |

`asChild` keeps its section, marked deprecated, since it still works.

Limitations gains the both-at-once case, checked against each factory: react throws in development, solid warns, vue and svelte use the render form.

## 🧩 Frameworks

- [x] React
- [x] Solid
- [x] Svelte
- [x] Vue

## 💣 Is this a breaking change (Yes/No):

No. Docs and examples only.

## ✅ Checklist

- [ ] Added a changeset for user-facing changes
- [ ] Added or updated tests
- [x] Added an example for any new prop or part
- [x] Updated the docs

## 📝 Additional information

**The examples pass only the props.** `render` also takes the part's state, but no component forwards state yet, so the second argument always arrives empty. Documenting it now would describe something that doesn't work. It goes in when the components plumb it — that is the next roadmap item.

All four packages typecheck, and `next build` passes.

Roadmap: #3997
