### PR TITLE
docs(react): show how to read a part's state in render

### DIFF
--- a/packages/react/src/components/popover/examples/render-state.tsx
+++ b/packages/react/src/components/popover/examples/render-state.tsx
@@ -1,0 +1,18 @@
+import { Popover } from '@ark-ui/react/popover'
+import { ChevronDownIcon, ChevronUpIcon } from 'lucide-react'
+
+export const RenderState = () => (
+  <Popover.Root>
+    <Popover.Trigger
+      render={(props, state) => (
+        <button type="button" {...props}>
+          {state.open ? 'Close' : 'Open'} Popover
+          {state.open ? <ChevronUpIcon /> : <ChevronDownIcon />}
+        </button>
+      )}
+    />
+    <Popover.Positioner>
+      <Popover.Content>Content</Popover.Content>
+    </Popover.Positioner>
+  </Popover.Root>
+)

--- a/packages/vue/src/components/popover/examples/render-state.vue
+++ b/packages/vue/src/components/popover/examples/render-state.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+import { Popover } from '@ark-ui/vue/popover'
+import { ChevronDownIcon, ChevronUpIcon } from 'lucide-vue-next'
+</script>
+
+<template>
+  <Popover.Root>
+    <Popover.Trigger #render="{ props, state }">
+      <button type="button" v-bind="props">
+        {{ state.open ? 'Close' : 'Open' }} Popover
+        <ChevronUpIcon v-if="state.open" />
+        <ChevronDownIcon v-else />
+      </button>
+    </Popover.Trigger>
+    <Popover.Positioner>
+      <Popover.Content>Content</Popover.Content>
+    </Popover.Positioner>
+  </Popover.Root>
+</template>

--- a/packages/vue/src/components/popover/popover.stories.ts
+++ b/packages/vue/src/components/popover/popover.stories.ts
@@ -11,6 +11,7 @@ import MultipleTriggersExample from './examples/multiple-triggers.vue'
 import NestedExample from './examples/nested.vue'
 import PositioningExample from './examples/positioning.vue'
 import RenderExample from './examples/render.vue'
+import RenderStateExample from './examples/render-state.vue'
 import RootProviderExample from './examples/root-provider.vue'
 import SameWidthExample from './examples/same-width.vue'
 import WithDialogExample from './examples/with-dialog.vue'
@@ -94,6 +95,13 @@ export const Positioning = {
 export const Render = {
   render: () => ({
     components: { Component: RenderExample },
+    template: '<Component />',
+  }),
+}
+
+export const RenderState = {
+  render: () => ({
+    components: { Component: RenderStateExample },
     template: '<Component />',
   }),
 }

--- a/website/src/content/pages/guides/composition.mdx
+++ b/website/src/content/pages/guides/composition.mdx
@@ -25,6 +25,20 @@ Each framework spells this the way that framework composes:
 
 The capability is the same in all four: each one hands you the part's props to apply, and the part's state.
 
+## Reading the part's state
+
+The function form receives the part's state alongside its props, so your element can render from what the machine knows
+rather than from a CSS attribute selector.
+
+<ExampleCode id="render-state" component="popover" />
+
+`Popover.Trigger` gives you `open`, `current` and `value`. Each part publishes its own shape — `Checkbox.Root` has
+`checked` and `indeterminate`, `Accordion.Item` has `expanded` and `focused` — and the type comes with it, so
+`state.open` is checked rather than guessed.
+
+This is the difference between `render` and `asChild`. `asChild` could only place your element; `render` tells it what
+the part is doing.
+
 ## The asChild Prop
 
 `asChild` does the same job by wrapping the element as a child instead of passing it to `render`.

--- a/website/src/lib/example-registry.ts
+++ b/website/src/lib/example-registry.ts
@@ -399,6 +399,7 @@ import * as Popover_Modal from '@examples/popover/examples/modal'
 import * as Popover_MultipleTriggers from '@examples/popover/examples/multiple-triggers'
 import * as Popover_Nested from '@examples/popover/examples/nested'
 import * as Popover_Positioning from '@examples/popover/examples/positioning'
+import * as Popover_RenderState from '@examples/popover/examples/render-state'
 import * as Popover_Render from '@examples/popover/examples/render'
 import * as Popover_RootProvider from '@examples/popover/examples/root-provider'
 import * as Popover_SameWidth from '@examples/popover/examples/same-width'
@@ -1044,6 +1045,7 @@ const exampleModules: Record<string, ExampleModule> = {
   'popover/multiple-triggers': Popover_MultipleTriggers,
   'popover/nested': Popover_Nested,
   'popover/positioning': Popover_Positioning,
+  'popover/render-state': Popover_RenderState,
   'popover/render': Popover_Render,
   'popover/root-provider': Popover_RootProvider,
   'popover/same-width': Popover_SameWidth,


### PR DESCRIPTION
> [!NOTE]
> Stacked on #4023, which is where the state forwarding lives. Base retargets to `v6` once that lands.

## 📝 Description

#4023 gives `render={(props, state) => ...}` a real second argument across 137 parts, but ships no example and no page that mentions it. This documents it.

## ⛳️ Current behavior

`state` is undocumented. The composition guide says the render form "hands you the part's props to apply, and the part's state", and then never shows the state half. There is no example of it in any framework.

## 🚀 New behavior

A `render-state` example on `Popover.Trigger`, the same part the guide already uses for `render`:

```tsx
<Popover.Trigger
  render={(props, state) => (
    <button type="button" {...props}>
      {state.open ? 'Close' : 'Open'} Popover
      {state.open ? <ChevronUpIcon /> : <ChevronDownIcon />}
    </button>
  )}
/>
```

Plus a **Reading the part's state** section in the composition guide, which makes the point the feature exists for: the element renders from what the machine knows rather than from a CSS attribute selector. That is the difference between `render` and `asChild` — `asChild` could only place your element, `render` tells it what the part is doing.

## 🧩 Frameworks

- [x] React
- [ ] Solid
- [x] Vue
- [ ] Svelte

React and Vue are the two that forward state today — Vue landed in d6042f5. Solid and Svelte fall back to "Example not found" in their code tab until their own forwarding lands. That is not a new failure mode: 44 of the 622 examples are already partial, most of them React-only.

## 💣 Is this a breaking change (Yes/No):

No.

## ✅ Checklist

- [ ] Added a changeset for user-facing changes
- [ ] Added or updated tests
- [x] Added an example for any new prop or part
- [x] Updated the docs

No changeset: examples and a guide page, no package behaviour. Covered by the test in #4023.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61710876"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/chakra/-/pull-requests/chakra-ui/ark/4028"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge with no actionable defects identified.

<details><summary><h3>Summary</h3></summary>

- Adds Popover render-state examples for React and Vue.
- Registers the React example with the documentation website and the Vue example with Storybook.
- Extends the composition guide with state-field examples and a comparison between `render` and `asChild`.
</details>

<!-- /greptile_comment -->