### PR TITLE
fix(deps): stop the popper patch corrupting its type declarations

### DIFF
--- a/patches/@zag-js%2Fpopper@2.0.0-next.2.patch
+++ b/patches/@zag-js%2Fpopper@2.0.0-next.2.patch
@@ -66,33 +66,3 @@ index 989b43436b22b1e215d631d2b18ce31bc47b766b..ef0501476ee7e715a0757cc5f18454af
        zIndexComputed = false;
      }
      const reference = resolveReference();
-diff --git a/dist/types.d.mts b/dist/types.d.mts
-index 16688ff05d03dcd60f8f33560adb27f13becd267..9504467b9f6dd9e184a5d8083ba7241b8315a749 100644
---- a/dist/types.d.mts
-+++ b/dist/types.d.mts
-@@ -114,6 +114,10 @@ interface PositioningOptions {
-      * Useful when you want to use a different element as the anchor.
-      */
-     getAnchorElement?: (() => HTMLElement | VirtualElement | null) | undefined;
-+    /**
-+     * Function that returns the arrow element.
-+     */
-+    getArrowElement?: (() => HTMLElement | null) | undefined;
-     /**
-      *  Function that returns the anchor rect
-      * @deprecated Use `getAnchorElement` instead
-diff --git a/dist/types.d.ts b/dist/types.d.ts
-index 16688ff05d03dcd60f8f33560adb27f13becd267..9504467b9f6dd9e184a5d8083ba7241b8315a749 100644
---- a/dist/types.d.ts
-+++ b/dist/types.d.ts
-@@ -114,6 +114,10 @@ interface PositioningOptions {
-      * Useful when you want to use a different element as the anchor.
-      */
-     getAnchorElement?: (() => HTMLElement | VirtualElement | null) | undefined;
-+    /**
-+     * Function that returns the arrow element.
-+     */
-+    getArrowElement?: (() => HTMLElement | null) | undefined;
-     /**
-      *  Function that returns the anchor rect
-      * @deprecated Use `getAnchorElement` instead


### PR DESCRIPTION
## 📝 Description

`v6`'s Typecheck job is red with 24 `TS1434` errors, and they are not in Ark's source — they are in `@zag-js/popper`'s type declarations, corrupted by our own patch.

## ⛳️ Current behavior

```
node_modules/.bun/@zag-js+popper@2.0.0-next.2/.../dist/types.d.mts(121,30): error TS1434: Unexpected keyword or identifier
```

The patch adds `getArrowElement` to `dist/types.d.ts` and `dist/types.d.mts`. Applied, the hunk lands inside the jsdoc block above `getAnchorElement`:

```ts
    /**
    /**
     * Function that returns the arrow element.
     */
    getArrowElement?: (() => HTMLElement | null) | undefined;
     * Function that returns the anchor element.
     * Useful when you want to use a different element as the anchor.
     */
    getAnchorElement?: (() => HTMLElement | VirtualElement | null) | undefined;
```

Two `/**` opens, and the tail of the original comment is left outside it — so the parser reads prose as code. That is the whole of the 24 errors.

The patch text is not at fault. Its context lines match the pristine package byte for byte, and I checked against `npm pack @zag-js/popper@2.0.0-next.2` to be sure. The hunk simply lands in the wrong place when applied, which makes this the applier rather than the diff.

## 🚀 New behavior

The two type hunks are dropped. Ark never references `getArrowElement` anywhere in its source, so they were only ever completeness, and they are the only part that corrupts.

The two `dist/get-placement.{js,mjs}` hunks are kept, so the arrow-element caching behaviour is untouched: `cachedArrowEl` is still there after install, and the module still parses.

| | before | after |
| --- | --- | --- |
| React | ✅ | ✅ |
| Solid | ✅ | ✅ |
| Vue | ✅ | ✅ |
| Svelte | ❌ 41 | ❌ 41 |

React, Solid and Vue were the ones failing on the popper errors and are clean now. Svelte's 41 are a different problem — see below.

## 🧩 Frameworks

- [ ] React
- [ ] Solid
- [ ] Svelte
- [ ] Vue
- [x] Not framework-specific

## 💣 Is this a breaking change (Yes/No):

No. Dropping a type-only addition Ark does not use.

## ✅ Checklist

- [ ] Added a changeset for user-facing changes
- [ ] Added or updated tests
- [ ] Added an example for any new prop or part
- [ ] Updated the docs

No changeset: this changes a patch file, not a published package.

## 📝 Additional information

**This does not make `v6` green on its own.** Svelte still has 41 errors, because `chore: pin @zag-js packages to 2.0.0-next.2` landed the bump without the Svelte half of it. `next.2` changed `useMachine` from `Partial<T["props"]>` to `InputProps<T>`, which makes `id` required, and Svelte's hooks never passed one. [#4019](https://github.com/chakra-ui/ark/pull/4019) is what fixes that.

**Worth knowing for the next patch.** Only `popper` patches type declarations; `menu`, `tooltip`, `tree-view` and `virtualizer` are all JS-only and apply correctly. If a future patch needs a type change, a local `declare module` augmentation in Ark avoids this failure mode entirely.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61675260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/chakra/-/pull-requests/chakra-ui/ark/4026"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge because it removes the declaration corruption without introducing a reachable contract or runtime regression.

<details><summary><h3>Summary</h3></summary>

- Removes modifications to `dist/types.d.ts` and `dist/types.d.mts`.
- Keeps the existing CommonJS and ESM runtime patches intact.
</details>

<!-- /greptile_comment -->