### PR TITLE
chore: move to zag 2.0.0-next.2

### DIFF
--- a/.changeset/zag-next-2-svelte-ids.md
+++ b/.changeset/zag-next-2-svelte-ids.md
@@ -1,0 +1,25 @@
+---
+'@ark-ui/react': patch
+'@ark-ui/solid': patch
+'@ark-ui/svelte': patch
+'@ark-ui/vue': patch
+---
+
+Move to zag `2.0.0-next.2` and drop the shims it makes unnecessary.
+
+`normalizeHotkey` and the `Platform` re-export are back in `@zag-js/hotkeys`, and `@zag-js/presence` now calls
+`onEnterComplete`, so Ark's local stand-ins for all three are gone.
+
+**Svelte:** the `useX` hooks now require an `id`. `useMachine` began taking `InputProps<T>` rather than
+`Partial<T["props"]>`, which surfaced that Svelte never passed one — two hook instances on a page rendered the same
+element ids (`undefined:trigger` for both). Svelte can only mint an id inside a component (`$props.id()` is not
+callable from `.svelte.ts`, and a module counter is not SSR-safe), so the hook has to be given one:
+
+```diff
+- const collapsible = useCollapsible()
++ const id = $props.id()
++ const collapsible = useCollapsible({ id })
+```
+
+Components are unaffected — `<Collapsible.Root>` and friends still generate their own id, and `id` stays optional on
+them. Note that `$props.id()` may only be called once per component; derive from it if you need two.

--- a/packages/react/src/components/presence/use-presence.ts
+++ b/packages/react/src/components/presence/use-presence.ts
@@ -10,11 +10,6 @@ import { useEvent } from '../../utils/use-event.ts'
 
 export interface UsePresenceProps extends Optional<presence.Props, 'present'>, RenderStrategyProps {
   /**
-   * Function called when the animation ends in the open state.
-   */
-  // TODO(zag-bump): drop once @zag-js/presence v2 ports `onEnterComplete` back into its props.
-  onEnterComplete?: VoidFunction | undefined
-  /**
    * Whether to allow the initial presence animation.
    * @default false
    */
@@ -30,7 +25,7 @@ export const usePresence = (props: UsePresenceProps = {}) => {
     present,
     onEnterComplete: useEvent(props.onEnterComplete),
     onExitComplete: useEvent(props.onExitComplete),
-  } as Partial<presence.Props>
+  }
 
   const service = useMachine(presence.machine, machineProps)
   const api = presence.connect(service, normalizeProps)

--- a/packages/react/src/providers/hotkeys/use-hotkeys.ts
+++ b/packages/react/src/providers/hotkeys/use-hotkeys.ts
@@ -1,10 +1,10 @@
 'use client'
 
-import { type CommandDefinition, type HotkeyStore, type ParsedHotkey, parseHotkey } from '@zag-js/hotkeys'
+import { type CommandDefinition, type HotkeyStore, type Platform, normalizeHotkey } from '@zag-js/hotkeys'
 import { isEqual, warn } from '@zag-js/utils'
 import { useEffect, useId, useRef } from 'react'
 import { type UseHotkeyStoreProps, useHotkeyStore } from './use-hotkey-store.ts'
-import { type Platform, usePlatform } from './use-platform.ts'
+import { usePlatform } from './use-platform.ts'
 
 export interface UseHotkeysCommand extends Omit<CommandDefinition, 'id'> {
   /**
@@ -27,7 +27,7 @@ export interface UseHotkeysProps extends UseHotkeyStoreProps {
 }
 
 interface Registration {
-  hotkey: ParsedHotkey
+  hotkey: string
   scopes: CommandDefinition['scopes']
   label: string | undefined
   description: string | undefined
@@ -46,7 +46,7 @@ const warnOnForeignId = (store: HotkeyStore, id: string) => {
 }
 
 const toRegistration = (command: UseHotkeysCommand, platform: Platform): Registration => ({
-  hotkey: parseHotkey(command.hotkey, platform),
+  hotkey: normalizeHotkey(command.hotkey, platform),
   scopes: command.scopes,
   label: command.label,
   description: command.description,

--- a/packages/react/src/providers/hotkeys/use-platform.ts
+++ b/packages/react/src/providers/hotkeys/use-platform.ts
@@ -1,13 +1,11 @@
 'use client'
 
-import { getPlatform, isAndroid, isApple } from '@zag-js/dom-query'
+import { isApple, isLinux } from '@zag-js/dom-query'
 import { useCallback, useSyncExternalStore } from 'react'
 
-// TODO(zag-bump): once @zag-js/hotkeys > 1.43.1 is released, import `Platform` from it and
-// replace the inline linux check with `isLinux` from @zag-js/dom-query.
-export type Platform = 'mac' | 'windows' | 'linux'
+import type { Platform } from '@zag-js/hotkeys'
 
-const isLinux = () => /^Linux|^CrOS/i.test(getPlatform()) && !isAndroid()
+export type { Platform }
 
 const subscribe = () => () => {}
 

--- a/packages/solid/src/components/presence/use-presence.ts
+++ b/packages/solid/src/components/presence/use-presence.ts
@@ -7,11 +7,6 @@ import { runIfFn } from '../../utils/run-if-fn.ts'
 
 export interface UsePresenceProps extends Optional<presence.Props, 'present'>, RenderStrategyProps {
   /**
-   * Function called when the animation ends in the open state.
-   */
-  // TODO(zag-bump): drop once @zag-js/presence v2 ports `onEnterComplete` back into its props.
-  onEnterComplete?: VoidFunction | undefined
-  /**
    * Whether to allow the initial presence animation.
    * @default false
    */

--- a/packages/solid/src/providers/hotkeys/use-hotkeys.ts
+++ b/packages/solid/src/providers/hotkeys/use-hotkeys.ts
@@ -1,10 +1,10 @@
-import { type CommandDefinition, type HotkeyStore, type ParsedHotkey, parseHotkey } from '@zag-js/hotkeys'
+import { type CommandDefinition, type HotkeyStore, type Platform, normalizeHotkey } from '@zag-js/hotkeys'
 import { isEqual, warn } from '@zag-js/utils'
 import { createEffect, createMemo, createUniqueId, onCleanup, untrack } from 'solid-js'
 import type { MaybeAccessor } from '../../types.ts'
 import { runIfFn } from '../../utils/run-if-fn.ts'
 import { type UseHotkeyStoreProps, useHotkeyStore } from './use-hotkey-store.ts'
-import { type Platform, usePlatform } from './use-platform.ts'
+import { usePlatform } from './use-platform.ts'
 
 export interface UseHotkeysCommand extends Omit<CommandDefinition, 'id'> {
   /**
@@ -27,7 +27,7 @@ export interface UseHotkeysProps extends UseHotkeyStoreProps {
 }
 
 interface Registration {
-  hotkey: ParsedHotkey
+  hotkey: string
   scopes: CommandDefinition['scopes']
   label: string | undefined
   description: string | undefined
@@ -46,7 +46,7 @@ const warnOnForeignId = (store: HotkeyStore, id: string) => {
 }
 
 const toRegistration = (command: UseHotkeysCommand, platform: Platform): Registration => ({
-  hotkey: parseHotkey(command.hotkey, platform),
+  hotkey: normalizeHotkey(command.hotkey, platform),
   scopes: command.scopes,
   label: command.label,
   description: command.description,

--- a/packages/solid/src/providers/hotkeys/use-platform.ts
+++ b/packages/solid/src/providers/hotkeys/use-platform.ts
@@ -1,11 +1,9 @@
-import { getPlatform, isAndroid, isApple } from '@zag-js/dom-query'
+import { isApple, isLinux } from '@zag-js/dom-query'
 import { type Accessor, createSignal, onMount } from 'solid-js'
 
-// TODO(zag-bump): once @zag-js/hotkeys > 1.43.1 is released, import `Platform` from it and
-// replace the inline linux check with `isLinux` from @zag-js/dom-query.
-export type Platform = 'mac' | 'windows' | 'linux'
+import type { Platform } from '@zag-js/hotkeys'
 
-const isLinux = () => /^Linux|^CrOS/i.test(getPlatform()) && !isAndroid()
+export type { Platform }
 
 const detect = (): Platform => {
   if (isApple()) return 'mac'

--- a/packages/svelte/src/lib/components/accordion/accordion-root.svelte
+++ b/packages/svelte/src/lib/components/accordion/accordion-root.svelte
@@ -1,9 +1,9 @@
 <script module lang="ts">
-  import type { Assign, HTMLProps, PolymorphicProps, RefAttribute } from '$lib/types'
+  import type { Assign, HTMLProps, Optional, PolymorphicProps, RefAttribute } from '$lib/types'
   import type { UseAccordionProps } from './use-accordion.svelte.ts'
 
   export interface AccordionRootBaseProps
-    extends UseAccordionProps, RenderStrategyProps, PolymorphicProps<'div'>, RefAttribute {}
+    extends Optional<UseAccordionProps, 'id'>, RenderStrategyProps, PolymorphicProps<'div'>, RefAttribute {}
   export interface AccordionRootProps extends Assign<HTMLProps<'div'>, AccordionRootBaseProps> {}
 </script>
 
@@ -24,7 +24,7 @@
 
   const [renderStrategyProps, accordionProps] = $derived(splitRenderStrategyProps(props))
   const [useAccordionProps, localProps] = $derived(
-    createSplitProps<UseAccordionProps>()(accordionProps, [
+    createSplitProps<Optional<UseAccordionProps, 'id'>>()(accordionProps, [
       'collapsible',
       'defaultValue',
       'disabled',

--- a/packages/svelte/src/lib/components/accordion/use-accordion.svelte.ts
+++ b/packages/svelte/src/lib/components/accordion/use-accordion.svelte.ts
@@ -1,14 +1,14 @@
 import { useEnvironmentContext } from '$lib/providers/environment'
 import { useLocaleContext } from '$lib/providers/locale'
-import type { Accessor, Optional } from '$lib/types'
+import type { Accessor } from '$lib/types'
 import * as accordion from '@zag-js/accordion'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/svelte'
 import { type MaybeFunction, runIfFn } from '@zag-js/utils'
 
-export interface UseAccordionProps extends Optional<Omit<accordion.Props, 'dir' | 'getRootNode'>, 'id'> {}
+export interface UseAccordionProps extends Omit<accordion.Props, 'dir' | 'getRootNode'> {}
 export interface UseAccordionReturn extends Accessor<accordion.Api<PropTypes>> {}
 
-export const useAccordion = (props?: MaybeFunction<UseAccordionProps>): UseAccordionReturn => {
+export const useAccordion = (props: MaybeFunction<UseAccordionProps>): UseAccordionReturn => {
   const env = useEnvironmentContext()
   const locale = useLocaleContext()
 

--- a/packages/svelte/src/lib/components/carousel/carousel-root.svelte
+++ b/packages/svelte/src/lib/components/carousel/carousel-root.svelte
@@ -1,8 +1,9 @@
 <script module lang="ts">
-  import type { Assign, HTMLProps, PolymorphicProps, RefAttribute } from '$lib/types'
+  import type { Assign, HTMLProps, Optional, PolymorphicProps, RefAttribute } from '$lib/types'
   import type { UseCarouselProps } from './use-carousel.svelte.ts'
 
-  export interface CarouselRootBaseProps extends UseCarouselProps, PolymorphicProps<'div'>, RefAttribute {}
+  export interface CarouselRootBaseProps
+    extends Optional<UseCarouselProps, 'id'>, PolymorphicProps<'div'>, RefAttribute {}
   export interface CarouselRootProps extends Assign<HTMLProps<'div'>, CarouselRootBaseProps> {}
 </script>
 
@@ -17,7 +18,7 @@
   const providedId = $props.id()
 
   const [useCarouselProps, localProps] = $derived(
-    createSplitProps<UseCarouselProps>()(props, [
+    createSplitProps<Optional<UseCarouselProps, 'id'>>()(props, [
       'allowMouseDrag',
       'autoPlay',
       'autoSize',

--- a/packages/svelte/src/lib/components/carousel/use-carousel.svelte.ts
+++ b/packages/svelte/src/lib/components/carousel/use-carousel.svelte.ts
@@ -1,14 +1,14 @@
 import { useEnvironmentContext } from '$lib/providers/environment'
 import { useLocaleContext } from '$lib/providers/locale'
-import type { Accessor, Optional } from '$lib/types'
+import type { Accessor } from '$lib/types'
 import * as carousel from '@zag-js/carousel'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/svelte'
 import { type MaybeFunction, runIfFn } from '@zag-js/utils'
 
-export interface UseCarouselProps extends Optional<Omit<carousel.Props, 'dir' | 'getRootNode'>, 'id'> {}
+export interface UseCarouselProps extends Omit<carousel.Props, 'dir' | 'getRootNode'> {}
 export interface UseCarouselReturn extends Accessor<carousel.Api<PropTypes>> {}
 
-export const useCarousel = (props?: MaybeFunction<UseCarouselProps>) => {
+export const useCarousel = (props: MaybeFunction<UseCarouselProps>) => {
   const env = useEnvironmentContext()
   const locale = useLocaleContext()
 

--- a/packages/svelte/src/lib/components/checkbox/checkbox-root.svelte
+++ b/packages/svelte/src/lib/components/checkbox/checkbox-root.svelte
@@ -1,8 +1,9 @@
 <script module lang="ts">
-  import type { Assign, HTMLProps, PolymorphicProps, RefAttribute } from '$lib/types'
+  import type { Assign, HTMLProps, Optional, PolymorphicProps, RefAttribute } from '$lib/types'
   import type { UseCheckboxProps } from './use-checkbox.svelte.ts'
 
-  export interface CheckboxRootBaseProps extends UseCheckboxProps, PolymorphicProps<'label'>, RefAttribute {}
+  export interface CheckboxRootBaseProps
+    extends Optional<UseCheckboxProps, 'id'>, PolymorphicProps<'label'>, RefAttribute {}
   export interface CheckboxRootProps extends Assign<HTMLProps<'label'>, CheckboxRootBaseProps> {}
 </script>
 

--- a/packages/svelte/src/lib/components/checkbox/examples/root-provider.svelte
+++ b/packages/svelte/src/lib/components/checkbox/examples/root-provider.svelte
@@ -4,7 +4,8 @@
   import styles from 'styles/checkbox.module.css'
   import button from 'styles/button.module.css'
 
-  const checkbox = useCheckbox()
+  const id = $props.id()
+  const checkbox = useCheckbox({ id })
 </script>
 
 <div class="vstack">

--- a/packages/svelte/src/lib/components/checkbox/split-checkbox-props.svelte.ts
+++ b/packages/svelte/src/lib/components/checkbox/split-checkbox-props.svelte.ts
@@ -1,9 +1,10 @@
+import type { Optional } from '$lib/types'
 import { createSplitProps } from '$lib/utils/create-split-props'
 import type { UseCheckboxProps } from './use-checkbox.svelte.ts'
 
-const splitFn = createSplitProps<UseCheckboxProps>()
+const splitFn = createSplitProps<Optional<UseCheckboxProps, 'id'>>()
 
-export const splitCheckboxProps = <T extends UseCheckboxProps>(props: T) =>
+export const splitCheckboxProps = <T extends Optional<UseCheckboxProps, 'id'>>(props: T) =>
   splitFn(props, [
     'checked',
     'defaultChecked',

--- a/packages/svelte/src/lib/components/checkbox/use-checkbox.svelte.ts
+++ b/packages/svelte/src/lib/components/checkbox/use-checkbox.svelte.ts
@@ -1,17 +1,17 @@
 import { useEnvironmentContext } from '$lib/providers/environment'
 import { useLocaleContext } from '$lib/providers/locale'
-import type { Accessor, Optional } from '$lib/types'
+import type { Accessor } from '$lib/types'
 import * as checkbox from '@zag-js/checkbox'
 import { type PropTypes, mergeProps, normalizeProps, useMachine } from '@zag-js/svelte'
 import { type MaybeFunction, runIfFn } from '@zag-js/utils'
 import { useFieldContext } from '../field/index.ts'
 import { useCheckboxGroupContext } from './use-checkbox-group-context.ts'
 
-export interface UseCheckboxProps extends Optional<Omit<checkbox.Props, 'dir' | 'getRootNode'>, 'id'> {}
+export interface UseCheckboxProps extends Omit<checkbox.Props, 'dir' | 'getRootNode'> {}
 
 export interface UseCheckboxReturn extends Accessor<checkbox.Api<PropTypes>> {}
 
-export const useCheckbox = (props: MaybeFunction<UseCheckboxProps> = {}): UseCheckboxReturn => {
+export const useCheckbox = (props: MaybeFunction<UseCheckboxProps>): UseCheckboxReturn => {
   const env = useEnvironmentContext()
   const locale = useLocaleContext()
   const checkboxGroup = useCheckboxGroupContext()
@@ -32,6 +32,7 @@ export const useCheckbox = (props: MaybeFunction<UseCheckboxProps> = {}): UseChe
       required: field?.()?.required,
       getRootNode: env().getRootNode,
       ...localProps,
+      id: resolvedProps.id,
     }
   })
 

--- a/packages/svelte/src/lib/components/clipboard/clipboard-root.svelte
+++ b/packages/svelte/src/lib/components/clipboard/clipboard-root.svelte
@@ -1,8 +1,9 @@
 <script module lang="ts">
-  import type { Assign, HTMLProps, PolymorphicProps, RefAttribute } from '$lib/types'
+  import type { Assign, HTMLProps, Optional, PolymorphicProps, RefAttribute } from '$lib/types'
   import type { UseClipboardProps } from './use-clipboard.svelte.ts'
 
-  export interface ClipboardRootBaseProps extends UseClipboardProps, PolymorphicProps<'div'>, RefAttribute {}
+  export interface ClipboardRootBaseProps
+    extends Optional<UseClipboardProps, 'id'>, PolymorphicProps<'div'>, RefAttribute {}
   export interface ClipboardRootProps extends Assign<HTMLProps<'div'>, ClipboardRootBaseProps> {}
 </script>
 

--- a/packages/svelte/src/lib/components/clipboard/clipboard-split-props.svelte.ts
+++ b/packages/svelte/src/lib/components/clipboard/clipboard-split-props.svelte.ts
@@ -1,7 +1,8 @@
+import type { Optional } from '$lib/types'
 import { createSplitProps } from '$lib/utils/create-split-props'
 import type { UseClipboardProps } from './use-clipboard.svelte.ts'
 
-const splitFn = createSplitProps<UseClipboardProps>()
+const splitFn = createSplitProps<Optional<UseClipboardProps, 'id'>>()
 
-export const splitClipboardProps = <T extends UseClipboardProps>(props: T) =>
+export const splitClipboardProps = <T extends Optional<UseClipboardProps, 'id'>>(props: T) =>
   splitFn(props, ['defaultValue', 'id', 'ids', 'onStatusChange', 'onValueChange', 'timeout', 'translations', 'value'])

--- a/packages/svelte/src/lib/components/clipboard/examples/root-provider.svelte
+++ b/packages/svelte/src/lib/components/clipboard/examples/root-provider.svelte
@@ -3,7 +3,8 @@
   import { CheckIcon, ClipboardCopyIcon } from 'lucide-svelte'
   import styles from 'styles/clipboard.module.css'
 
-  const clipboard = useClipboard(() => ({ value: 'https://ark-ui.com' }))
+  const id = $props.id()
+  const clipboard = useClipboard(() => ({ id, value: 'https://ark-ui.com' }))
 </script>
 
 <div class="stack">

--- a/packages/svelte/src/lib/components/clipboard/use-clipboard.svelte.ts
+++ b/packages/svelte/src/lib/components/clipboard/use-clipboard.svelte.ts
@@ -1,14 +1,14 @@
 import { useEnvironmentContext } from '$lib/providers/environment'
-import type { Accessor, Optional } from '$lib/types'
+import type { Accessor } from '$lib/types'
 import * as clipboard from '@zag-js/clipboard'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/svelte'
 import { type MaybeFunction, runIfFn } from '@zag-js/utils'
 
-export interface UseClipboardProps extends Optional<Omit<clipboard.Props, 'getRootNode'>, 'id'> {}
+export interface UseClipboardProps extends Omit<clipboard.Props, 'getRootNode'> {}
 
 export interface UseClipboardReturn extends Accessor<clipboard.Api<PropTypes>> {}
 
-export const useClipboard = (props?: MaybeFunction<UseClipboardProps>): UseClipboardReturn => {
+export const useClipboard = (props: MaybeFunction<UseClipboardProps>): UseClipboardReturn => {
   const env = useEnvironmentContext()
 
   const machineProps = $derived.by(() => {

--- a/packages/svelte/src/lib/components/collapsible/collapsible-root.svelte
+++ b/packages/svelte/src/lib/components/collapsible/collapsible-root.svelte
@@ -1,8 +1,9 @@
 <script module lang="ts">
-  import type { Assign, HTMLProps, PolymorphicProps, RefAttribute } from '$lib/types'
+  import type { Assign, HTMLProps, Optional, PolymorphicProps, RefAttribute } from '$lib/types'
   import type { UseCollapsibleProps } from './use-collapsible.svelte.ts'
 
-  export interface CollapsibleRootBaseProps extends UseCollapsibleProps, PolymorphicProps<'div'>, RefAttribute {}
+  export interface CollapsibleRootBaseProps
+    extends Optional<UseCollapsibleProps, 'id'>, PolymorphicProps<'div'>, RefAttribute {}
   export interface CollapsibleRootProps extends Assign<HTMLProps<'div'>, CollapsibleRootBaseProps> {}
 </script>
 

--- a/packages/svelte/src/lib/components/collapsible/examples/root-provider.svelte
+++ b/packages/svelte/src/lib/components/collapsible/examples/root-provider.svelte
@@ -3,7 +3,8 @@
   import { ChevronRightIcon } from 'lucide-svelte'
   import styles from 'styles/collapsible.module.css'
 
-  const collapsible = useCollapsible()
+  const id = $props.id()
+  const collapsible = useCollapsible({ id })
 </script>
 
 <div class="stack">

--- a/packages/svelte/src/lib/components/collapsible/split-collapsible-props.svelte.ts
+++ b/packages/svelte/src/lib/components/collapsible/split-collapsible-props.svelte.ts
@@ -1,9 +1,10 @@
+import type { Optional } from '$lib/types'
 import { createSplitProps } from '$lib/utils/create-split-props'
 import type { UseCollapsibleProps } from './use-collapsible.svelte.ts'
 
-const splitFn = createSplitProps<UseCollapsibleProps>()
+const splitFn = createSplitProps<Optional<UseCollapsibleProps, 'id'>>()
 
-export const splitCollapsibleProps = <T extends UseCollapsibleProps>(props: T) =>
+export const splitCollapsibleProps = <T extends Optional<UseCollapsibleProps, 'id'>>(props: T) =>
   splitFn(props, [
     'collapsedHeight',
     'collapsedWidth',

--- a/packages/svelte/src/lib/components/collapsible/use-collapsible.svelte.ts
+++ b/packages/svelte/src/lib/components/collapsible/use-collapsible.svelte.ts
@@ -1,11 +1,11 @@
 import { useEnvironmentContext } from '$lib/providers/environment'
 import { useLocaleContext } from '$lib/providers/locale'
-import type { Accessor, Optional } from '$lib/types'
+import type { Accessor } from '$lib/types'
 import * as collapsible from '@zag-js/collapsible'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/svelte'
 import { type MaybeFunction, runIfFn } from '@zag-js/utils'
 
-export interface UseCollapsibleProps extends Optional<Omit<collapsible.Props, 'dir' | 'getRootNode'>, 'id'> {
+export interface UseCollapsibleProps extends Omit<collapsible.Props, 'dir' | 'getRootNode'> {
   /**
    * Whether the content should be lazy mounted
    */
@@ -22,7 +22,7 @@ export interface UseCollapsibleProps extends Optional<Omit<collapsible.Props, 'd
 
 export interface UseCollapsibleReturn extends Accessor<collapsible.Api<PropTypes> & { isUnmounted: boolean }> {}
 
-export const useCollapsible = (props?: MaybeFunction<UseCollapsibleProps>): UseCollapsibleReturn => {
+export const useCollapsible = (props: MaybeFunction<UseCollapsibleProps>): UseCollapsibleReturn => {
   const env = useEnvironmentContext()
   const locale = useLocaleContext()
 

--- a/packages/svelte/src/lib/components/color-picker/color-picker-root.svelte
+++ b/packages/svelte/src/lib/components/color-picker/color-picker-root.svelte
@@ -1,10 +1,10 @@
 <script module lang="ts">
-  import type { Assign, HTMLProps, PolymorphicProps, RefAttribute } from '$lib/types'
+  import type { Assign, HTMLProps, Optional, PolymorphicProps, RefAttribute } from '$lib/types'
   import type { UsePresenceProps } from '../presence/index.ts'
   import type { UseColorPickerProps } from './use-color-picker.svelte.ts'
 
   export interface ColorPickerRootBaseProps
-    extends UseColorPickerProps, UsePresenceProps, PolymorphicProps<'div'>, RefAttribute {}
+    extends Optional<UseColorPickerProps, 'id'>, UsePresenceProps, PolymorphicProps<'div'>, RefAttribute {}
   export interface ColorPickerRootProps extends Assign<HTMLProps<'div'>, ColorPickerRootBaseProps> {}
 </script>
 

--- a/packages/svelte/src/lib/components/color-picker/split-color-picker-props.svelte.ts
+++ b/packages/svelte/src/lib/components/color-picker/split-color-picker-props.svelte.ts
@@ -1,9 +1,10 @@
+import type { Optional } from '$lib/types'
 import { createSplitProps } from '$lib/utils/create-split-props'
 import type { UseColorPickerProps } from './use-color-picker.svelte.ts'
 
-const splitFn = createSplitProps<UseColorPickerProps>()
+const splitFn = createSplitProps<Optional<UseColorPickerProps, 'id'>>()
 
-export const splitColorPickerProps = <T extends UseColorPickerProps>(props: T) =>
+export const splitColorPickerProps = <T extends Optional<UseColorPickerProps, 'id'>>(props: T) =>
   splitFn(props, [
     'closeOnSelect',
     'defaultOpen',

--- a/packages/svelte/src/lib/components/color-picker/use-color-picker.svelte.ts
+++ b/packages/svelte/src/lib/components/color-picker/use-color-picker.svelte.ts
@@ -1,16 +1,16 @@
 import { useEnvironmentContext } from '$lib/providers/environment'
 import { useLocaleContext } from '$lib/providers/locale'
-import type { Accessor, Optional } from '$lib/types'
+import type { Accessor } from '$lib/types'
 import * as colorPicker from '@zag-js/color-picker'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/svelte'
 import { type MaybeFunction, runIfFn } from '@zag-js/utils'
 import { useFieldContext } from '../field/index.ts'
 
-export interface UseColorPickerProps extends Optional<Omit<colorPicker.Props, 'dir' | 'getRootNode'>, 'id'> {}
+export interface UseColorPickerProps extends Omit<colorPicker.Props, 'dir' | 'getRootNode'> {}
 
 export interface UseColorPickerReturn extends Accessor<colorPicker.Api<PropTypes>> {}
 
-export const useColorPicker = (props: MaybeFunction<UseColorPickerProps> = {}): UseColorPickerReturn => {
+export const useColorPicker = (props: MaybeFunction<UseColorPickerProps>): UseColorPickerReturn => {
   const env = useEnvironmentContext()
   const locale = useLocaleContext()
   const field = useFieldContext()

--- a/packages/svelte/src/lib/components/combobox/combobox-root.svelte
+++ b/packages/svelte/src/lib/components/combobox/combobox-root.svelte
@@ -1,12 +1,12 @@
 <script module lang="ts">
-  import type { Assign, HTMLProps, PolymorphicProps, RefAttribute } from '$lib/types'
+  import type { Assign, HTMLProps, Optional, PolymorphicProps, RefAttribute } from '$lib/types'
   import type { Snippet } from 'svelte'
   import type { CollectionItem } from '../collection/index.ts'
   import type { UsePresenceProps } from '../presence/index.ts'
   import type { UseComboboxProps } from './use-combobox.svelte.ts'
 
   export interface ComboboxRootBaseProps<T extends CollectionItem>
-    extends UseComboboxProps<T>, UsePresenceProps, PolymorphicProps<'div'>, RefAttribute {}
+    extends Optional<UseComboboxProps<T>, 'id'>, UsePresenceProps, PolymorphicProps<'div'>, RefAttribute {}
 
   export interface ComboboxRootProps<T extends CollectionItem> extends Assign<
     HTMLProps<'div'>,
@@ -41,7 +41,7 @@
 
   const [presenceProps, comboboxProps] = $derived(splitPresenceProps(props))
   const [useComboboxProps, localProps] = $derived(
-    createSplitProps<UseComboboxProps<T>>()(comboboxProps, [
+    createSplitProps<Optional<UseComboboxProps<T>, 'id'>>()(comboboxProps, [
       'allowCustomValue',
       'alwaysSubmitOnEnter',
       'autoFocus',

--- a/packages/svelte/src/lib/components/combobox/examples/rehydrate-value.svelte
+++ b/packages/svelte/src/lib/components/combobox/examples/rehydrate-value.svelte
@@ -21,7 +21,9 @@
 
   let inputValue = $state('')
 
+  const id = $props.id()
   const combobox = useCombobox(() => ({
+    id,
     collection: collection(),
     defaultValue: ['C-3PO'],
     placeholder: 'Example: Dexter',

--- a/packages/svelte/src/lib/components/combobox/use-combobox.svelte.ts
+++ b/packages/svelte/src/lib/components/combobox/use-combobox.svelte.ts
@@ -1,15 +1,15 @@
 import { useEnvironmentContext } from '$lib/providers/environment'
 import { useLocaleContext } from '$lib/providers/locale'
-import type { Accessor, Optional } from '$lib/types'
+import type { Accessor } from '$lib/types'
 import * as combobox from '@zag-js/combobox'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/svelte'
 import { type MaybeFunction, runIfFn } from '@zag-js/utils'
 import type { CollectionItem, ListCollection } from '../collection/index.ts'
 import { useFieldContext } from '../field/index.ts'
 
-export interface UseComboboxProps<T extends CollectionItem> extends Optional<
-  Omit<combobox.Props<T>, 'dir' | 'getRootNode' | 'collection'>,
-  'id'
+export interface UseComboboxProps<T extends CollectionItem> extends Omit<
+  combobox.Props<T>,
+  'dir' | 'getRootNode' | 'collection'
 > {
   /**
    * The collection of items

--- a/packages/svelte/src/lib/components/date-input/date-input-root.svelte
+++ b/packages/svelte/src/lib/components/date-input/date-input-root.svelte
@@ -1,8 +1,10 @@
 <script module lang="ts">
+  import type { Optional } from '$lib/types'
   import type { Assign, HTMLProps, PolymorphicProps, RefAttribute } from '$lib/types.js'
   import type { UseDateInputProps } from './use-date-input.svelte.js'
 
-  export interface DateInputRootBaseProps extends UseDateInputProps, PolymorphicProps<'div'>, RefAttribute {}
+  export interface DateInputRootBaseProps
+    extends Optional<UseDateInputProps, 'id'>, PolymorphicProps<'div'>, RefAttribute {}
   export interface DateInputRootProps extends Assign<HTMLProps<'div'>, DateInputRootBaseProps> {}
 </script>
 
@@ -17,7 +19,7 @@
   const providedId = $props.id()
 
   const [useDateInputProps, localProps] = $derived(
-    createSplitProps<UseDateInputProps>()(props, [
+    createSplitProps<Optional<UseDateInputProps, 'id'>>()(props, [
       'disabled',
       'id',
       'ids',

--- a/packages/svelte/src/lib/components/date-input/use-date-input.svelte.ts
+++ b/packages/svelte/src/lib/components/date-input/use-date-input.svelte.ts
@@ -4,11 +4,11 @@ import { type PropTypes, normalizeProps, useMachine } from '@zag-js/svelte'
 import { type MaybeFunction, runIfFn } from '@zag-js/utils'
 import { useEnvironmentContext, useLocaleContext } from '../../providers/index.js'
 
-export interface UseDateInputProps extends Optional<Omit<dateInput.Props, 'dir' | 'getRootNode'>, 'id'> {}
+export interface UseDateInputProps extends Omit<dateInput.Props, 'dir' | 'getRootNode'> {}
 
 export interface UseDateInputReturn extends Accessor<dateInput.Api<PropTypes>> {}
 
-export const useDateInput = (props?: MaybeFunction<UseDateInputProps>): UseDateInputReturn => {
+export const useDateInput = (props: MaybeFunction<UseDateInputProps>): UseDateInputReturn => {
   const env = useEnvironmentContext()
   const locale = useLocaleContext()
 

--- a/packages/svelte/src/lib/components/date-picker/date-picker-root.svelte
+++ b/packages/svelte/src/lib/components/date-picker/date-picker-root.svelte
@@ -1,10 +1,11 @@
 <script module lang="ts">
+  import type { Optional } from '$lib/types'
   import type { Assign, HTMLProps, PolymorphicProps, RefAttribute } from '$lib/types.js'
   import type { UseDatePickerProps } from './use-date-picker.svelte.js'
   import type { UsePresenceProps } from '../presence/index.js'
 
   export interface DatePickerRootBaseProps
-    extends UseDatePickerProps, UsePresenceProps, PolymorphicProps<'div'>, RefAttribute {}
+    extends Optional<UseDatePickerProps, 'id'>, UsePresenceProps, PolymorphicProps<'div'>, RefAttribute {}
   export interface DatePickerRootProps extends Assign<HTMLProps<'div'>, DatePickerRootBaseProps> {}
 </script>
 
@@ -28,7 +29,7 @@
 
   const [presenceProps, datePickerProps] = $derived(splitPresenceProps(props))
   const [useDatePickerProps, localProps] = $derived(
-    createSplitProps<UseDatePickerProps>()(datePickerProps, [
+    createSplitProps<Optional<UseDatePickerProps, 'id'>>()(datePickerProps, [
       'closeOnSelect',
       'createCalendar',
       'defaultFocusedValue',

--- a/packages/svelte/src/lib/components/date-picker/use-date-picker.svelte.ts
+++ b/packages/svelte/src/lib/components/date-picker/use-date-picker.svelte.ts
@@ -4,11 +4,11 @@ import { type PropTypes, normalizeProps, useMachine } from '@zag-js/svelte'
 import { type MaybeFunction, runIfFn } from '@zag-js/utils'
 import { useEnvironmentContext, useLocaleContext } from '../../providers/index.js'
 
-export interface UseDatePickerProps extends Optional<Omit<datePicker.Props, 'dir' | 'getRootNode'>, 'id'> {}
+export interface UseDatePickerProps extends Omit<datePicker.Props, 'dir' | 'getRootNode'> {}
 
 export interface UseDatePickerReturn extends Accessor<datePicker.Api<PropTypes>> {}
 
-export const useDatePicker = (props?: MaybeFunction<UseDatePickerProps>): UseDatePickerReturn => {
+export const useDatePicker = (props: MaybeFunction<UseDatePickerProps>): UseDatePickerReturn => {
   const env = useEnvironmentContext()
   const locale = useLocaleContext()
 

--- a/packages/svelte/src/lib/components/dialog/dialog-root.svelte
+++ b/packages/svelte/src/lib/components/dialog/dialog-root.svelte
@@ -1,9 +1,10 @@
 <script module lang="ts">
+  import type { Optional } from '$lib/types'
   import type { Snippet } from 'svelte'
   import type { UsePresenceProps } from '../presence/index.ts'
   import type { UseDialogProps } from './use-dialog.svelte.ts'
 
-  export interface DialogRootBaseProps extends UseDialogProps, UsePresenceProps {}
+  export interface DialogRootBaseProps extends Optional<UseDialogProps, 'id'>, UsePresenceProps {}
   export interface DialogRootProps extends DialogRootBaseProps {
     children?: Snippet
   }

--- a/packages/svelte/src/lib/components/dialog/use-dialog.svelte.ts
+++ b/packages/svelte/src/lib/components/dialog/use-dialog.svelte.ts
@@ -1,15 +1,15 @@
 import { useEnvironmentContext } from '$lib/providers/environment'
 import { useLocaleContext } from '$lib/providers/locale'
-import type { Accessor, Optional } from '$lib/types'
+import type { Accessor } from '$lib/types'
 import * as dialog from '@zag-js/dialog'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/svelte'
 import { type MaybeFunction, runIfFn } from '@zag-js/utils'
 
-export interface UseDialogProps extends Optional<Omit<dialog.Props, 'getRootNode' | 'dir'>, 'id'> {}
+export interface UseDialogProps extends Omit<dialog.Props, 'getRootNode' | 'dir'> {}
 
 export interface UseDialogReturn extends Accessor<dialog.Api<PropTypes>> {}
 
-export const useDialog = (props?: MaybeFunction<UseDialogProps>): UseDialogReturn => {
+export const useDialog = (props: MaybeFunction<UseDialogProps>): UseDialogReturn => {
   const env = useEnvironmentContext()
   const locale = useLocaleContext()
 

--- a/packages/svelte/src/lib/components/drawer/drawer-root.svelte
+++ b/packages/svelte/src/lib/components/drawer/drawer-root.svelte
@@ -1,9 +1,10 @@
 <script module lang="ts">
+  import type { Optional } from '$lib/types'
   import type { Snippet } from 'svelte'
   import type { UsePresenceProps } from '../presence/index.ts'
   import type { UseDrawerProps } from './use-drawer.svelte.ts'
 
-  export interface DrawerRootBaseProps extends UseDrawerProps, UsePresenceProps {}
+  export interface DrawerRootBaseProps extends Optional<UseDrawerProps, 'id'>, UsePresenceProps {}
   export interface DrawerRootProps extends DrawerRootBaseProps {
     children?: Snippet
   }

--- a/packages/svelte/src/lib/components/drawer/examples/root-provider.svelte
+++ b/packages/svelte/src/lib/components/drawer/examples/root-provider.svelte
@@ -4,10 +4,8 @@
   import button from 'styles/button.module.css'
   import styles from 'styles/drawer.module.css'
 
-  const drawer = useDrawer({
-    defaultSnapPoint: 0.5,
-    snapPoints: [0.25, 0.5, 1],
-  })
+  const id = $props.id()
+  const drawer = useDrawer({ id, defaultSnapPoint: 0.5, snapPoints: [0.25, 0.5, 1] })
 </script>
 
 <div class="stack">

--- a/packages/svelte/src/lib/components/drawer/use-drawer.svelte.ts
+++ b/packages/svelte/src/lib/components/drawer/use-drawer.svelte.ts
@@ -1,12 +1,12 @@
 import { useEnvironmentContext } from '$lib/providers/environment'
 import { useLocaleContext } from '$lib/providers/locale'
-import type { Accessor, Optional } from '$lib/types'
+import type { Accessor } from '$lib/types'
 import * as drawer from '@zag-js/drawer'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/svelte'
 import { type MaybeFunction, runIfFn } from '@zag-js/utils'
 import { useDrawerStackStore } from './use-drawer-stack-store.ts'
 
-export interface UseDrawerProps extends Optional<Omit<drawer.Props, 'dir' | 'getRootNode' | 'defaultSnapPoint'>, 'id'> {
+export interface UseDrawerProps extends Omit<drawer.Props, 'dir' | 'getRootNode' | 'defaultSnapPoint'> {
   defaultSnapPoint?: drawer.SnapPoint | undefined
 }
 export interface UseDrawerReturn extends Accessor<drawer.Api<PropTypes>> {}

--- a/packages/svelte/src/lib/components/editable/editable-root.svelte
+++ b/packages/svelte/src/lib/components/editable/editable-root.svelte
@@ -1,8 +1,8 @@
 <script module lang="ts">
-  import type { Assign, HTMLProps, RefAttribute } from '$lib/types'
+  import type { Assign, HTMLProps, Optional, RefAttribute } from '$lib/types'
   import type { UseEditableProps } from './use-editable.svelte.ts'
 
-  export interface EditableRootBaseProps extends UseEditableProps, RefAttribute {}
+  export interface EditableRootBaseProps extends Optional<UseEditableProps, 'id'>, RefAttribute {}
   export interface EditableRootProps extends Assign<HTMLProps<'div'>, EditableRootBaseProps> {}
 </script>
 

--- a/packages/svelte/src/lib/components/editable/editable-split-props.ts
+++ b/packages/svelte/src/lib/components/editable/editable-split-props.ts
@@ -1,8 +1,9 @@
+import type { Optional } from '$lib/types'
 import { createSplitProps } from '$lib/utils/create-split-props'
 import type { UseEditableProps } from './use-editable.svelte.ts'
 
-const splitFn = createSplitProps<UseEditableProps>()
-export function splitEditableProps<T extends UseEditableProps>(props: T) {
+const splitFn = createSplitProps<Optional<UseEditableProps, 'id'>>()
+export function splitEditableProps<T extends Optional<UseEditableProps, 'id'>>(props: T) {
   return splitFn(props, [
     'activationMode',
     'autoResize',

--- a/packages/svelte/src/lib/components/editable/examples/root-provider.svelte
+++ b/packages/svelte/src/lib/components/editable/examples/root-provider.svelte
@@ -3,7 +3,8 @@
   import PencilIcon from 'lucide-svelte/icons/pencil'
   import styles from 'styles/editable.module.css'
 
-  const editable = useEditable({ defaultValue: 'Hello World' })
+  const id = $props.id()
+  const editable = useEditable({ id, defaultValue: 'Hello World' })
 </script>
 
 <Editable.RootProvider class={styles.Root} value={editable}>

--- a/packages/svelte/src/lib/components/editable/use-editable.svelte.ts
+++ b/packages/svelte/src/lib/components/editable/use-editable.svelte.ts
@@ -1,15 +1,15 @@
 import { useEnvironmentContext } from '$lib/providers/environment'
 import { useLocaleContext } from '$lib/providers/locale'
-import type { Accessor, Optional } from '$lib/types'
+import type { Accessor } from '$lib/types'
 import * as editable from '@zag-js/editable'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/svelte'
 import { type MaybeFunction, runIfFn } from '@zag-js/utils'
 import { useFieldContext } from '../field/index.ts'
 
-export interface UseEditableProps extends Optional<Omit<editable.Props, 'dir' | 'getRootNode'>, 'id'> {}
+export interface UseEditableProps extends Omit<editable.Props, 'dir' | 'getRootNode'> {}
 export interface UseEditableReturn extends Accessor<editable.Api<PropTypes>> {}
 
-export const useEditable = (props?: MaybeFunction<UseEditableProps>): UseEditableReturn => {
+export const useEditable = (props: MaybeFunction<UseEditableProps>): UseEditableReturn => {
   const env = useEnvironmentContext()
   const locale = useLocaleContext()
   const field = useFieldContext()

--- a/packages/svelte/src/lib/components/field/field-root.svelte
+++ b/packages/svelte/src/lib/components/field/field-root.svelte
@@ -1,5 +1,5 @@
 <script module lang="ts">
-  import type { Assign, HTMLProps, PolymorphicProps, RefAttribute } from '$lib/types'
+  import type { Assign, HTMLProps, Optional, PolymorphicProps, RefAttribute } from '$lib/types'
   import type { UseFieldProps } from './use-field.svelte.ts'
 
   export interface FieldRootBaseProps extends UseFieldProps, PolymorphicProps<'div'>, RefAttribute {}
@@ -16,7 +16,15 @@
   let { ref = $bindable(null), ...props }: FieldRootProps = $props()
 
   const [useFieldProps, localProps] = $derived(
-    createSplitProps<UseFieldProps>()(props, ['id', 'ids', 'disabled', 'invalid', 'readOnly', 'required', 'target']),
+    createSplitProps<Optional<UseFieldProps, 'id'>>()(props, [
+      'id',
+      'ids',
+      'disabled',
+      'invalid',
+      'readOnly',
+      'required',
+      'target',
+    ]),
   )
 
   const providedId = $props.id()

--- a/packages/svelte/src/lib/components/fieldset/fieldset-root.svelte
+++ b/packages/svelte/src/lib/components/fieldset/fieldset-root.svelte
@@ -1,5 +1,5 @@
 <script module lang="ts">
-  import type { Assign, HTMLProps, PolymorphicProps, RefAttribute } from '$lib/types'
+  import type { Assign, HTMLProps, Optional, PolymorphicProps, RefAttribute } from '$lib/types'
   import type { UseFieldsetProps } from './use-fieldset.svelte.ts'
 
   export interface FieldsetRootBaseProps extends UseFieldsetProps, PolymorphicProps<'fieldset'>, RefAttribute {}
@@ -16,7 +16,7 @@
   let { ref = $bindable(null), ...props }: FieldsetRootProps = $props()
 
   const [useFieldsetProps, localProps] = $derived(
-    createSplitProps<UseFieldsetProps>()(props, ['id', 'disabled', 'invalid']),
+    createSplitProps<Optional<UseFieldsetProps, 'id'>>()(props, ['id', 'disabled', 'invalid']),
   )
 
   const providedId = $props.id()

--- a/packages/svelte/src/lib/components/file-upload/examples/pasting-files.svelte
+++ b/packages/svelte/src/lib/components/file-upload/examples/pasting-files.svelte
@@ -9,8 +9,7 @@
   <FileUpload.Label>Upload with Paste</FileUpload.Label>
   <textarea
     placeholder="Paste an image here (Ctrl/Cmd + V)"
-    onpaste={(e) => fileUpload().setClipboardFiles(e.clipboardData)}
-  ></textarea>
+    onpaste={(e) => fileUpload().setClipboardFiles(e.clipboardData)}></textarea>
   <FileUpload.ItemGroup>
     {#each fileUpload().acceptedFiles as file (file.name)}
       <FileUpload.Item {file}>

--- a/packages/svelte/src/lib/components/file-upload/file-upload-root.svelte
+++ b/packages/svelte/src/lib/components/file-upload/file-upload-root.svelte
@@ -1,8 +1,9 @@
 <script module lang="ts">
-  import type { Assign, HTMLProps, PolymorphicProps, RefAttribute } from '$lib/types'
+  import type { Assign, HTMLProps, Optional, PolymorphicProps, RefAttribute } from '$lib/types'
   import type { UseFileUploadProps } from './use-file-upload.svelte.ts'
 
-  export interface FileUploadRootBaseProps extends UseFileUploadProps, PolymorphicProps<'div'>, RefAttribute {}
+  export interface FileUploadRootBaseProps
+    extends Optional<UseFileUploadProps, 'id'>, PolymorphicProps<'div'>, RefAttribute {}
   export interface FileUploadRootProps extends Assign<HTMLProps<'div'>, FileUploadRootBaseProps> {}
 </script>
 
@@ -17,7 +18,7 @@
   const providedId = $props.id()
 
   const [useFileUploadProps, localProps] = $derived(
-    createSplitProps<UseFileUploadProps>()(props, [
+    createSplitProps<Optional<UseFileUploadProps, 'id'>>()(props, [
       'accept',
       'acceptedFiles',
       'allowDrop',

--- a/packages/svelte/src/lib/components/file-upload/use-file-upload.svelte.ts
+++ b/packages/svelte/src/lib/components/file-upload/use-file-upload.svelte.ts
@@ -1,15 +1,15 @@
 import { useEnvironmentContext } from '$lib/providers/environment'
 import { useLocaleContext } from '$lib/providers/locale'
-import type { Accessor, Optional } from '$lib/types'
+import type { Accessor } from '$lib/types'
 import * as fileUpload from '@zag-js/file-upload'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/svelte'
 import { type MaybeFunction, runIfFn } from '@zag-js/utils'
 import { useFieldContext } from '../field/index.ts'
 
-export interface UseFileUploadProps extends Optional<Omit<fileUpload.Props, 'dir' | 'getRootNode'>, 'id'> {}
+export interface UseFileUploadProps extends Omit<fileUpload.Props, 'dir' | 'getRootNode'> {}
 export interface UseFileUploadReturn extends Accessor<fileUpload.Api<PropTypes>> {}
 
-export const useFileUpload = (props?: MaybeFunction<UseFileUploadProps>): UseFileUploadReturn => {
+export const useFileUpload = (props: MaybeFunction<UseFileUploadProps>): UseFileUploadReturn => {
   const env = useEnvironmentContext()
   const locale = useLocaleContext()
   const field = useFieldContext()

--- a/packages/svelte/src/lib/components/floating-panel/floating-panel-root.svelte
+++ b/packages/svelte/src/lib/components/floating-panel/floating-panel-root.svelte
@@ -1,11 +1,12 @@
 <script lang="ts" module>
+  import type { Optional } from '$lib/types'
   import type { PolymorphicProps } from '$lib/types.js'
   import type { Snippet } from 'svelte'
   import type { UsePresenceProps } from '../presence/use-presence.svelte.js'
   import type { UseFloatingPanelProps } from './use-floating-panel.svelte.js'
 
   export interface FloatingPanelRootBaseProps
-    extends UseFloatingPanelProps, UsePresenceProps, PolymorphicProps<'div'> {}
+    extends Optional<UseFloatingPanelProps, 'id'>, UsePresenceProps, PolymorphicProps<'div'> {}
   export interface FloatingPanelRootProps extends FloatingPanelRootBaseProps {
     children?: Snippet
   }
@@ -23,7 +24,7 @@
 
   const [presenceProps, otherProps] = $derived(splitPresenceProps(props))
   const [floatingPanelProps, localProps] = $derived(
-    createSplitProps<UseFloatingPanelProps>()(otherProps, [
+    createSplitProps<Optional<UseFloatingPanelProps, 'id'>>()(otherProps, [
       'allowOverflow',
       'closeOnEscape',
       'defaultOpen',

--- a/packages/svelte/src/lib/components/floating-panel/use-floating-panel.svelte.ts
+++ b/packages/svelte/src/lib/components/floating-panel/use-floating-panel.svelte.ts
@@ -4,10 +4,10 @@ import { type PropTypes, normalizeProps, useMachine } from '@zag-js/svelte'
 import { type MaybeFunction, runIfFn } from '@zag-js/utils'
 import { useEnvironmentContext, useLocaleContext } from '../../providers/index.js'
 
-export interface UseFloatingPanelProps extends Optional<Omit<floatingPanel.Props, 'getRootNode'>, 'id'> {}
+export interface UseFloatingPanelProps extends Omit<floatingPanel.Props, 'getRootNode'> {}
 export interface UseFloatingPanelReturn extends Accessor<floatingPanel.Api<PropTypes>> {}
 
-export const useFloatingPanel = (props: MaybeFunction<UseFloatingPanelProps> = {}): UseFloatingPanelReturn => {
+export const useFloatingPanel = (props: MaybeFunction<UseFloatingPanelProps>): UseFloatingPanelReturn => {
   const env = useEnvironmentContext()
   const locale = useLocaleContext()
 

--- a/packages/svelte/src/lib/components/hover-card/hover-card-root.svelte
+++ b/packages/svelte/src/lib/components/hover-card/hover-card-root.svelte
@@ -1,8 +1,9 @@
 <script module lang="ts">
+  import type { Optional } from '$lib/types'
   import type { UsePresenceProps } from '../presence/index.ts'
   import type { UseHoverCardProps } from './use-hover-card.svelte.ts'
 
-  export interface HoverCardRootBaseProps extends UseHoverCardProps, UsePresenceProps {
+  export interface HoverCardRootBaseProps extends Optional<UseHoverCardProps, 'id'>, UsePresenceProps {
     children?: Snippet
   }
   export interface HoverCardRootProps extends HoverCardRootBaseProps {}

--- a/packages/svelte/src/lib/components/hover-card/use-hover-card.svelte.ts
+++ b/packages/svelte/src/lib/components/hover-card/use-hover-card.svelte.ts
@@ -1,14 +1,14 @@
 import { useEnvironmentContext } from '$lib/providers/environment'
 import { useLocaleContext } from '$lib/providers/locale'
-import type { Accessor, Optional } from '$lib/types'
+import type { Accessor } from '$lib/types'
 import * as hoverCard from '@zag-js/hover-card'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/svelte'
 import { type MaybeFunction, runIfFn } from '@zag-js/utils'
 
-export interface UseHoverCardProps extends Optional<Omit<hoverCard.Props, 'dir' | 'getRootNode'>, 'id'> {}
+export interface UseHoverCardProps extends Omit<hoverCard.Props, 'dir' | 'getRootNode'> {}
 export interface UseHoverCardReturn extends Accessor<hoverCard.Api<PropTypes>> {}
 
-export const useHoverCard = (props?: MaybeFunction<UseHoverCardProps>): UseHoverCardReturn => {
+export const useHoverCard = (props: MaybeFunction<UseHoverCardProps>): UseHoverCardReturn => {
   const env = useEnvironmentContext()
   const locale = useLocaleContext()
 

--- a/packages/svelte/src/lib/components/image-cropper/examples/crop-preview.svelte
+++ b/packages/svelte/src/lib/components/image-cropper/examples/crop-preview.svelte
@@ -4,7 +4,8 @@
   import button from 'styles/button.module.css'
   import styles from 'styles/image-cropper.module.css'
 
-  const imageCropper = useImageCropper()
+  const id = $props.id()
+  const imageCropper = useImageCropper({ id })
   let preview = $state<string | null>(null)
 
   const handleCrop = async () => {

--- a/packages/svelte/src/lib/components/image-cropper/examples/reset.svelte
+++ b/packages/svelte/src/lib/components/image-cropper/examples/reset.svelte
@@ -11,7 +11,8 @@
   import button from 'styles/button.module.css'
   import styles from 'styles/image-cropper.module.css'
 
-  const imageCropper = useImageCropper()
+  const id = $props.id()
+  const imageCropper = useImageCropper({ id })
 </script>
 
 <div class={styles.Layout}>

--- a/packages/svelte/src/lib/components/image-cropper/examples/root-provider.svelte
+++ b/packages/svelte/src/lib/components/image-cropper/examples/root-provider.svelte
@@ -4,7 +4,8 @@
   import button from 'styles/button.module.css'
   import styles from 'styles/image-cropper.module.css'
 
-  const imageCropper = useImageCropper()
+  const id = $props.id()
+  const imageCropper = useImageCropper({ id })
 </script>
 
 <div class={styles.Layout}>

--- a/packages/svelte/src/lib/components/image-cropper/image-cropper-root.svelte
+++ b/packages/svelte/src/lib/components/image-cropper/image-cropper-root.svelte
@@ -1,9 +1,10 @@
 <script module lang="ts">
   import type { Snippet } from 'svelte'
-  import type { Assign, HTMLProps, PolymorphicProps, RefAttribute } from '$lib/types'
+  import type { Assign, HTMLProps, Optional, PolymorphicProps, RefAttribute } from '$lib/types'
   import type { UseImageCropperProps } from './use-image-cropper.svelte.ts'
 
-  export interface ImageCropperRootBaseProps extends UseImageCropperProps, PolymorphicProps<'div'>, RefAttribute {}
+  export interface ImageCropperRootBaseProps
+    extends Optional<UseImageCropperProps, 'id'>, PolymorphicProps<'div'>, RefAttribute {}
   export interface ImageCropperRootProps extends Assign<HTMLProps<'div'>, ImageCropperRootBaseProps> {
     children?: Snippet
   }
@@ -26,7 +27,7 @@
   const providedId = $props.id()
 
   const [useImageCropperProps, localProps] = $derived(
-    createSplitProps<UseImageCropperProps>()(props, [
+    createSplitProps<Optional<UseImageCropperProps, 'id'>>()(props, [
       'aspectRatio',
       'cropShape',
       'defaultFlip',

--- a/packages/svelte/src/lib/components/image-cropper/use-image-cropper.svelte.ts
+++ b/packages/svelte/src/lib/components/image-cropper/use-image-cropper.svelte.ts
@@ -1,14 +1,14 @@
 import { useEnvironmentContext } from '$lib/providers/environment'
 import { useLocaleContext } from '$lib/providers/locale'
-import type { Accessor, Optional } from '$lib/types'
+import type { Accessor } from '$lib/types'
 import * as imageCropper from '@zag-js/image-cropper'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/svelte'
 import { type MaybeFunction, runIfFn } from '@zag-js/utils'
 
-export interface UseImageCropperProps extends Optional<Omit<imageCropper.Props, 'dir' | 'getRootNode'>, 'id'> {}
+export interface UseImageCropperProps extends Omit<imageCropper.Props, 'dir' | 'getRootNode'> {}
 export interface UseImageCropperReturn extends Accessor<imageCropper.Api<PropTypes>> {}
 
-export const useImageCropper = (props?: MaybeFunction<UseImageCropperProps>): UseImageCropperReturn => {
+export const useImageCropper = (props: MaybeFunction<UseImageCropperProps>): UseImageCropperReturn => {
   const env = useEnvironmentContext()
   const locale = useLocaleContext()
 

--- a/packages/svelte/src/lib/components/listbox/examples/root-provider.svelte
+++ b/packages/svelte/src/lib/components/listbox/examples/root-provider.svelte
@@ -13,7 +13,8 @@
     ],
   })
 
-  const listbox = useListbox({ collection })
+  const id = $props.id()
+  const listbox = useListbox({ id, collection })
 </script>
 
 <div class="stack">

--- a/packages/svelte/src/lib/components/listbox/listbox-root.svelte
+++ b/packages/svelte/src/lib/components/listbox/listbox-root.svelte
@@ -1,11 +1,13 @@
 <script lang="ts" module>
+  import type { Optional } from '$lib/types'
   import type { Snippet } from 'svelte'
 
   import type { Assign, HTMLProps, PolymorphicProps } from '$lib/types.js'
   import type { CollectionItem } from '../collection/index.js'
   import type { UseListboxProps } from './use-listbox.svelte.js'
 
-  export interface ListboxRootBaseProps<T extends CollectionItem> extends UseListboxProps<T>, PolymorphicProps<'div'> {}
+  export interface ListboxRootBaseProps<T extends CollectionItem>
+    extends Optional<UseListboxProps<T>, 'id'>, PolymorphicProps<'div'> {}
   export interface ListboxRootProps<T extends CollectionItem> extends Assign<
     HTMLProps<'div'>,
     ListboxRootBaseProps<T>
@@ -32,7 +34,7 @@
   const providedId = $props.id()
 
   const [listboxProps, localProps] = $derived(
-    createSplitProps<UseListboxProps<T>>()(props, [
+    createSplitProps<Optional<UseListboxProps<T>, 'id'>>()(props, [
       'collection',
       'defaultHighlightedValue',
       'defaultValue',

--- a/packages/svelte/src/lib/components/listbox/use-listbox.svelte.ts
+++ b/packages/svelte/src/lib/components/listbox/use-listbox.svelte.ts
@@ -5,9 +5,9 @@ import { type MaybeFunction, runIfFn } from '@zag-js/utils'
 import { useEnvironmentContext, useLocaleContext } from '../../providers/index.js'
 import type { CollectionItem, ListCollection } from '../collection/index.js'
 
-export interface UseListboxProps<T extends CollectionItem> extends Optional<
-  Omit<listbox.Props<T>, 'dir' | 'getRootNode' | 'collection'>,
-  'id'
+export interface UseListboxProps<T extends CollectionItem> extends Omit<
+  listbox.Props<T>,
+  'dir' | 'getRootNode' | 'collection'
 > {
   /**
    * The collection of items

--- a/packages/svelte/src/lib/components/menu/examples/root-provider.svelte
+++ b/packages/svelte/src/lib/components/menu/examples/root-provider.svelte
@@ -4,7 +4,8 @@
   import button from 'styles/button.module.css'
   import styles from 'styles/menu.module.css'
 
-  const menu = useMenu()
+  const id = $props.id()
+  const menu = useMenu({ id })
 </script>
 
 <div class="stack">

--- a/packages/svelte/src/lib/components/menu/menu-root.svelte
+++ b/packages/svelte/src/lib/components/menu/menu-root.svelte
@@ -1,9 +1,10 @@
 <script module lang="ts">
+  import type { Optional } from '$lib/types'
   import { onMount, type Snippet } from 'svelte'
   import type { UsePresenceProps } from '../presence/index.ts'
   import type { UseMenuProps } from './use-menu.svelte.ts'
 
-  export interface MenuRootBaseProps extends UseMenuProps, UsePresenceProps {
+  export interface MenuRootBaseProps extends Optional<UseMenuProps, 'id'>, UsePresenceProps {
     children?: Snippet
   }
   export interface MenuRootProps extends MenuRootBaseProps {}
@@ -22,7 +23,7 @@
 
   const [presenceProps, menuProps] = $derived(splitPresenceProps(props))
   const [useMenuProps, localProps] = $derived(
-    createSplitProps<UseMenuProps>()(menuProps, [
+    createSplitProps<Optional<UseMenuProps, 'id'>>()(menuProps, [
       'anchorPoint',
       'aria-label',
       'closeOnSelect',

--- a/packages/svelte/src/lib/components/menu/use-menu.svelte.ts
+++ b/packages/svelte/src/lib/components/menu/use-menu.svelte.ts
@@ -1,17 +1,17 @@
 import { useEnvironmentContext } from '$lib/providers/environment'
 import { useLocaleContext } from '$lib/providers/locale'
-import type { Accessor, Optional } from '$lib/types'
+import type { Accessor } from '$lib/types'
 import * as menu from '@zag-js/menu'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/svelte'
 import { type MaybeFunction, runIfFn } from '@zag-js/utils'
 
-export interface UseMenuProps extends Optional<Omit<menu.Props, 'dir' | 'getRootNode'>, 'id'> {}
+export interface UseMenuProps extends Omit<menu.Props, 'dir' | 'getRootNode'> {}
 export interface UseMenuReturn extends Accessor<{
   api: menu.Api<PropTypes>
   service: menu.Service
 }> {}
 
-export const useMenu = (props?: MaybeFunction<UseMenuProps>): UseMenuReturn => {
+export const useMenu = (props: MaybeFunction<UseMenuProps>): UseMenuReturn => {
   const env = useEnvironmentContext()
   const locale = useLocaleContext()
 

--- a/packages/svelte/src/lib/components/navigation-menu/navigation-menu-root.svelte
+++ b/packages/svelte/src/lib/components/navigation-menu/navigation-menu-root.svelte
@@ -1,10 +1,10 @@
 <script module lang="ts">
-  import type { Assign, HTMLProps, PolymorphicProps, RefAttribute } from '$lib/types'
+  import type { Assign, HTMLProps, Optional, PolymorphicProps, RefAttribute } from '$lib/types'
   import type { UsePresenceProps } from '../presence/index.ts'
   import type { UseNavigationMenuProps } from './use-navigation-menu.svelte.ts'
 
   export interface NavigationMenuRootBaseProps
-    extends UseNavigationMenuProps, UsePresenceProps, PolymorphicProps<'nav'>, RefAttribute {}
+    extends Optional<UseNavigationMenuProps, 'id'>, UsePresenceProps, PolymorphicProps<'nav'>, RefAttribute {}
   export interface NavigationMenuRootProps extends Assign<HTMLProps<'nav'>, NavigationMenuRootBaseProps> {}
 </script>
 
@@ -19,7 +19,7 @@
   let { ref = $bindable(null), value = $bindable(), ...props }: NavigationMenuRootProps = $props()
 
   const providedId = $props.id()
-  const splitRootProps = createSplitProps<UseNavigationMenuProps>()
+  const splitRootProps = createSplitProps<Optional<UseNavigationMenuProps, 'id'>>()
 
   const [renderStrategyProps, navigationMenuProps] = $derived(splitRenderStrategyProps(props))
   const [useNavigationMenuProps, localProps] = $derived(

--- a/packages/svelte/src/lib/components/navigation-menu/use-navigation-menu.svelte.ts
+++ b/packages/svelte/src/lib/components/navigation-menu/use-navigation-menu.svelte.ts
@@ -1,14 +1,14 @@
 import { useEnvironmentContext } from '$lib/providers/environment'
 import { useLocaleContext } from '$lib/providers/locale'
-import type { Accessor, Optional } from '$lib/types'
+import type { Accessor } from '$lib/types'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/svelte'
 import * as navigationMenu from '@zag-js/navigation-menu'
 import { type MaybeFunction, runIfFn } from '@zag-js/utils'
 
-export interface UseNavigationMenuProps extends Optional<Omit<navigationMenu.Props, 'dir' | 'getRootNode'>, 'id'> {}
+export interface UseNavigationMenuProps extends Omit<navigationMenu.Props, 'dir' | 'getRootNode'> {}
 export interface UseNavigationMenuReturn extends Accessor<navigationMenu.Api<PropTypes>> {}
 
-export const useNavigationMenu = (props?: MaybeFunction<UseNavigationMenuProps>): UseNavigationMenuReturn => {
+export const useNavigationMenu = (props: MaybeFunction<UseNavigationMenuProps>): UseNavigationMenuReturn => {
   const env = useEnvironmentContext()
   const locale = useLocaleContext()
 

--- a/packages/svelte/src/lib/components/number-input/number-input-root.svelte
+++ b/packages/svelte/src/lib/components/number-input/number-input-root.svelte
@@ -1,8 +1,9 @@
 <script module lang="ts">
-  import type { Assign, HTMLProps, PolymorphicProps, RefAttribute } from '$lib/types'
+  import type { Assign, HTMLProps, Optional, PolymorphicProps, RefAttribute } from '$lib/types'
   import type { UseNumberInputProps } from './use-number-input.svelte.ts'
 
-  export interface NumberInputRootBaseProps extends UseNumberInputProps, PolymorphicProps<'div'>, RefAttribute {}
+  export interface NumberInputRootBaseProps
+    extends Optional<UseNumberInputProps, 'id'>, PolymorphicProps<'div'>, RefAttribute {}
   export interface NumberInputRootProps extends Assign<HTMLProps<'div'>, NumberInputRootBaseProps> {}
 </script>
 

--- a/packages/svelte/src/lib/components/number-input/split-number-input-props.svelte.ts
+++ b/packages/svelte/src/lib/components/number-input/split-number-input-props.svelte.ts
@@ -1,9 +1,10 @@
+import type { Optional } from '$lib/types'
 import { createSplitProps } from '$lib/utils/create-split-props'
 import type { UseNumberInputProps } from './use-number-input.svelte.ts'
 
-const splitFn = createSplitProps<UseNumberInputProps>()
+const splitFn = createSplitProps<Optional<UseNumberInputProps, 'id'>>()
 
-export const splitNumberInputProps = <T extends UseNumberInputProps>(props: T) =>
+export const splitNumberInputProps = <T extends Optional<UseNumberInputProps, 'id'>>(props: T) =>
   splitFn(props, [
     'allowMouseWheel',
     'allowOverflow',

--- a/packages/svelte/src/lib/components/number-input/use-number-input.svelte.ts
+++ b/packages/svelte/src/lib/components/number-input/use-number-input.svelte.ts
@@ -1,16 +1,16 @@
 import { useEnvironmentContext } from '$lib/providers/environment'
 import { useLocaleContext } from '$lib/providers/locale'
-import type { Accessor, Optional } from '$lib/types'
+import type { Accessor } from '$lib/types'
 import * as numberInput from '@zag-js/number-input'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/svelte'
 import { type MaybeFunction, ensureProps, runIfFn } from '@zag-js/utils'
 import { useFieldContext } from '../field/index.ts'
 
-export interface UseNumberInputProps extends Optional<Omit<numberInput.Props, 'dir' | 'getRootNode'>, 'id'> {}
+export interface UseNumberInputProps extends Omit<numberInput.Props, 'dir' | 'getRootNode'> {}
 
 export interface UseNumberInputReturn extends Accessor<numberInput.Api<PropTypes>> {}
 
-export const useNumberInput = (props: MaybeFunction<UseNumberInputProps> = {}): UseNumberInputReturn => {
+export const useNumberInput = (props: MaybeFunction<UseNumberInputProps>): UseNumberInputReturn => {
   const env = useEnvironmentContext()
   const locale = useLocaleContext()
   const field = useFieldContext()

--- a/packages/svelte/src/lib/components/pagination/pagination-root.svelte
+++ b/packages/svelte/src/lib/components/pagination/pagination-root.svelte
@@ -1,8 +1,9 @@
 <script module lang="ts">
-  import type { Assign, HTMLProps, PolymorphicProps, RefAttribute } from '$lib/types'
+  import type { Assign, HTMLProps, Optional, PolymorphicProps, RefAttribute } from '$lib/types'
   import type { UsePaginationProps } from './use-pagination.svelte.ts'
 
-  export interface PaginationRootBaseProps extends UsePaginationProps, PolymorphicProps<'nav'>, RefAttribute {}
+  export interface PaginationRootBaseProps
+    extends Optional<UsePaginationProps, 'id'>, PolymorphicProps<'nav'>, RefAttribute {}
   export interface PaginationRootProps extends Assign<HTMLProps<'nav'>, PaginationRootBaseProps> {}
 </script>
 
@@ -17,7 +18,7 @@
   const providedId = $props.id()
 
   const [paginationProps, localProps] = $derived(
-    createSplitProps<UsePaginationProps>()(props, [
+    createSplitProps<Optional<UsePaginationProps, 'id'>>()(props, [
       'boundaryCount',
       'count',
       'defaultPage',

--- a/packages/svelte/src/lib/components/pagination/use-pagination.svelte.ts
+++ b/packages/svelte/src/lib/components/pagination/use-pagination.svelte.ts
@@ -5,10 +5,10 @@ import type { MaybeFunction } from '@zag-js/utils'
 import { useEnvironmentContext, useLocaleContext } from '../../providers/index.ts'
 import type { Accessor, Optional } from '../../types.ts'
 
-export interface UsePaginationProps extends Optional<Omit<pagination.Props, 'dir' | 'getRootNode'>, 'id'> {}
+export interface UsePaginationProps extends Omit<pagination.Props, 'dir' | 'getRootNode'> {}
 export interface UsePaginationReturn extends Accessor<pagination.Api<PropTypes>> {}
 
-export const usePagination = (props: MaybeFunction<UsePaginationProps> = {}): UsePaginationReturn => {
+export const usePagination = (props: MaybeFunction<UsePaginationProps>): UsePaginationReturn => {
   const env = useEnvironmentContext()
   const locale = useLocaleContext()
 

--- a/packages/svelte/src/lib/components/password-input/password-input-root-provider.svelte
+++ b/packages/svelte/src/lib/components/password-input/password-input-root-provider.svelte
@@ -5,7 +5,10 @@
   export interface PasswordInputRootProviderBaseProps extends PolymorphicProps<'div'>, RefAttribute {
     value: UsePasswordInputReturn
   }
-  export interface PasswordInputRootProviderProps extends Assign<HTMLProps<'div'>, PasswordInputRootProviderBaseProps> {}
+  export interface PasswordInputRootProviderProps extends Assign<
+    HTMLProps<'div'>,
+    PasswordInputRootProviderBaseProps
+  > {}
 </script>
 
 <script lang="ts">

--- a/packages/svelte/src/lib/components/password-input/password-input-root.svelte
+++ b/packages/svelte/src/lib/components/password-input/password-input-root.svelte
@@ -1,9 +1,10 @@
 <script module lang="ts">
   import type { Snippet } from 'svelte'
-  import type { Assign, HTMLProps, PolymorphicProps, RefAttribute } from '$lib/types'
+  import type { Assign, HTMLProps, Optional, PolymorphicProps, RefAttribute } from '$lib/types'
   import type { UsePasswordInputProps } from './use-password-input.svelte.ts'
 
-  export interface PasswordInputRootBaseProps extends UsePasswordInputProps, PolymorphicProps<'div'>, RefAttribute {}
+  export interface PasswordInputRootBaseProps
+    extends Optional<UsePasswordInputProps, 'id'>, PolymorphicProps<'div'>, RefAttribute {}
   export interface PasswordInputRootProps extends Assign<HTMLProps<'div'>, PasswordInputRootBaseProps> {
     children?: Snippet
   }
@@ -20,7 +21,7 @@
   const providedId = $props.id()
 
   const [usePasswordInputProps, localProps] = $derived(
-    createSplitProps<UsePasswordInputProps>()(props, [
+    createSplitProps<Optional<UsePasswordInputProps, 'id'>>()(props, [
       'autoComplete',
       'defaultVisible',
       'disabled',

--- a/packages/svelte/src/lib/components/password-input/use-password-input.svelte.ts
+++ b/packages/svelte/src/lib/components/password-input/use-password-input.svelte.ts
@@ -1,15 +1,15 @@
 import { useEnvironmentContext } from '$lib/providers/environment'
 import { useLocaleContext } from '$lib/providers/locale'
-import type { Accessor, Optional } from '$lib/types'
+import type { Accessor } from '$lib/types'
 import * as passwordInput from '@zag-js/password-input'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/svelte'
 import { type MaybeFunction, runIfFn } from '@zag-js/utils'
 import { useFieldContext } from '../field/index.ts'
 
-export interface UsePasswordInputProps extends Optional<Omit<passwordInput.Props, 'dir' | 'getRootNode'>, 'id'> {}
+export interface UsePasswordInputProps extends Omit<passwordInput.Props, 'dir' | 'getRootNode'> {}
 export interface UsePasswordInputReturn extends Accessor<passwordInput.Api<PropTypes>> {}
 
-export const usePasswordInput = (props?: MaybeFunction<UsePasswordInputProps>): UsePasswordInputReturn => {
+export const usePasswordInput = (props: MaybeFunction<UsePasswordInputProps>): UsePasswordInputReturn => {
   const env = useEnvironmentContext()
   const locale = useLocaleContext()
   const field = useFieldContext()

--- a/packages/svelte/src/lib/components/pin-input/pin-input-root.svelte
+++ b/packages/svelte/src/lib/components/pin-input/pin-input-root.svelte
@@ -1,9 +1,10 @@
 <script module lang="ts">
   import type { Snippet } from 'svelte'
-  import type { Assign, HTMLProps, PolymorphicProps, RefAttribute } from '$lib/types'
+  import type { Assign, HTMLProps, Optional, PolymorphicProps, RefAttribute } from '$lib/types'
   import type { UsePinInputProps } from './use-pin-input.svelte.ts'
 
-  export interface PinInputRootBaseProps extends UsePinInputProps, PolymorphicProps<'div'>, RefAttribute {}
+  export interface PinInputRootBaseProps
+    extends Optional<UsePinInputProps, 'id'>, PolymorphicProps<'div'>, RefAttribute {}
   export interface PinInputRootProps extends Assign<HTMLProps<'div'>, PinInputRootBaseProps> {
     children?: Snippet
   }
@@ -20,7 +21,7 @@
   const providedId = $props.id()
 
   const [usePinInputProps, localProps] = $derived(
-    createSplitProps<UsePinInputProps>()(props, [
+    createSplitProps<Optional<UsePinInputProps, 'id'>>()(props, [
       'autoFocus',
       'autoSubmit',
       'blurOnComplete',

--- a/packages/svelte/src/lib/components/pin-input/use-pin-input.svelte.ts
+++ b/packages/svelte/src/lib/components/pin-input/use-pin-input.svelte.ts
@@ -1,15 +1,15 @@
 import { useEnvironmentContext } from '$lib/providers/environment'
 import { useLocaleContext } from '$lib/providers/locale'
-import type { Accessor, Optional } from '$lib/types'
+import type { Accessor } from '$lib/types'
 import * as pinInput from '@zag-js/pin-input'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/svelte'
 import { type MaybeFunction, runIfFn } from '@zag-js/utils'
 import { useFieldContext } from '../field/index.ts'
 
-export interface UsePinInputProps extends Optional<Omit<pinInput.Props, 'dir' | 'getRootNode'>, 'id'> {}
+export interface UsePinInputProps extends Omit<pinInput.Props, 'dir' | 'getRootNode'> {}
 export interface UsePinInputReturn extends Accessor<pinInput.Api<PropTypes>> {}
 
-export const usePinInput = (props?: MaybeFunction<UsePinInputProps>): UsePinInputReturn => {
+export const usePinInput = (props: MaybeFunction<UsePinInputProps>): UsePinInputReturn => {
   const env = useEnvironmentContext()
   const locale = useLocaleContext()
   const field = useFieldContext()

--- a/packages/svelte/src/lib/components/popover/examples/root-provider.svelte
+++ b/packages/svelte/src/lib/components/popover/examples/root-provider.svelte
@@ -4,7 +4,9 @@
   import button from 'styles/button.module.css'
   import styles from 'styles/popover.module.css'
 
+  const id = $props.id()
   const popover = usePopover({
+    id,
     positioning: {
       placement: 'bottom-start',
     },

--- a/packages/svelte/src/lib/components/popover/popover-root.svelte
+++ b/packages/svelte/src/lib/components/popover/popover-root.svelte
@@ -1,9 +1,10 @@
 <script module lang="ts">
+  import type { Optional } from '$lib/types'
   import type { Snippet } from 'svelte'
   import type { UsePresenceProps } from '../presence/index.ts'
   import type { UsePopoverProps } from './use-popover.svelte.ts'
 
-  export interface PopoverRootBaseProps extends UsePopoverProps, UsePresenceProps {}
+  export interface PopoverRootBaseProps extends Optional<UsePopoverProps, 'id'>, UsePresenceProps {}
   export interface PopoverRootProps extends PopoverRootBaseProps {
     children?: Snippet
   }

--- a/packages/svelte/src/lib/components/popover/use-popover.svelte.ts
+++ b/packages/svelte/src/lib/components/popover/use-popover.svelte.ts
@@ -1,15 +1,15 @@
 import { useEnvironmentContext } from '$lib/providers/environment'
 import { useLocaleContext } from '$lib/providers/locale'
-import type { Accessor, Optional } from '$lib/types'
+import type { Accessor } from '$lib/types'
 import * as popover from '@zag-js/popover'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/svelte'
 import { type MaybeFunction, runIfFn } from '@zag-js/utils'
 
-export interface UsePopoverProps extends Optional<Omit<popover.Props, 'dir' | 'getRootNode'>, 'id'> {}
+export interface UsePopoverProps extends Omit<popover.Props, 'dir' | 'getRootNode'> {}
 
 export interface UsePopoverReturn extends Accessor<popover.Api<PropTypes>> {}
 
-export const usePopover = (props?: MaybeFunction<UsePopoverProps>): UsePopoverReturn => {
+export const usePopover = (props: MaybeFunction<UsePopoverProps>): UsePopoverReturn => {
   const env = useEnvironmentContext()
   const locale = useLocaleContext()
 

--- a/packages/svelte/src/lib/components/presence/use-presence.svelte.ts
+++ b/packages/svelte/src/lib/components/presence/use-presence.svelte.ts
@@ -6,11 +6,6 @@ import { type MaybeFunction, runIfFn } from '@zag-js/utils'
 
 export interface UsePresenceProps extends Optional<presence.Props, 'present'>, RenderStrategyProps {
   /**
-   * Function called when the animation ends in the open state.
-   */
-  // TODO(zag-bump): drop once @zag-js/presence v2 ports `onEnterComplete` back into its props.
-  onEnterComplete?: VoidFunction | undefined
-  /**
    * Whether to allow the initial presence animation.
    * @default false
    */

--- a/packages/svelte/src/lib/components/radio-group/radio-group-root.svelte
+++ b/packages/svelte/src/lib/components/radio-group/radio-group-root.svelte
@@ -1,5 +1,5 @@
 <script module lang="ts">
-  import type { Assign, HTMLProps, PolymorphicProps, RefAttribute } from '$lib/types'
+  import type { Assign, HTMLProps, Optional, PolymorphicProps, RefAttribute } from '$lib/types'
   import type { ValueChangeDetails } from '@zag-js/radio-group'
   import type { UseRadioGroupProps } from './use-radio-group.svelte.ts'
 
@@ -7,7 +7,8 @@
     valueChange: ValueChangeDetails
   }
 
-  export interface RadioGroupRootBaseProps extends UseRadioGroupProps, PolymorphicProps<'div'>, RefAttribute {}
+  export interface RadioGroupRootBaseProps
+    extends Optional<UseRadioGroupProps, 'id'>, PolymorphicProps<'div'>, RefAttribute {}
   export interface RadioGroupRootProps extends Assign<HTMLProps<'div'>, RadioGroupRootBaseProps> {}
 </script>
 
@@ -22,7 +23,7 @@
   const providedId = $props.id()
 
   const [radioGroupProps, localProps] = $derived(
-    createSplitProps<UseRadioGroupProps>()(props, [
+    createSplitProps<Optional<UseRadioGroupProps, 'id'>>()(props, [
       'defaultValue',
       'disabled',
       'form',

--- a/packages/svelte/src/lib/components/radio-group/use-radio-group.svelte.ts
+++ b/packages/svelte/src/lib/components/radio-group/use-radio-group.svelte.ts
@@ -5,7 +5,7 @@ import { useEnvironmentContext, useLocaleContext } from '../../providers/index.t
 import type { Accessor, Optional } from '../../types.ts'
 import { useFieldsetContext } from '../fieldset/index.ts'
 
-export interface UseRadioGroupProps extends Optional<Omit<radio.Props, 'dir' | 'getRootNode'>, 'id'> {}
+export interface UseRadioGroupProps extends Omit<radio.Props, 'dir' | 'getRootNode'> {}
 export interface UseRadioGroupReturn extends Accessor<radio.Api<PropTypes>> {}
 
 export const useRadioGroup = (props: MaybeFunction<UseRadioGroupProps>): UseRadioGroupReturn => {

--- a/packages/svelte/src/lib/components/rating-group/rating-group-root.svelte
+++ b/packages/svelte/src/lib/components/rating-group/rating-group-root.svelte
@@ -1,8 +1,9 @@
 <script module lang="ts">
-  import type { Assign, HTMLProps, PolymorphicProps, RefAttribute } from '$lib/types'
+  import type { Assign, HTMLProps, Optional, PolymorphicProps, RefAttribute } from '$lib/types'
   import type { UseRatingGroupProps } from './use-rating-group.svelte.ts'
 
-  export interface RatingGroupRootBaseProps extends UseRatingGroupProps, PolymorphicProps<'div'>, RefAttribute {}
+  export interface RatingGroupRootBaseProps
+    extends Optional<UseRatingGroupProps, 'id'>, PolymorphicProps<'div'>, RefAttribute {}
   export interface RatingGroupRootProps extends Assign<HTMLProps<'div'>, RatingGroupRootBaseProps> {}
 </script>
 

--- a/packages/svelte/src/lib/components/rating-group/split-rating-group-props.svelte.ts
+++ b/packages/svelte/src/lib/components/rating-group/split-rating-group-props.svelte.ts
@@ -1,9 +1,10 @@
+import type { Optional } from '$lib/types'
 import { createSplitProps } from '$lib/utils/create-split-props'
 import type { UseRatingGroupProps } from './use-rating-group.svelte.ts'
 
-const splitFn = createSplitProps<UseRatingGroupProps>()
+const splitFn = createSplitProps<Optional<UseRatingGroupProps, 'id'>>()
 
-export const splitRatingGroupProps = <T extends UseRatingGroupProps>(props: T) =>
+export const splitRatingGroupProps = <T extends Optional<UseRatingGroupProps, 'id'>>(props: T) =>
   splitFn(props, [
     'allowHalf',
     'autoFocus',

--- a/packages/svelte/src/lib/components/rating-group/use-rating-group.svelte.ts
+++ b/packages/svelte/src/lib/components/rating-group/use-rating-group.svelte.ts
@@ -5,7 +5,7 @@ import { useEnvironmentContext, useLocaleContext } from '../../providers/index.t
 import type { Accessor, Optional } from '../../types.ts'
 import { useFieldContext } from '../field/index.ts'
 
-export interface UseRatingGroupProps extends Optional<Omit<rating.Props, 'dir' | 'getRootNode'>, 'id'> {}
+export interface UseRatingGroupProps extends Omit<rating.Props, 'dir' | 'getRootNode'> {}
 export interface UseRatingGroupReturn extends Accessor<rating.Api<PropTypes>> {}
 
 export const useRatingGroup = (props: MaybeFunction<UseRatingGroupProps>): UseRatingGroupReturn => {

--- a/packages/svelte/src/lib/components/scroll-area/scroll-area-root.svelte
+++ b/packages/svelte/src/lib/components/scroll-area/scroll-area-root.svelte
@@ -1,8 +1,10 @@
 <script module lang="ts">
+  import type { Optional } from '$lib/types'
   import type { Assign, HTMLProps, PolymorphicProps, RefAttribute } from '$lib/types.js'
   import type { UseScrollAreaProps } from './use-scroll-area.svelte.ts'
 
-  export interface ScrollAreaRootBaseProps extends UseScrollAreaProps, PolymorphicProps<'div'>, RefAttribute {}
+  export interface ScrollAreaRootBaseProps
+    extends Optional<UseScrollAreaProps, 'id'>, PolymorphicProps<'div'>, RefAttribute {}
   export interface ScrollAreaRootProps extends Assign<HTMLProps<'div'>, ScrollAreaRootBaseProps> {}
 </script>
 
@@ -16,7 +18,9 @@
   let { ref = $bindable(null), ...props }: ScrollAreaRootProps = $props()
   const providedId = $props.id()
 
-  const [scrollAreaProps, localProps] = $derived(createSplitProps<UseScrollAreaProps>()(props, ['id', 'ids']))
+  const [scrollAreaProps, localProps] = $derived(
+    createSplitProps<Optional<UseScrollAreaProps, 'id'>>()(props, ['id', 'ids']),
+  )
 
   const resolvedProps = $derived<UseScrollAreaProps>({
     ...scrollAreaProps,

--- a/packages/svelte/src/lib/components/scroll-area/use-scroll-area.svelte.ts
+++ b/packages/svelte/src/lib/components/scroll-area/use-scroll-area.svelte.ts
@@ -4,11 +4,11 @@ import { type PropTypes, normalizeProps, useMachine } from '@zag-js/svelte'
 import { type MaybeFunction, runIfFn } from '@zag-js/utils'
 import { useEnvironmentContext, useLocaleContext } from '../../providers/index.js'
 
-export interface UseScrollAreaProps extends Optional<Omit<scrollArea.Props, 'dir' | 'getRootNode'>, 'id'> {}
+export interface UseScrollAreaProps extends Omit<scrollArea.Props, 'dir' | 'getRootNode'> {}
 
 export interface UseScrollAreaReturn extends Accessor<scrollArea.Api<PropTypes>> {}
 
-export const useScrollArea = (props: MaybeFunction<UseScrollAreaProps> = {}): UseScrollAreaReturn => {
+export const useScrollArea = (props: MaybeFunction<UseScrollAreaProps>): UseScrollAreaReturn => {
   const env = useEnvironmentContext()
   const locale = useLocaleContext()
 

--- a/packages/svelte/src/lib/components/segment-group/segment-group-root.svelte
+++ b/packages/svelte/src/lib/components/segment-group/segment-group-root.svelte
@@ -1,5 +1,5 @@
 <script module lang="ts">
-  import type { Assign, HTMLProps, PolymorphicProps, RefAttribute } from '$lib/types'
+  import type { Assign, HTMLProps, Optional, PolymorphicProps, RefAttribute } from '$lib/types'
   import type { ValueChangeDetails } from '@zag-js/radio-group'
   import type { UseSegmentGroupProps } from './use-segment-group.svelte.ts'
 
@@ -7,7 +7,8 @@
     valueChange: ValueChangeDetails
   }
 
-  export interface SegmentGroupRootBaseProps extends UseSegmentGroupProps, PolymorphicProps<'div'>, RefAttribute {}
+  export interface SegmentGroupRootBaseProps
+    extends Optional<UseSegmentGroupProps, 'id'>, PolymorphicProps<'div'>, RefAttribute {}
   export interface SegmentGroupRootProps extends Assign<HTMLProps<'div'>, SegmentGroupRootBaseProps> {}
 </script>
 

--- a/packages/svelte/src/lib/components/segment-group/split-segment-group-props.svelte.ts
+++ b/packages/svelte/src/lib/components/segment-group/split-segment-group-props.svelte.ts
@@ -1,9 +1,10 @@
+import type { Optional } from '$lib/types'
 import { createSplitProps } from '$lib/utils/create-split-props'
 import type { UseSegmentGroupProps } from './use-segment-group.svelte.ts'
 
-const splitFn = createSplitProps<UseSegmentGroupProps>()
+const splitFn = createSplitProps<Optional<UseSegmentGroupProps, 'id'>>()
 
-export const splitSegmentGroupProps = <T extends UseSegmentGroupProps>(props: T) =>
+export const splitSegmentGroupProps = <T extends Optional<UseSegmentGroupProps, 'id'>>(props: T) =>
   splitFn(props, [
     'defaultValue',
     'disabled',

--- a/packages/svelte/src/lib/components/segment-group/use-segment-group.svelte.ts
+++ b/packages/svelte/src/lib/components/segment-group/use-segment-group.svelte.ts
@@ -4,7 +4,7 @@ import { type MaybeFunction, runIfFn } from '@zag-js/utils'
 import { useEnvironmentContext, useLocaleContext } from '../../providers/index.ts'
 import type { Accessor, Optional } from '../../types.ts'
 
-export interface UseSegmentGroupProps extends Optional<Omit<segmentGroup.Props, 'dir' | 'getRootNode'>, 'id'> {}
+export interface UseSegmentGroupProps extends Omit<segmentGroup.Props, 'dir' | 'getRootNode'> {}
 export interface UseSegmentGroupReturn extends Accessor<segmentGroup.Api<PropTypes>> {}
 
 export const useSegmentGroup = (props: MaybeFunction<UseSegmentGroupProps>): UseSegmentGroupReturn => {

--- a/packages/svelte/src/lib/components/select/examples/select-on-highlight.svelte
+++ b/packages/svelte/src/lib/components/select/examples/select-on-highlight.svelte
@@ -13,7 +13,9 @@
     ],
   })
 
+  const id = $props.id()
   const select = useSelect({
+    id,
     collection: frameworks,
     onHighlightChange({ highlightedValue }) {
       if (highlightedValue) {

--- a/packages/svelte/src/lib/components/select/select-root.svelte
+++ b/packages/svelte/src/lib/components/select/select-root.svelte
@@ -1,11 +1,11 @@
 <script module lang="ts">
-  import type { Assign, HTMLProps, PolymorphicProps, RefAttribute } from '$lib/types'
+  import type { Assign, HTMLProps, Optional, PolymorphicProps, RefAttribute } from '$lib/types'
   import type { Snippet } from 'svelte'
   import type { CollectionItem } from '../collection/index.ts'
   import type { UseSelectProps } from './use-select.svelte.ts'
 
   export interface SelectRootBaseProps<T extends CollectionItem = CollectionItem>
-    extends UseSelectProps<T>, UsePresenceProps, PolymorphicProps<'div'>, RefAttribute {}
+    extends Optional<UseSelectProps<T>, 'id'>, UsePresenceProps, PolymorphicProps<'div'>, RefAttribute {}
 
   export interface SelectRootProps<T extends CollectionItem = CollectionItem> extends Assign<
     HTMLProps<'div'>,
@@ -32,7 +32,7 @@
 
   const [presenceProps, selectProps] = $derived(splitPresenceProps(props))
   const [useSelectProps, localProps] = $derived(
-    createSplitProps<UseSelectProps<T>>()(selectProps, [
+    createSplitProps<Optional<UseSelectProps<T>, 'id'>>()(selectProps, [
       'alignItemWithTrigger',
       'autoComplete',
       'closeOnSelect',

--- a/packages/svelte/src/lib/components/select/use-select.svelte.ts
+++ b/packages/svelte/src/lib/components/select/use-select.svelte.ts
@@ -1,14 +1,14 @@
 import { useEnvironmentContext, useLocaleContext } from '$lib/providers'
-import type { Accessor, Optional } from '$lib/types'
+import type { Accessor } from '$lib/types'
 import * as select from '@zag-js/select'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/svelte'
 import { type MaybeFunction, runIfFn } from '@zag-js/utils'
 import type { CollectionItem, ListCollection } from '../collection/index.ts'
 import { useFieldContext } from '../field/index.ts'
 
-export interface UseSelectProps<T extends CollectionItem> extends Optional<
-  Omit<select.Props<T>, 'dir' | 'getRootNode' | 'collection'>,
-  'id'
+export interface UseSelectProps<T extends CollectionItem> extends Omit<
+  select.Props<T>,
+  'dir' | 'getRootNode' | 'collection'
 > {
   /**
    * The collection of items

--- a/packages/svelte/src/lib/components/signature-pad/signature-pad-root.svelte
+++ b/packages/svelte/src/lib/components/signature-pad/signature-pad-root.svelte
@@ -1,8 +1,9 @@
 <script module lang="ts">
-  import type { Assign, HTMLProps, PolymorphicProps, RefAttribute } from '$lib/types'
+  import type { Assign, HTMLProps, Optional, PolymorphicProps, RefAttribute } from '$lib/types'
   import type { UseSignaturePadProps } from './use-signature-pad.svelte.ts'
 
-  export interface SignaturePadRootBaseProps extends UseSignaturePadProps, PolymorphicProps<'div'>, RefAttribute {}
+  export interface SignaturePadRootBaseProps
+    extends Optional<UseSignaturePadProps, 'id'>, PolymorphicProps<'div'>, RefAttribute {}
   export interface SignaturePadRootProps extends Assign<HTMLProps<'div'>, SignaturePadRootBaseProps> {}
 </script>
 
@@ -17,7 +18,7 @@
   const providedId = $props.id()
 
   const [useSignaturePadProps, localProps] = $derived(
-    createSplitProps<UseSignaturePadProps>()(props, [
+    createSplitProps<Optional<UseSignaturePadProps, 'id'>>()(props, [
       'id',
       'ids',
       'defaultPaths',

--- a/packages/svelte/src/lib/components/signature-pad/use-signature-pad.svelte.ts
+++ b/packages/svelte/src/lib/components/signature-pad/use-signature-pad.svelte.ts
@@ -1,15 +1,15 @@
 import { useEnvironmentContext } from '$lib/providers/environment'
 import { useLocaleContext } from '$lib/providers/locale'
-import type { Accessor, Optional } from '$lib/types'
+import type { Accessor } from '$lib/types'
 import * as signaturePad from '@zag-js/signature-pad'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/svelte'
 import { type MaybeFunction, runIfFn } from '@zag-js/utils'
 import { useFieldContext } from '../field/index.ts'
 
-export interface UseSignaturePadProps extends Optional<Omit<signaturePad.Props, 'dir' | 'getRootNode'>, 'id'> {}
+export interface UseSignaturePadProps extends Omit<signaturePad.Props, 'dir' | 'getRootNode'> {}
 export interface UseSignaturePadReturn extends Accessor<signaturePad.Api<PropTypes>> {}
 
-export const useSignaturePad = (props?: MaybeFunction<UseSignaturePadProps>) => {
+export const useSignaturePad = (props: MaybeFunction<UseSignaturePadProps>) => {
   const env = useEnvironmentContext()
   const locale = useLocaleContext()
   const field = useFieldContext()

--- a/packages/svelte/src/lib/components/splitter/examples/dynamic-collapsible.svelte
+++ b/packages/svelte/src/lib/components/splitter/examples/dynamic-collapsible.svelte
@@ -8,7 +8,9 @@
 
   const isBelowMd = $derived(rootSize != null && rootSize < 600)
 
+  const id = $props.id()
   const splitter = useSplitter(() => ({
+    id,
     panels: [{ id: 'a', collapsible: isBelowMd, collapsedSize: 5, minSize: 20, maxSize: 40 }, { id: 'b' }],
     defaultSize: [15, 85],
   }))

--- a/packages/svelte/src/lib/components/splitter/splitter-root.svelte
+++ b/packages/svelte/src/lib/components/splitter/splitter-root.svelte
@@ -1,8 +1,9 @@
 <script module lang="ts">
-  import type { Assign, HTMLProps, PolymorphicProps, RefAttribute } from '$lib/types'
+  import type { Assign, HTMLProps, Optional, PolymorphicProps, RefAttribute } from '$lib/types'
   import type { UseSplitterProps } from './use-splitter.svelte.ts'
 
-  export interface SplitterRootBaseProps extends UseSplitterProps, PolymorphicProps<'div'>, RefAttribute {}
+  export interface SplitterRootBaseProps
+    extends Optional<UseSplitterProps, 'id'>, PolymorphicProps<'div'>, RefAttribute {}
   export interface SplitterRootProps extends Assign<HTMLProps<'div'>, SplitterRootBaseProps> {}
 </script>
 

--- a/packages/svelte/src/lib/components/splitter/splitter-split-props.svelte.ts
+++ b/packages/svelte/src/lib/components/splitter/splitter-split-props.svelte.ts
@@ -1,8 +1,9 @@
+import type { Optional } from '$lib/types'
 import { createSplitProps } from '$lib/utils/create-split-props'
 import type { UseSplitterProps } from './use-splitter.svelte.ts'
 
-export function splitSplitterProps<T extends UseSplitterProps>(props: T) {
-  return createSplitProps<UseSplitterProps>()(props, [
+export function splitSplitterProps<T extends Optional<UseSplitterProps, 'id'>>(props: T) {
+  return createSplitProps<Optional<UseSplitterProps, 'id'>>()(props, [
     'defaultSize',
     'id',
     'ids',

--- a/packages/svelte/src/lib/components/splitter/use-splitter.svelte.ts
+++ b/packages/svelte/src/lib/components/splitter/use-splitter.svelte.ts
@@ -1,11 +1,11 @@
 import { useEnvironmentContext } from '$lib/providers/environment'
 import { useLocaleContext } from '$lib/providers/locale'
-import type { Accessor, Optional } from '$lib/types'
+import type { Accessor } from '$lib/types'
 import * as splitter from '@zag-js/splitter'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/svelte'
 import { type MaybeFunction, ensureProps, runIfFn } from '@zag-js/utils'
 
-export interface UseSplitterProps extends Optional<Omit<splitter.Props, 'dir' | 'getRootNode'>, 'id'> {}
+export interface UseSplitterProps extends Omit<splitter.Props, 'dir' | 'getRootNode'> {}
 
 export interface UseSplitterReturn extends Accessor<splitter.Api<PropTypes>> {}
 

--- a/packages/svelte/src/lib/components/steps/steps-root.svelte
+++ b/packages/svelte/src/lib/components/steps/steps-root.svelte
@@ -1,8 +1,8 @@
 <script module lang="ts">
-  import type { Assign, HTMLProps, PolymorphicProps, RefAttribute } from '$lib/types'
+  import type { Assign, HTMLProps, Optional, PolymorphicProps, RefAttribute } from '$lib/types'
   import type { UseStepsProps } from './use-steps.svelte.ts'
 
-  export interface StepsRootBaseProps extends UseStepsProps, PolymorphicProps<'div'>, RefAttribute {}
+  export interface StepsRootBaseProps extends Optional<UseStepsProps, 'id'>, PolymorphicProps<'div'>, RefAttribute {}
   export interface StepsRootProps extends Assign<HTMLProps<'div'>, StepsRootBaseProps> {}
 </script>
 
@@ -17,7 +17,7 @@
   const providedId = $props.id()
 
   const [useStepsProps, localProps] = $derived(
-    createSplitProps<UseStepsProps>()(props, [
+    createSplitProps<Optional<UseStepsProps, 'id'>>()(props, [
       'count',
       'defaultStep',
       'id',

--- a/packages/svelte/src/lib/components/steps/use-steps.svelte.ts
+++ b/packages/svelte/src/lib/components/steps/use-steps.svelte.ts
@@ -1,14 +1,14 @@
 import { useEnvironmentContext } from '$lib/providers/environment'
 import { useLocaleContext } from '$lib/providers/locale'
-import type { Accessor, Optional } from '$lib/types'
+import type { Accessor } from '$lib/types'
 import * as steps from '@zag-js/steps'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/svelte'
 import { type MaybeFunction, runIfFn } from '@zag-js/utils'
 
-export interface UseStepsProps extends Optional<Omit<steps.Props, 'dir' | 'getRootNode'>, 'id'> {}
+export interface UseStepsProps extends Omit<steps.Props, 'dir' | 'getRootNode'> {}
 export interface UseStepsReturn extends Accessor<steps.Api<PropTypes>> {}
 
-export const useSteps = (props?: MaybeFunction<UseStepsProps>) => {
+export const useSteps = (props: MaybeFunction<UseStepsProps>) => {
   const env = useEnvironmentContext()
   const locale = useLocaleContext()
 

--- a/packages/svelte/src/lib/components/switch/switch-root.svelte
+++ b/packages/svelte/src/lib/components/switch/switch-root.svelte
@@ -1,8 +1,9 @@
 <script module lang="ts">
-  import type { Assign, HTMLProps, PolymorphicProps, RefAttribute } from '$lib/types'
+  import type { Assign, HTMLProps, Optional, PolymorphicProps, RefAttribute } from '$lib/types'
   import type { UseSwitchProps } from './use-switch.svelte.ts'
 
-  export interface SwitchRootBaseProps extends UseSwitchProps, PolymorphicProps<'label'>, RefAttribute {}
+  export interface SwitchRootBaseProps
+    extends Optional<UseSwitchProps, 'id'>, PolymorphicProps<'label'>, RefAttribute {}
   export interface SwitchRootProps extends Assign<HTMLProps<'label'>, SwitchRootBaseProps> {}
 </script>
 
@@ -17,7 +18,7 @@
   const providedId = $props.id()
 
   const [useSwitchProps, localProps] = $derived(
-    createSplitProps<UseSwitchProps>()(props, [
+    createSplitProps<Optional<UseSwitchProps, 'id'>>()(props, [
       'checked',
       'defaultChecked',
       'disabled',

--- a/packages/svelte/src/lib/components/switch/use-switch.svelte.ts
+++ b/packages/svelte/src/lib/components/switch/use-switch.svelte.ts
@@ -1,15 +1,15 @@
 import { useEnvironmentContext } from '$lib/providers/environment'
 import { useLocaleContext } from '$lib/providers/locale'
-import type { Accessor, Optional } from '$lib/types'
+import type { Accessor } from '$lib/types'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/svelte'
 import * as zagSwitch from '@zag-js/switch'
 import { type MaybeFunction, runIfFn } from '@zag-js/utils'
 import { useFieldContext } from '../field/index.ts'
 
-export interface UseSwitchProps extends Optional<Omit<zagSwitch.Props, 'dir' | 'getRootNode'>, 'id'> {}
+export interface UseSwitchProps extends Omit<zagSwitch.Props, 'dir' | 'getRootNode'> {}
 export interface UseSwitchReturn extends Accessor<zagSwitch.Api<PropTypes>> {}
 
-export const useSwitch = (props?: MaybeFunction<UseSwitchProps>) => {
+export const useSwitch = (props: MaybeFunction<UseSwitchProps>) => {
   const env = useEnvironmentContext()
   const locale = useLocaleContext()
   const field = useFieldContext()

--- a/packages/svelte/src/lib/components/tabs/tabs-root.svelte
+++ b/packages/svelte/src/lib/components/tabs/tabs-root.svelte
@@ -1,8 +1,9 @@
 <script module lang="ts">
-  import type { Assign, HTMLProps, PolymorphicProps, RefAttribute } from '$lib/types'
+  import type { Assign, HTMLProps, Optional, PolymorphicProps, RefAttribute } from '$lib/types'
   import type { UseTabsProps } from './use-tabs.svelte.ts'
 
-  export interface TabsRootBaseProps extends UseTabsProps, RenderStrategyProps, PolymorphicProps<'div'>, RefAttribute {}
+  export interface TabsRootBaseProps
+    extends Optional<UseTabsProps, 'id'>, RenderStrategyProps, PolymorphicProps<'div'>, RefAttribute {}
   export interface TabsRootProps extends Assign<HTMLProps<'div'>, TabsRootBaseProps> {}
 </script>
 
@@ -26,7 +27,7 @@
 
   const [useTabsProps, localProps] = $derived.by(() => {
     const props = { ...tabsProps, value }
-    return createSplitProps<UseTabsProps>()(props, [
+    return createSplitProps<Optional<UseTabsProps, 'id'>>()(props, [
       'value',
       'onValueChange',
       'onFocusChange',

--- a/packages/svelte/src/lib/components/tabs/use-tabs.svelte.ts
+++ b/packages/svelte/src/lib/components/tabs/use-tabs.svelte.ts
@@ -1,14 +1,14 @@
 import { useEnvironmentContext } from '$lib/providers/environment'
 import { useLocaleContext } from '$lib/providers/locale'
-import type { Accessor, Optional } from '$lib/types'
+import type { Accessor } from '$lib/types'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/svelte'
 import * as tabs from '@zag-js/tabs'
 import { type MaybeFunction, runIfFn } from '@zag-js/utils'
 
-export interface UseTabsProps extends Optional<Omit<tabs.Props, 'dir' | 'getRootNode'>, 'id'> {}
+export interface UseTabsProps extends Omit<tabs.Props, 'dir' | 'getRootNode'> {}
 export interface UseTabsReturn extends Accessor<tabs.Api<PropTypes>> {}
 
-export const useTabs = (props?: MaybeFunction<UseTabsProps>): UseTabsReturn => {
+export const useTabs = (props: MaybeFunction<UseTabsProps>): UseTabsReturn => {
   const env = useEnvironmentContext()
   const locale = useLocaleContext()
 

--- a/packages/svelte/src/lib/components/tags-input/examples/programmatic-control.svelte
+++ b/packages/svelte/src/lib/components/tags-input/examples/programmatic-control.svelte
@@ -4,7 +4,8 @@
   import button from 'styles/button.module.css'
   import styles from 'styles/tags-input.module.css'
 
-  const tagsInput = useTagsInput()
+  const id = $props.id()
+  const tagsInput = useTagsInput({ id })
 </script>
 
 <div class="stack">

--- a/packages/svelte/src/lib/components/tags-input/examples/with-combobox.svelte
+++ b/packages/svelte/src/lib/components/tags-input/examples/with-combobox.svelte
@@ -17,12 +17,16 @@
   })
 
   const uid = $props.id()
+  const tagsInputId = `tags_${uid}`
+  const comboboxId = `combobox_${uid}`
 
   const tagsInput = useTagsInput({
+    id: tagsInputId,
     ids: { input: `input_${uid}`, control: `control_${uid}` },
   })
 
   const comboboxApi = useCombobox({
+    id: comboboxId,
     ids: { input: `input_${uid}`, control: `control_${uid}` },
     get collection() {
       return collection()

--- a/packages/svelte/src/lib/components/tags-input/tags-input-root.svelte
+++ b/packages/svelte/src/lib/components/tags-input/tags-input-root.svelte
@@ -1,8 +1,9 @@
 <script module lang="ts">
-  import type { Assign, HTMLProps, PolymorphicProps, RefAttribute } from '$lib/types'
+  import type { Assign, HTMLProps, Optional, PolymorphicProps, RefAttribute } from '$lib/types'
   import type { UseTagsInputProps } from './use-tags-input.svelte.ts'
 
-  export interface TagsInputRootBaseProps extends UseTagsInputProps, PolymorphicProps<'div'>, RefAttribute {}
+  export interface TagsInputRootBaseProps
+    extends Optional<UseTagsInputProps, 'id'>, PolymorphicProps<'div'>, RefAttribute {}
   export interface TagsInputRootProps extends Assign<HTMLProps<'div'>, TagsInputRootBaseProps> {}
 </script>
 
@@ -21,7 +22,7 @@
   }: TagsInputRootProps = $props()
 
   const [useTagsInputProps, localProps] = $derived(
-    createSplitProps<UseTagsInputProps>()(props, [
+    createSplitProps<Optional<UseTagsInputProps, 'id'>>()(props, [
       'addOnPaste',
       'allowDuplicates',
       'allowOverflow',

--- a/packages/svelte/src/lib/components/tags-input/use-tags-input.svelte.ts
+++ b/packages/svelte/src/lib/components/tags-input/use-tags-input.svelte.ts
@@ -1,15 +1,15 @@
 import { useEnvironmentContext, useLocaleContext } from '$lib/providers'
-import type { Accessor, Optional } from '$lib/types'
+import type { Accessor } from '$lib/types'
 import { runIfFn } from '$lib/utils/run-if-fn'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/svelte'
 import * as tagsInput from '@zag-js/tags-input'
 import { type MaybeFunction, ensureProps } from '@zag-js/utils'
 import { useFieldContext } from '../field/index.ts'
 
-export interface UseTagsInputProps extends Optional<Omit<tagsInput.Props, 'dir' | 'getRootNode'>, 'id'> {}
+export interface UseTagsInputProps extends Omit<tagsInput.Props, 'dir' | 'getRootNode'> {}
 export interface UseTagsInputReturn extends Accessor<tagsInput.Api<PropTypes>> {}
 
-export const useTagsInput = (inProps: MaybeFunction<UseTagsInputProps> = {}): UseTagsInputReturn => {
+export const useTagsInput = (inProps: MaybeFunction<UseTagsInputProps>): UseTagsInputReturn => {
   const props = $derived.by<UseTagsInputProps>(() => {
     const resolvedProps = runIfFn(inProps)
     ensureProps(resolvedProps, ['id'])

--- a/packages/svelte/src/lib/components/toc/examples/root-provider.svelte
+++ b/packages/svelte/src/lib/components/toc/examples/root-provider.svelte
@@ -11,7 +11,8 @@
   ]
 
   let contentEl: HTMLElement | null = $state(null)
-  const toc = useToc({ items, rootMargin: '0px 0px -80% 0px', scrollEl: () => contentEl })
+  const id = $props.id()
+  const toc = useToc({ id, items, rootMargin: '0px 0px -80% 0px', scrollEl: () => contentEl })
 </script>
 
 <Toc.RootProvider class={styles.Root} value={toc}>

--- a/packages/svelte/src/lib/components/toc/toc-root.svelte
+++ b/packages/svelte/src/lib/components/toc/toc-root.svelte
@@ -1,8 +1,9 @@
 <script module lang="ts">
+  import type { Optional } from '$lib/types'
   import type { Assign, HTMLProps, PolymorphicProps, RefAttribute } from '../../types'
   import type { UseTocProps } from './use-toc.svelte'
 
-  export interface TocRootBaseProps extends UseTocProps, PolymorphicProps<'div'>, RefAttribute {}
+  export interface TocRootBaseProps extends Optional<UseTocProps, 'id'>, PolymorphicProps<'div'>, RefAttribute {}
   export interface TocRootProps extends Assign<HTMLProps<'div'>, TocRootBaseProps> {}
 </script>
 
@@ -16,7 +17,7 @@
   const providedId = $props.id()
 
   const [useTocProps, localProps] = $derived(
-    createSplitProps<UseTocProps>()(props, [
+    createSplitProps<Optional<UseTocProps, 'id'>>()(props, [
       'activeIds',
       'autoScroll',
       'defaultActiveIds',

--- a/packages/svelte/src/lib/components/toc/use-toc.svelte.ts
+++ b/packages/svelte/src/lib/components/toc/use-toc.svelte.ts
@@ -1,14 +1,14 @@
 import { useEnvironmentContext } from '$lib/providers/environment'
 import { useLocaleContext } from '$lib/providers/locale'
-import type { Accessor, Optional } from '$lib/types'
+import type { Accessor } from '$lib/types'
 import * as toc from '@zag-js/toc'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/svelte'
 import { type MaybeFunction, runIfFn } from '@zag-js/utils'
 
-export interface UseTocProps extends Optional<Omit<toc.Props, 'dir' | 'getRootNode'>, 'id'> {}
+export interface UseTocProps extends Omit<toc.Props, 'dir' | 'getRootNode'> {}
 export interface UseTocReturn extends Accessor<toc.Api<PropTypes>> {}
 
-export const useToc = (props?: MaybeFunction<UseTocProps>): UseTocReturn => {
+export const useToc = (props: MaybeFunction<UseTocProps>): UseTocReturn => {
   const env = useEnvironmentContext()
   const locale = useLocaleContext()
 

--- a/packages/svelte/src/lib/components/toggle-group/toggle-group-root.svelte
+++ b/packages/svelte/src/lib/components/toggle-group/toggle-group-root.svelte
@@ -1,8 +1,9 @@
 <script module lang="ts">
-  import type { Assign, HTMLProps, PolymorphicProps, RefAttribute } from '$lib/types'
+  import type { Assign, HTMLProps, Optional, PolymorphicProps, RefAttribute } from '$lib/types'
   import type { UseToggleGroupProps } from './use-toggle-group.svelte.ts'
 
-  export interface ToggleGroupRootBaseProps extends UseToggleGroupProps, PolymorphicProps<'div'>, RefAttribute {}
+  export interface ToggleGroupRootBaseProps
+    extends Optional<UseToggleGroupProps, 'id'>, PolymorphicProps<'div'>, RefAttribute {}
   export interface ToggleGroupRootProps extends Assign<HTMLProps<'div'>, ToggleGroupRootBaseProps> {}
 </script>
 
@@ -16,7 +17,7 @@
   let { ref = $bindable(null), value = $bindable<string[]>(), ...props }: ToggleGroupRootProps = $props()
 
   const [useToggleGroupProps, localProps] = $derived(
-    createSplitProps<UseToggleGroupProps>()(props, [
+    createSplitProps<Optional<UseToggleGroupProps, 'id'>>()(props, [
       'defaultValue',
       'deselectable',
       'disabled',

--- a/packages/svelte/src/lib/components/toggle-group/use-toggle-group.svelte.ts
+++ b/packages/svelte/src/lib/components/toggle-group/use-toggle-group.svelte.ts
@@ -1,15 +1,15 @@
 import { useEnvironmentContext } from '$lib/providers/environment'
 import { useLocaleContext } from '$lib/providers/locale'
-import type { Accessor, Optional } from '$lib/types'
+import type { Accessor } from '$lib/types'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/svelte'
 import * as toggleGroup from '@zag-js/toggle-group'
 import { type MaybeFunction, runIfFn } from '@zag-js/utils'
 
-export interface UseToggleGroupProps extends Optional<Omit<toggleGroup.Props, 'dir' | 'getRootNode'>, 'id'> {}
+export interface UseToggleGroupProps extends Omit<toggleGroup.Props, 'dir' | 'getRootNode'> {}
 
 export interface UseToggleGroupReturn extends Accessor<toggleGroup.Api<PropTypes>> {}
 
-export const useToggleGroup = (props: MaybeFunction<UseToggleGroupProps> = {}): UseToggleGroupReturn => {
+export const useToggleGroup = (props: MaybeFunction<UseToggleGroupProps>): UseToggleGroupReturn => {
   const env = useEnvironmentContext()
   const locale = useLocaleContext()
 

--- a/packages/svelte/src/lib/components/tooltip/examples/root-provider.svelte
+++ b/packages/svelte/src/lib/components/tooltip/examples/root-provider.svelte
@@ -3,7 +3,8 @@
   import { Tooltip, useTooltip } from '@ark-ui/svelte/tooltip'
   import styles from 'styles/tooltip.module.css'
 
-  const tooltip = useTooltip()
+  const id = $props.id()
+  const tooltip = useTooltip({ id })
 </script>
 
 <button onclick={() => tooltip().setOpen(true)}>Open</button>

--- a/packages/svelte/src/lib/components/tour/examples/async-step.svelte
+++ b/packages/svelte/src/lib/components/tour/examples/async-step.svelte
@@ -55,7 +55,8 @@
     },
   ]
 
-  const tour = useTour({ steps })
+  const id = $props.id()
+  const tour = useTour({ id, steps })
 </script>
 
 <div class={styles.Root}>

--- a/packages/svelte/src/lib/components/tour/examples/basic.svelte
+++ b/packages/svelte/src/lib/components/tour/examples/basic.svelte
@@ -55,7 +55,8 @@
     },
   ]
 
-  const tour = useTour({ steps })
+  const id = $props.id()
+  const tour = useTour({ id, steps })
 </script>
 
 <div class={styles.Root}>

--- a/packages/svelte/src/lib/components/tour/examples/events.svelte
+++ b/packages/svelte/src/lib/components/tour/examples/events.svelte
@@ -44,7 +44,9 @@
     logs = [...logs, message]
   }
 
+  const id = $props.id()
   const tour = useTour({
+    id,
     steps,
     onStepChange(details) {
       addLog(`Step changed: ${details.stepId}`)

--- a/packages/svelte/src/lib/components/tour/examples/keyboard-navigation.svelte
+++ b/packages/svelte/src/lib/components/tour/examples/keyboard-navigation.svelte
@@ -38,7 +38,8 @@
     },
   ]
 
-  const tour = useTour({ steps, keyboardNavigation: true })
+  const id = $props.id()
+  const tour = useTour({ id, steps, keyboardNavigation: true })
 </script>
 
 <div class={styles.Root}>

--- a/packages/svelte/src/lib/components/tour/examples/mixed-types.svelte
+++ b/packages/svelte/src/lib/components/tour/examples/mixed-types.svelte
@@ -44,7 +44,8 @@
     },
   ]
 
-  const tour = useTour({ steps })
+  const id = $props.id()
+  const tour = useTour({ id, steps })
 </script>
 
 <div class={styles.Root}>

--- a/packages/svelte/src/lib/components/tour/examples/progress-bar.svelte
+++ b/packages/svelte/src/lib/components/tour/examples/progress-bar.svelte
@@ -49,7 +49,8 @@
     },
   ]
 
-  const tour = useTour({ steps })
+  const id = $props.id()
+  const tour = useTour({ id, steps })
 </script>
 
 <div class={styles.Root}>

--- a/packages/svelte/src/lib/components/tour/examples/skip-tour.svelte
+++ b/packages/svelte/src/lib/components/tour/examples/skip-tour.svelte
@@ -42,7 +42,8 @@
     },
   ]
 
-  const tour = useTour({ steps })
+  const id = $props.id()
+  const tour = useTour({ id, steps })
 </script>
 
 <div class={styles.Root}>

--- a/packages/svelte/src/lib/components/tour/examples/wait-for-click.svelte
+++ b/packages/svelte/src/lib/components/tour/examples/wait-for-click.svelte
@@ -61,7 +61,8 @@
     },
   ]
 
-  const tour = useTour({ steps })
+  const id = $props.id()
+  const tour = useTour({ id, steps })
 </script>
 
 <div class={styles.Root}>

--- a/packages/svelte/src/lib/components/tour/examples/wait-for-element.svelte
+++ b/packages/svelte/src/lib/components/tour/examples/wait-for-element.svelte
@@ -57,7 +57,8 @@
     items = [...items, `Item ${items.length + 1}`]
   }
 
-  const tour = useTour({ steps })
+  const id = $props.id()
+  const tour = useTour({ id, steps })
 </script>
 
 <div class={styles.Root}>

--- a/packages/svelte/src/lib/components/tour/examples/wait-for-input.svelte
+++ b/packages/svelte/src/lib/components/tour/examples/wait-for-input.svelte
@@ -68,7 +68,8 @@
     },
   ]
 
-  const tour = useTour({ steps })
+  const id = $props.id()
+  const tour = useTour({ id, steps })
 </script>
 
 <div class={styles.Root}>

--- a/packages/svelte/src/lib/components/tour/use-tour.svelte.ts
+++ b/packages/svelte/src/lib/components/tour/use-tour.svelte.ts
@@ -1,14 +1,14 @@
 import { useEnvironmentContext, useLocaleContext } from '$lib/providers'
-import type { Accessor, Optional } from '$lib/types'
+import type { Accessor } from '$lib/types'
 import { type PropTypes, normalizeProps, useMachine } from '@zag-js/svelte'
 import * as tour from '@zag-js/tour'
 import { type MaybeFunction, runIfFn } from '@zag-js/utils'
 
-export interface UseTourProps extends Optional<Omit<tour.Props, 'dir' | 'getRootNode'>, 'id'> {}
+export interface UseTourProps extends Omit<tour.Props, 'dir' | 'getRootNode'> {}
 
 export interface UseTourReturn extends Accessor<tour.Api<PropTypes>> {}
 
-export const useTour = (props: MaybeFunction<UseTourProps> = {}): UseTourReturn => {
+export const useTour = (props: MaybeFunction<UseTourProps>): UseTourReturn => {
   const env = useEnvironmentContext() ?? {}
   const locale = useLocaleContext() ?? {}
 

--- a/packages/svelte/src/lib/providers/hotkeys/use-hotkeys.svelte.ts
+++ b/packages/svelte/src/lib/providers/hotkeys/use-hotkeys.svelte.ts
@@ -1,8 +1,8 @@
-import { type CommandDefinition, type HotkeyStore, type ParsedHotkey, parseHotkey } from '@zag-js/hotkeys'
+import { type CommandDefinition, type HotkeyStore, type Platform, normalizeHotkey } from '@zag-js/hotkeys'
 import { onDestroy } from 'svelte'
 import { type MaybeFunction, isEqual, runIfFn, warn } from '@zag-js/utils'
 import { type UseHotkeyStoreProps, useHotkeyStore } from './use-hotkey-store.svelte.ts'
-import { type Platform, usePlatform } from './use-platform.svelte.ts'
+import { usePlatform } from './use-platform.svelte.ts'
 
 export interface UseHotkeysCommand extends Omit<CommandDefinition, 'id'> {
   /**
@@ -31,7 +31,7 @@ export interface UseHotkeysProps extends UseHotkeyStoreProps {
 const createInstanceId = () => `hotkeys:${Math.random().toString(36).slice(2, 10)}`
 
 interface Registration {
-  hotkey: ParsedHotkey
+  hotkey: string
   scopes: CommandDefinition['scopes']
   label: string | undefined
   description: string | undefined
@@ -50,7 +50,7 @@ const warnOnForeignId = (store: HotkeyStore, id: string) => {
 }
 
 const toRegistration = (command: UseHotkeysCommand, platform: Platform): Registration => ({
-  hotkey: parseHotkey(command.hotkey, platform),
+  hotkey: normalizeHotkey(command.hotkey, platform),
   scopes: command.scopes,
   label: command.label,
   description: command.description,

--- a/packages/svelte/src/lib/providers/hotkeys/use-platform.svelte.ts
+++ b/packages/svelte/src/lib/providers/hotkeys/use-platform.svelte.ts
@@ -1,10 +1,8 @@
-import { getPlatform, isAndroid, isApple } from '@zag-js/dom-query'
+import { isApple, isLinux } from '@zag-js/dom-query'
 
-// TODO(zag-bump): once @zag-js/hotkeys > 1.43.1 is released, import `Platform` from it and
-// replace the inline linux check with `isLinux` from @zag-js/dom-query.
-export type Platform = 'mac' | 'windows' | 'linux'
+import type { Platform } from '@zag-js/hotkeys'
 
-const isLinux = () => /^Linux|^CrOS/i.test(getPlatform()) && !isAndroid()
+export type { Platform }
 
 const detect = (): Platform => {
   if (isApple()) return 'mac'

--- a/packages/vue/src/providers/hotkeys/use-hotkeys.ts
+++ b/packages/vue/src/providers/hotkeys/use-hotkeys.ts
@@ -1,8 +1,8 @@
-import { type CommandDefinition, type HotkeyStore, type ParsedHotkey, parseHotkey } from '@zag-js/hotkeys'
+import { type CommandDefinition, type HotkeyStore, type Platform, normalizeHotkey } from '@zag-js/hotkeys'
 import { isEqual, warn } from '@zag-js/utils'
 import { type MaybeRef, onUnmounted, toValue, useId, watchEffect } from 'vue'
 import { type UseHotkeyStoreProps, useHotkeyStore } from './use-hotkey-store.ts'
-import { type Platform, usePlatform } from './use-platform.ts'
+import { usePlatform } from './use-platform.ts'
 
 export interface UseHotkeysCommand extends Omit<CommandDefinition, 'id'> {
   /**
@@ -25,7 +25,7 @@ export interface UseHotkeysProps extends UseHotkeyStoreProps {
 }
 
 interface Registration {
-  hotkey: ParsedHotkey
+  hotkey: string
   scopes: CommandDefinition['scopes']
   label: string | undefined
   description: string | undefined
@@ -44,7 +44,7 @@ const warnOnForeignId = (store: HotkeyStore, id: string) => {
 }
 
 const toRegistration = (command: UseHotkeysCommand, platform: Platform): Registration => ({
-  hotkey: parseHotkey(command.hotkey, platform),
+  hotkey: normalizeHotkey(command.hotkey, platform),
   scopes: command.scopes,
   label: command.label,
   description: command.description,

--- a/packages/vue/src/providers/hotkeys/use-platform.ts
+++ b/packages/vue/src/providers/hotkeys/use-platform.ts
@@ -1,11 +1,9 @@
-import { getPlatform, isAndroid, isApple } from '@zag-js/dom-query'
+import { isApple, isLinux } from '@zag-js/dom-query'
 import { type Ref, onMounted, ref } from 'vue'
 
-// TODO(zag-bump): once @zag-js/hotkeys > 1.43.1 is released, import `Platform` from it and
-// replace the inline linux check with `isLinux` from @zag-js/dom-query.
-export type Platform = 'mac' | 'windows' | 'linux'
+import type { Platform } from '@zag-js/hotkeys'
 
-const isLinux = () => /^Linux|^CrOS/i.test(getPlatform()) && !isAndroid()
+export type { Platform }
 
 const detect = (): Platform => {
   if (isApple()) return 'mac'


### PR DESCRIPTION
> [!WARNING]
> Draft. One upstream blocker left — see **What's left** at the bottom.

## 📝 Description

Moves the monorepo to zag `2.0.0-next.2`, removes the three shims it makes unnecessary, and fixes the Svelte id bug the bump exposed.

## ⛳️ Current behavior

Ark is pinned to `2.0.0-next.1` and carries three `TODO(zag-bump)` stand-ins for APIs the v2 line was missing.

Separately, the Svelte hooks never passed an `id` to their machine. Two instances on a page rendered the same element ids:

```
instance1 = ["undefined:trigger", "undefined:content"]
instance2 = ["undefined:trigger", "undefined:content"]
```

This was always broken; it stayed invisible because `useMachine` took `Partial<T["props"]>`, so the missing `id` never showed up as a type error.

## 🚀 New behavior

**Shims removed.** Verified against next.2 before deleting each one:

```
parseHotkey('shift')  → { keys: [], shift: true }   (was { keys: ['shift'], shift: false })
isPressed('shift')    → true                        (was false)
disabled → enabled    → before 0, after 1           (was 0 and 0)
```

- `@zag-js/hotkeys` — `normalizeHotkey` restored, `Platform` re-exported from the index
- `@zag-js/presence` — `onEnterComplete` is called by the machine now

**Svelte ids.** `useMachine` moved from `Partial<T["props"]>` to `InputProps<T>`, which turned the missing `id` into 36 type errors across 36 composables. Svelte can only mint an id inside a component — `$props.id()` is not callable from `.svelte.ts`, `props_id` is internal-only, and a module counter is not SSR-safe — so the hooks now require one:

```diff
- const collapsible = useCollapsible()
+ const id = $props.id()
+ const collapsible = useCollapsible({ id })
```

Components are unchanged for consumers. `<Collapsible.Root>` still generates its own id and `id` stays optional on it, via `Optional<UseCollapsibleProps, 'id'>` on the root props and the split-props helpers.

Verified the actual fix, not just the types — four instances across both the hook path and the component path:

```
["c1:content", "c2:content", "c3:content", "c4:content"]
```

Two things worth knowing for anyone doing this elsewhere: `$props.id()` must be its own variable declaration (it cannot be inlined into a call), and it may only be called **once per component** — `tags-input/with-combobox` hosts two machines and derives both ids from a single call.

`toggle` is untouched: its machine has no `id` at all.

## 🧩 Frameworks

- [x] React
- [x] Solid
- [x] Svelte
- [x] Vue

## 💣 Is this a breaking change (Yes/No):

Yes, for Svelte consumers calling the `useX` hooks directly. They must pass an `id`. This converts a silent runtime bug — duplicate element ids, broken `aria-controls` — into a compile error. Component users are unaffected.

## ✅ Checklist

- [x] Added a changeset for user-facing changes
- [x] Added or updated tests
- [ ] Added an example for any new prop or part
- [x] Updated the docs

## 📝 What's left before this can merge

**Blocker — upstream.** `@zag-js/select@2.0.0-next.2` throws on highlight:

```js
// select.machine.mjs:839, announceHighlightedItem
const formatter = prop("translations").itemAnnouncement
→ TypeError: Cannot read properties of undefined (reading 'itemAnnouncement')
```

`popover` and `toast` dropped the same default but only read it in `connect`, so they are unaffected.

**Not a blocker.** Vue color-picker renders `hsla()` where the test expects hex, a pre-existing cross-framework parity issue, unrelated to the bump.