### PR TITLE
fix(vue): drop two stray tags left in templates

### DIFF
--- a/.changeset/vue-stray-template-tags.md
+++ b/.changeset/vue-stray-template-tags.md
@@ -1,0 +1,5 @@
+---
+'@ark-ui/vue': patch
+---
+
+Fix `Select.HiddenSelect` rendering a stray `>` as text in every option, so each one read `Label >`.

--- a/packages/vue/src/components/select/select-hidden-select.vue
+++ b/packages/vue/src/components/select/select-hidden-select.vue
@@ -36,7 +36,6 @@ useForwardExpose()
       :disabled="select.collection.getItemDisabled(item)"
     >
       {{ select.collection.stringifyItem(item) }}
-      >
     </option>
   </ark.select>
 </template>

--- a/packages/vue/src/components/toc/examples/with-tree-view.vue
+++ b/packages/vue/src/components/toc/examples/with-tree-view.vue
@@ -141,10 +141,6 @@ const onActiveChange = ({ activeItems }: { activeItems: { value: string }[] }) =
                   </TreeView.NodeGroupContent>
                 </TreeView.NodeGroup>
               </TreeView.NodeProvider>
-                    </template>
-                  </TreeView.BranchContent>
-                </TreeView.Branch>
-              </TreeView.NodeProvider>
             </template>
           </TreeView.Tree>
         </TreeView.Root>


### PR DESCRIPTION
## 📝 Description

Two stray tags left behind in Vue templates. Both turned up while verifying #4013; neither is related to it.

## ⛳️ Current behavior

`Select.HiddenSelect` has a bare `>` on its own line inside `<option>`, which renders as text. Every option reads `Label >`:

```vue
{{ select.collection.stringifyItem(item) }}
>
</option>
```

The toc tree-view example still carries the closing tags of `BranchContent` and `Branch` from before the rename to `NodeGroupContent`:

```vue
</TreeView.NodeProvider>
      </template>
    </TreeView.BranchContent>
  </TreeView.Branch>
</TreeView.NodeProvider>
```

Prettier cannot parse the file at all:

```
SyntaxError: Unexpected closing tag "TreeView.BranchContent". (145:19)
```

## 🚀 New behavior

Both removed. The option renders its label, and the example parses.

## 🧩 Frameworks

- [ ] React
- [ ] Solid
- [ ] Svelte
- [x] Vue
- [ ] Not framework-specific

## 💣 Is this a breaking change (Yes/No):

No.

## ✅ Checklist

- [x] Added a changeset for user-facing changes
- [ ] Added or updated tests
- [ ] Added an example for any new prop or part
- [ ] Updated the docs

Changeset covers the hidden select. The example fix is not user-facing.

## 📝 Additional information

The unparseable example is worth checking against the red docs build.


<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR corrects two stray Vue template artifacts.
- Removes a literal `>` that appeared in every hidden select option label.
- Removes obsolete, unmatched tree-view closing tags so the table-of-contents example parses correctly.
- Adds a patch changeset for `@ark-ui/vue`.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The deletions restore the intended option label and valid tree-view template structure without introducing a behavioral, build, or release-contract defect.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .changeset/vue-stray-template-tags.md | Adds a correctly formatted patch changeset describing the user-visible hidden-select fix. |
| packages/vue/src/components/select/select-hidden-select.vue | Removes unintended option text and aligns the rendered label with sibling framework implementations. |
| packages/vue/src/components/toc/examples/with-tree-view.vue | Removes obsolete unmatched closing tags while leaving the tree-view template correctly balanced and nested. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: add changeset"](https://github.com/chakra-ui/ark/commit/e90c378b57ecea03a5260669fe211c5a75f97b22) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60798669)</sub>

<!-- /greptile_comment -->