### PR TITLE
fix(svelte): let a part compose into another part's render snippet

### DIFF
--- a/.changeset/svelte-props-fn-id.md
+++ b/.changeset/svelte-props-fn-id.md
@@ -1,0 +1,16 @@
+---
+'@ark-ui/svelte': patch
+---
+
+Fix composing one part inside another part's `render` snippet.
+
+The props function was typed as returning Svelte's `HTMLAttributes`, whose `id` is `string | null`. Ark parts take
+`string | undefined`, so spreading the props into a part did not typecheck:
+
+```svelte
+<Tooltip.Trigger>
+  {#snippet render(props)}
+    <Checkbox.Root {...props({ class: styles.Root })}>
+```
+
+The factory merges the machine's props, where `id` is always a string, so the nullable type was never accurate.

--- a/packages/svelte/src/lib/types.ts
+++ b/packages/svelte/src/lib/types.ts
@@ -6,7 +6,9 @@ export type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>
 export type Accessor<T> = () => T
 
 export type HTMLTag = keyof SvelteHTMLElements
-export type PropsFn<T extends HTMLTag> = (props?: HTMLProps<T>) => HTMLAttributes<HTMLElement>
+export type PropsFn<T extends HTMLTag> = (props?: HTMLProps<T>) => PartProps
+
+export type PartProps = Omit<HTMLAttributes<HTMLElement>, 'id'> & { id?: string | undefined }
 
 export type HTMLProps<T extends HTMLTag> = SvelteHTMLElements[T]
 


### PR DESCRIPTION
## 📝 Description

`v6`'s Svelte typecheck fails on two example files. The reported error is "Expression produces a union type that is too complex to represent", which is a symptom — the actual cause is one nullable property.

## ⛳️ Current behavior

```
src/lib/components/avatar/examples/avatar-stack.svelte 32:22
src/lib/components/tooltip/examples/with-checkbox.svelte 13:20

  Types of property 'id' are incompatible.
    Type 'string | null | undefined' is not assignable to type 'string | undefined'.
      Type 'null' is not assignable to type 'string | undefined'.
```

Both files do the same thing — compose one part inside another part's `render` snippet:

```svelte
<Tooltip.Trigger>
  {#snippet render(props)}
    <Checkbox.Root {...props({ class: styles.Root })}>
```

`PropsFn` was typed as returning Svelte's `HTMLAttributes`, whose `id` is `string | null`. Ark parts take `string | undefined`. So spreading the props into a part does not typecheck — and that is the composition pattern the `render` snippet exists for.

## 🚀 New behavior

```diff
- export type PropsFn<T extends HTMLTag> = (props?: HTMLProps<T>) => HTMLAttributes<HTMLElement>
+ export type PropsFn<T extends HTMLTag> = (props?: HTMLProps<T>) => PartProps
+
+ export type PartProps = Omit<HTMLAttributes<HTMLElement>, 'id'> & { id?: string | undefined }
```

The factory merges the machine's props, where `id` is always a string, so the nullable type was never accurate — it came from `HTMLAttributes` rather than from anything the factory can actually produce.

One type change clears all four errors.

## 🧩 Frameworks

- [ ] React
- [ ] Solid
- [x] Svelte
- [ ] Vue

## 💣 Is this a breaking change (Yes/No):

No. It narrows a type to what the factory already returns. Passing `id={null}` to a part was never meaningful.

## ✅ Checklist

- [x] Added a changeset for user-facing changes
- [ ] Added or updated tests
- [ ] Added an example for any new prop or part
- [ ] Updated the docs

No new test: the failure is type-level, so a runtime test cannot catch a regression. The two examples are the guard — if `PropsFn` widens again, typecheck fails on them exactly as it does today.

## 📝 Additional information

Verified on top of #4019:

```
react   typecheck exit=0
solid   typecheck exit=0
vue     typecheck exit=0
svelte  typecheck exit=0   (was 4 errors)
svelte  tests 10 files, 0 failures
```

This is the last typecheck failure on `v6`. What remains is the 5 select tests, which are fixed on zag's `v2` and land with next.3.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61682136"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/chakra/-/pull-requests/chakra-ui/ark/4027"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The pull request appears safe to merge with no actionable defects identified.

<details><summary><h3>Summary</h3></summary>

- Introduces `PartProps`, based on Svelte HTML attributes but with `id?: string | undefined`.
- Uses `PartProps` as the return type of `PropsFn`.
- Documents that the correction enables one Ark part to compose into another part’s render snippet.
</details>

<!-- /greptile_comment -->