### PR TITLE
docs(vue): show the render slot in its short form

### DIFF
--- a/packages/vue/src/components/popover/examples/render.vue
+++ b/packages/vue/src/components/popover/examples/render.vue
@@ -4,10 +4,8 @@ import { Popover } from '@ark-ui/vue/popover'
 
 <template>
   <Popover.Root>
-    <Popover.Trigger>
-      <template #render="{ props }">
-        <button type="button" v-bind="props">Open Popover</button>
-      </template>
+    <Popover.Trigger #render="{ props, state }">
+      <button type="button" v-bind="props">{{ state.open ? 'Close' : 'Open' }} Popover</button>
     </Popover.Trigger>
     <Popover.Positioner>
       <Popover.Content>Content</Popover.Content>

--- a/packages/vue/src/components/popover/popover.stories.ts
+++ b/packages/vue/src/components/popover/popover.stories.ts
@@ -10,6 +10,7 @@ import ModalExample from './examples/modal.vue'
 import MultipleTriggersExample from './examples/multiple-triggers.vue'
 import NestedExample from './examples/nested.vue'
 import PositioningExample from './examples/positioning.vue'
+import RenderExample from './examples/render.vue'
 import RootProviderExample from './examples/root-provider.vue'
 import SameWidthExample from './examples/same-width.vue'
 import WithDialogExample from './examples/with-dialog.vue'
@@ -86,6 +87,13 @@ export const Nested = {
 export const Positioning = {
   render: () => ({
     components: { Component: PositioningExample },
+    template: '<Component />',
+  }),
+}
+
+export const Render = {
+  render: () => ({
+    components: { Component: RenderExample },
     template: '<Component />',
   }),
 }

--- a/website/src/content/pages/guides/composition.mdx
+++ b/website/src/content/pages/guides/composition.mdx
@@ -16,15 +16,14 @@ handlers and ARIA attributes applied to it.
 
 Each framework spells this the way that framework composes:
 
-| Framework | Shape                                             |
-| --------- | ------------------------------------------------- |
-| React     | a `render` prop, taking an element or a function  |
-| Solid     | a `render` prop, taking a component or a function |
-| Vue       | a `render` slot                                   |
-| Svelte    | a `render` snippet                                |
+| Framework | Shape                                                   |
+| --------- | ------------------------------------------------------- |
+| React     | a `render` prop, taking an element or a function        |
+| Solid     | a `render` prop, taking a component or a function       |
+| Vue       | a `render` slot, written `#render` directly on the part |
+| Svelte    | a `render` snippet                                      |
 
-The capability is the same in all four. Only the spelling differs, because a template can't take an element as a prop
-value the way JSX can.
+The capability is the same in all four: each one hands you the part's props to apply, and the part's state.
 
 ## The asChild Prop
 


### PR DESCRIPTION
> [!NOTE]
> Stacked on #4013. The example cannot work without it, so review that one first. Base retargets to `v6` once it lands.

## 📝 Description

`#render` goes directly on the part. The `<template>` wrapper is only needed when another slot is passed alongside it, and every Vue example we have written uses the long form, which makes the API look heavier than it is.

## ⛳️ Current behavior

```vue
<Popover.Trigger>
  <template #render="{ props }">
    <button type="button" v-bind="props">Open Popover</button>
  </template>
</Popover.Trigger>
```

The guide also claimed a template cannot take an element as a prop value the way JSX can. That is true of vnodes, but it reads as an apology.

## 🚀 New behavior

```vue
<Popover.Trigger #render="{ props, state }">
  <button type="button" v-bind="props">{{ state.open ? 'Close' : 'Open' }} Popover</button>
</Popover.Trigger>
```

A line shorter than the React equivalent, and it reads the trigger's state. The example is wired into the stories so it can be run.

Mixing the shorthand with another slot is the one limitation, and Vue's own compiler error covers it clearly:

```
Mixed v-slot usage on both the component and nested <template>.
```

It cannot come up in practice — in render mode the factory returns before it touches `slots.default`.

## 🧩 Frameworks

- [ ] React
- [ ] Solid
- [ ] Svelte
- [x] Vue
- [ ] Not framework-specific

## 💣 Is this a breaking change (Yes/No):

No. The long form still works.

## ✅ Checklist

- [ ] Added a changeset for user-facing changes
- [ ] Added or updated tests
- [x] Added an example for any new prop or part
- [x] Updated the docs

Docs only, so no changeset. Behaviour is covered by the tests in #4013.

## 📝 Additional information

Both forms produce byte-identical DOM, so this is presentation only.


<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR simplifies Vue render-slot documentation and examples by placing `#render` directly on the component, demonstrates access to Popover state, and makes the example available in Storybook.

- Rewrites the Popover render example using Vue’s short slot form and a state-dependent label.
- Registers the render example as a Popover story.
- Updates the composition guide’s cross-framework render API description.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified in the changed examples, story registration, or documentation.

The short Vue slot form and `state.open` access match existing tested behavior, while the Storybook registration follows established neighboring patterns.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/vue/src/components/popover/examples/render.vue | Uses the supported short render-slot syntax and reads the tested reactive `state.open` value. |
| packages/vue/src/components/popover/popover.stories.ts | Registers the new example using the repository’s established Vue Storybook pattern. |
| website/src/content/pages/guides/composition.mdx | Clarifies Vue render-slot syntax and consistently describes the state available through functional render APIs. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(vue): show the render slot in its s..."](https://github.com/chakra-ui/ark/commit/88acf1eeba15ef5b9c961addc176c622fa1b2a69) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60798623)</sub>

<!-- /greptile_comment -->