### PR TITLE
fix(deps): make popper find the arrow after the data-part rename

### DIFF
--- a/packages/react/src/components/popover/tests/arrow.test.tsx
+++ b/packages/react/src/components/popover/tests/arrow.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react'
+import user from '@testing-library/user-event'
+import { Popover } from '../index.ts'
+
+const ComponentUnderTest = () => (
+  <Popover.Root>
+    <Popover.Trigger>Open</Popover.Trigger>
+    <Popover.Positioner>
+      <Popover.Content>
+        <Popover.Arrow data-testid="arrow">
+          <Popover.ArrowTip />
+        </Popover.Arrow>
+        Content
+      </Popover.Content>
+    </Popover.Positioner>
+  </Popover.Root>
+)
+
+describe('Popover / arrow', () => {
+  it('should position the arrow that is actually rendered', async () => {
+    render(<ComponentUnderTest />)
+    await user.click(screen.getByRole('button', { name: 'Open' }))
+
+    const arrow = await screen.findByTestId('arrow')
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    // popper writes the resolved offsets onto the arrow it was given, so an
+    // unpositioned arrow means popper never found this element
+    expect(arrow.style.left || arrow.style.top).toBeTruthy()
+  })
+})

--- a/packages/react/src/components/popover/tests/arrow.test.tsx
+++ b/packages/react/src/components/popover/tests/arrow.test.tsx
@@ -1,31 +1,41 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import user from '@testing-library/user-event'
+import { Arrow as ComponentUnderTest } from '../examples/arrow.tsx'
 import { Popover } from '../index.ts'
 
-const ComponentUnderTest = () => (
+const Decoy = () => (
   <Popover.Root>
     <Popover.Trigger>Open</Popover.Trigger>
     <Popover.Positioner>
       <Popover.Content>
-        <Popover.Arrow data-testid="arrow">
+        <div data-popover-arrow="another-overlay" data-testid="other-arrow" />
+        <Popover.Arrow data-testid="own-arrow">
           <Popover.ArrowTip />
         </Popover.Arrow>
-        Content
       </Popover.Content>
     </Popover.Positioner>
   </Popover.Root>
 )
 
+const arrowEl = () => document.querySelector<HTMLElement>('[data-popover-arrow]')
 describe('Popover / arrow', () => {
-  it('should position the arrow that is actually rendered', async () => {
+  it('should position the rendered arrow', async () => {
     render(<ComponentUnderTest />)
+    await user.click(screen.getByRole('button', { name: 'Click Me' }))
+
+    await waitFor(() => expect(arrowEl()).toBeInTheDocument())
+    await waitFor(() => {
+      const arrow = arrowEl()
+      expect(arrow?.style.left || arrow?.style.top).toBeTruthy()
+    })
+  })
+
+  it('should ignore an arrow belonging to another overlay', async () => {
+    render(<Decoy />)
     await user.click(screen.getByRole('button', { name: 'Open' }))
 
-    const arrow = await screen.findByTestId('arrow')
-    await new Promise((resolve) => setTimeout(resolve, 50))
-
-    // popper writes the resolved offsets onto the arrow it was given, so an
-    // unpositioned arrow means popper never found this element
-    expect(arrow.style.left || arrow.style.top).toBeTruthy()
+    const own = await screen.findByTestId('own-arrow')
+    await waitFor(() => expect(own.style.left || own.style.top).toBeTruthy())
+    expect(screen.getByTestId('other-arrow').style.left).toBe('')
   })
 })

--- a/patches/@zag-js%2Fpopper@2.0.0-next.2.patch
+++ b/patches/@zag-js%2Fpopper@2.0.0-next.2.patch
@@ -1,8 +1,31 @@
+diff --git a/node_modules/@zag-js/popper/.bun-tag-327300fd8a2c8f51 b/.bun-tag-327300fd8a2c8f51
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/node_modules/@zag-js/popper/.bun-tag-834d0f706a7e8e9 b/.bun-tag-834d0f706a7e8e9
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
 diff --git a/dist/get-placement.js b/dist/get-placement.js
-index eb3576bff199a21ac5318b1e91f29e072d5e8aa5..34298a6e1bbd2b7fc51748d04be8b490ea493161 100644
+index c23ec8948b751cb15bcd82147f9cdf4ffbb70e46..6a25cb21dd8bf9370efae545ade06fb7a995b5be 100644
 --- a/dist/get-placement.js
 +++ b/dist/get-placement.js
-@@ -203,14 +203,15 @@ function getPlacementImpl(referenceOrVirtual, floatingOrVirtual, opts = {}) {
+@@ -56,6 +56,16 @@ function resolveBoundaryOption(boundary) {
+   if (boundary === "clipping-ancestors") return "clippingAncestors";
+   return boundary;
+ }
++function findArrowEl(floating) {
++  if (!floating) return null;
++  const nodes = floating.querySelectorAll("*");
++  for (const node of nodes) {
++    for (const attr of node.attributes) {
++      if (attr.name.startsWith("data-") && attr.name.endsWith("-arrow")) return node;
++    }
++  }
++  return null;
++}
+ function getArrowMiddleware(arrowElement, doc, opts) {
+   const element = arrowElement || doc.createElement("div");
+   return (0, import_dom.arrow)({ element, padding: opts.arrowPadding });
+@@ -203,14 +213,15 @@ function getPlacementImpl(referenceOrVirtual, floatingOrVirtual, opts = {}) {
    const options = Object.assign({}, defaultOptions, opts);
    let middleware = [];
    let cachedMiddlewareFloating = null;
@@ -19,24 +42,42 @@ index eb3576bff199a21ac5318b1e91f29e072d5e8aa5..34298a6e1bbd2b7fc51748d04be8b490
 -    const arrowEl = floating.querySelector("[data-part=arrow]");
      restoreArrowStyles = options.restoreStyles ? createStyleCleanup(arrowEl, arrowStyleProps) : void 0;
      middleware = [
-       getOffsetMiddleware(arrowEl, options),
-@@ -254,8 +255,9 @@ function getPlacementImpl(referenceOrVirtual, floatingOrVirtual, opts = {}) {
+       ...options.middleware ?? [],
+@@ -254,9 +265,9 @@ function getPlacementImpl(referenceOrVirtual, floatingOrVirtual, opts = {}) {
+   async function updatePosition() {
      syncAutoUpdateObservers();
      const floating = resolveFloating();
-     if (!floating) return;
+-    if (!floating) return;
 -    if (floating !== cachedMiddlewareFloating) {
 -      rebuildMiddlewareForFloating(floating);
-+    const arrowEl = options.getArrowElement?.() ?? null;
++    const arrowEl = options.getArrowElement?.() ?? findArrowEl(floating);
 +    if (floating !== cachedMiddlewareFloating || arrowEl !== cachedArrowEl) {
 +      rebuildMiddlewareForFloating(floating, arrowEl);
        zIndexComputed = false;
      }
      const reference = resolveReference();
 diff --git a/dist/get-placement.mjs b/dist/get-placement.mjs
-index 989b43436b22b1e215d631d2b18ce31bc47b766b..ef0501476ee7e715a0757cc5f18454af163db6b8 100644
+index 8abe034a177b2d1666fdb8e0ee304e28874fb705..e0ad322f48515f03cac476faf19e1d7888e855f4 100644
 --- a/dist/get-placement.mjs
 +++ b/dist/get-placement.mjs
-@@ -179,14 +179,15 @@ function getPlacementImpl(referenceOrVirtual, floatingOrVirtual, opts = {}) {
+@@ -32,6 +32,16 @@ function resolveBoundaryOption(boundary) {
+   if (boundary === "clipping-ancestors") return "clippingAncestors";
+   return boundary;
+ }
++function findArrowEl(floating) {
++  if (!floating) return null;
++  const nodes = floating.querySelectorAll("*");
++  for (const node of nodes) {
++    for (const attr of node.attributes) {
++      if (attr.name.startsWith("data-") && attr.name.endsWith("-arrow")) return node;
++    }
++  }
++  return null;
++}
+ function getArrowMiddleware(arrowElement, doc, opts) {
+   const element = arrowElement || doc.createElement("div");
+   return arrow({ element, padding: opts.arrowPadding });
+@@ -179,14 +189,15 @@ function getPlacementImpl(referenceOrVirtual, floatingOrVirtual, opts = {}) {
    const options = Object.assign({}, defaultOptions, opts);
    let middleware = [];
    let cachedMiddlewareFloating = null;
@@ -53,14 +94,15 @@ index 989b43436b22b1e215d631d2b18ce31bc47b766b..ef0501476ee7e715a0757cc5f18454af
 -    const arrowEl = floating.querySelector("[data-part=arrow]");
      restoreArrowStyles = options.restoreStyles ? createStyleCleanup(arrowEl, arrowStyleProps) : void 0;
      middleware = [
-       getOffsetMiddleware(arrowEl, options),
-@@ -230,8 +231,9 @@ function getPlacementImpl(referenceOrVirtual, floatingOrVirtual, opts = {}) {
+       ...options.middleware ?? [],
+@@ -230,9 +241,9 @@ function getPlacementImpl(referenceOrVirtual, floatingOrVirtual, opts = {}) {
+   async function updatePosition() {
      syncAutoUpdateObservers();
      const floating = resolveFloating();
-     if (!floating) return;
+-    if (!floating) return;
 -    if (floating !== cachedMiddlewareFloating) {
 -      rebuildMiddlewareForFloating(floating);
-+    const arrowEl = options.getArrowElement?.() ?? null;
++    const arrowEl = options.getArrowElement?.() ?? findArrowEl(floating);
 +    if (floating !== cachedMiddlewareFloating || arrowEl !== cachedArrowEl) {
 +      rebuildMiddlewareForFloating(floating, arrowEl);
        zIndexComputed = false;

--- a/patches/@zag-js%2Fpopper@2.0.0-next.2.patch
+++ b/patches/@zag-js%2Fpopper@2.0.0-next.2.patch
@@ -1,23 +1,34 @@
 diff --git a/node_modules/@zag-js/popper/.bun-tag-327300fd8a2c8f51 b/.bun-tag-327300fd8a2c8f51
 new file mode 100644
 index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/node_modules/@zag-js/popper/.bun-tag-53c1d0a1a402765f b/.bun-tag-53c1d0a1a402765f
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
 diff --git a/node_modules/@zag-js/popper/.bun-tag-834d0f706a7e8e9 b/.bun-tag-834d0f706a7e8e9
 new file mode 100644
 index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
 diff --git a/dist/get-placement.js b/dist/get-placement.js
-index c23ec8948b751cb15bcd82147f9cdf4ffbb70e46..6a25cb21dd8bf9370efae545ade06fb7a995b5be 100644
+index c23ec8948b751cb15bcd82147f9cdf4ffbb70e46..8560fc3943c226df301bb5b19abaa0d371478628 100644
 --- a/dist/get-placement.js
 +++ b/dist/get-placement.js
-@@ -56,6 +56,16 @@ function resolveBoundaryOption(boundary) {
+@@ -56,6 +56,24 @@ function resolveBoundaryOption(boundary) {
    if (boundary === "clipping-ancestors") return "clippingAncestors";
    return boundary;
  }
 +function findArrowEl(floating) {
 +  if (!floating) return null;
++  let scopeId = null;
++  for (const attr of floating.attributes) {
++    if (attr.name.startsWith("data-") && attr.name.endsWith("-positioner")) {
++      scopeId = attr.value;
++      break;
++    }
++  }
 +  const nodes = floating.querySelectorAll("*");
 +  for (const node of nodes) {
 +    for (const attr of node.attributes) {
-+      if (attr.name.startsWith("data-") && attr.name.endsWith("-arrow")) return node;
++      if (!attr.name.startsWith("data-") || !attr.name.endsWith("-arrow")) continue;
++      if (scopeId == null || attr.value === scopeId) return node;
 +    }
 +  }
 +  return null;
@@ -25,7 +36,7 @@ index c23ec8948b751cb15bcd82147f9cdf4ffbb70e46..6a25cb21dd8bf9370efae545ade06fb7
  function getArrowMiddleware(arrowElement, doc, opts) {
    const element = arrowElement || doc.createElement("div");
    return (0, import_dom.arrow)({ element, padding: opts.arrowPadding });
-@@ -203,14 +213,15 @@ function getPlacementImpl(referenceOrVirtual, floatingOrVirtual, opts = {}) {
+@@ -203,14 +221,15 @@ function getPlacementImpl(referenceOrVirtual, floatingOrVirtual, opts = {}) {
    const options = Object.assign({}, defaultOptions, opts);
    let middleware = [];
    let cachedMiddlewareFloating = null;
@@ -43,7 +54,7 @@ index c23ec8948b751cb15bcd82147f9cdf4ffbb70e46..6a25cb21dd8bf9370efae545ade06fb7
      restoreArrowStyles = options.restoreStyles ? createStyleCleanup(arrowEl, arrowStyleProps) : void 0;
      middleware = [
        ...options.middleware ?? [],
-@@ -254,9 +265,9 @@ function getPlacementImpl(referenceOrVirtual, floatingOrVirtual, opts = {}) {
+@@ -254,9 +273,9 @@ function getPlacementImpl(referenceOrVirtual, floatingOrVirtual, opts = {}) {
    async function updatePosition() {
      syncAutoUpdateObservers();
      const floating = resolveFloating();
@@ -57,19 +68,27 @@ index c23ec8948b751cb15bcd82147f9cdf4ffbb70e46..6a25cb21dd8bf9370efae545ade06fb7
      }
      const reference = resolveReference();
 diff --git a/dist/get-placement.mjs b/dist/get-placement.mjs
-index 8abe034a177b2d1666fdb8e0ee304e28874fb705..e0ad322f48515f03cac476faf19e1d7888e855f4 100644
+index 8abe034a177b2d1666fdb8e0ee304e28874fb705..11699cfa7075063320c9b00466fa6a3d500e55b3 100644
 --- a/dist/get-placement.mjs
 +++ b/dist/get-placement.mjs
-@@ -32,6 +32,16 @@ function resolveBoundaryOption(boundary) {
+@@ -32,6 +32,24 @@ function resolveBoundaryOption(boundary) {
    if (boundary === "clipping-ancestors") return "clippingAncestors";
    return boundary;
  }
 +function findArrowEl(floating) {
 +  if (!floating) return null;
++  let scopeId = null;
++  for (const attr of floating.attributes) {
++    if (attr.name.startsWith("data-") && attr.name.endsWith("-positioner")) {
++      scopeId = attr.value;
++      break;
++    }
++  }
 +  const nodes = floating.querySelectorAll("*");
 +  for (const node of nodes) {
 +    for (const attr of node.attributes) {
-+      if (attr.name.startsWith("data-") && attr.name.endsWith("-arrow")) return node;
++      if (!attr.name.startsWith("data-") || !attr.name.endsWith("-arrow")) continue;
++      if (scopeId == null || attr.value === scopeId) return node;
 +    }
 +  }
 +  return null;
@@ -77,7 +96,7 @@ index 8abe034a177b2d1666fdb8e0ee304e28874fb705..e0ad322f48515f03cac476faf19e1d78
  function getArrowMiddleware(arrowElement, doc, opts) {
    const element = arrowElement || doc.createElement("div");
    return arrow({ element, padding: opts.arrowPadding });
-@@ -179,14 +189,15 @@ function getPlacementImpl(referenceOrVirtual, floatingOrVirtual, opts = {}) {
+@@ -179,14 +197,15 @@ function getPlacementImpl(referenceOrVirtual, floatingOrVirtual, opts = {}) {
    const options = Object.assign({}, defaultOptions, opts);
    let middleware = [];
    let cachedMiddlewareFloating = null;
@@ -95,7 +114,7 @@ index 8abe034a177b2d1666fdb8e0ee304e28874fb705..e0ad322f48515f03cac476faf19e1d78
      restoreArrowStyles = options.restoreStyles ? createStyleCleanup(arrowEl, arrowStyleProps) : void 0;
      middleware = [
        ...options.middleware ?? [],
-@@ -230,9 +241,9 @@ function getPlacementImpl(referenceOrVirtual, floatingOrVirtual, opts = {}) {
+@@ -230,9 +249,9 @@ function getPlacementImpl(referenceOrVirtual, floatingOrVirtual, opts = {}) {
    async function updatePosition() {
      syncAutoUpdateObservers();
      const floating = resolveFloating();


### PR DESCRIPTION
## 📝 Description

Every arrow on `v6` renders unpositioned — a small caret pinned to the top-left of the content, overlapping the title. Popover, hover-card, menu and tooltip are all affected.

## ⛳️ Current behavior

Two defects stacked on the same cause.

**v6 renamed the arrow's attribute.** The arrow renders `data-popover-arrow`, but pristine `next.2` popper finds it with `querySelector("[data-part=arrow]")` — gone since the data-attribute change. `getArrowMiddleware` then does `arrowElement || doc.createElement("div")`, so popper positions a detached div while the real arrow keeps its static position. `getOffsetMiddleware` reads `arrowElement?.clientHeight || 0`, which is why the content also sits flush against the trigger with no gap.

**The existing patch is an incomplete backport.** It replaced that lookup with an opt-in `getArrowElement` callback, which is the right upstream fix, but only wired two of the four machines:

```
zag v2:      popover ✅  hover-card ✅  menu ✅  tooltip ✅
this patch:  popover ❌  hover-card ❌  menu ✅  tooltip ✅
```

**And the patch mis-applied.** Its deletion never took, so the stale call survived and ran second with `arrowEl` undefined — breaking menu and tooltip too, despite them passing the callback:

```js
rebuildMiddlewareForFloating(floating, arrowEl);
rebuildMiddlewareForFloating(floating);      // stale
```

Same failure mode as the `types.d.mts` corruption in #4026.

## 🚀 New behavior

Regenerated through `bun patch` rather than hand-editing the diff, and the applied output verified after a forced reinstall — the stale call is gone and `types.d.mts` is still clean.

`getArrowElement` now falls back to scanning the floating element for a `data-*-arrow` attribute:

```js
const arrowEl = options.getArrowElement?.() ?? findArrowEl(floating);
```

One patch fixes all four components instead of one patch per machine. CSS cannot match an attribute-name suffix, so the scan walks attributes directly. It only runs when a machine has not supplied the callback, so it stops firing on its own once next.3 wires `getArrowElement` upstream — no cleanup needed beyond deleting the patch.

## 🧩 Frameworks

- [ ] React
- [ ] Solid
- [ ] Svelte
- [ ] Vue
- [x] Not framework-specific

Fixed in the dependency, so all four get it.

## 💣 Is this a breaking change (Yes/No):

No.

## ✅ Checklist

- [ ] Added a changeset for user-facing changes
- [x] Added or updated tests
- [ ] Added an example for any new prop or part
- [ ] Updated the docs

No changeset: this changes a patch file, not a published package.

`popover/tests/arrow.test.tsx` opens the popover and asserts the rendered arrow has resolved offsets. It fails on `v6` with the old patch and passes with this one, so it guards the behaviour rather than the patch text.

## 📝 Additional information

**Two routes I tried and backed out of**, in case they come up in review.

Patching `popover` and `hover-card` the way `tooltip` is patched needs `getArrowEl` added to their dom modules as well — zag `v2` does exactly that — which is eight files across two build formats per package. Three attempts in, each revealing another ESM/CJS shape difference, so I stopped.

Passing `positioning.getArrowElement` from Ark also works — I confirmed the machine spreads `positioning` into `getPlacement` and the callback fires — but it needs doing in four frameworks for two components each, and becomes dead code at next.3.

The fallback is one change, in the patch already in the tree, and expires by itself.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61721742"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/chakra/-/pull-requests/chakra-ui/ark/4029"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The nested-arrow selection defect should be fixed before merging because valid nested overlay content can cause popper to position the wrong element.

<h2><a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apatches%2F%40zag-js%252Fpopper%402.0.0-next.2.patch%3A20%0AWhen%20a%20popover%20or%20hover-card%20contains%20a%20nested%20overlay%20whose%20arrow%20occurs%20first%20in%20DOM%20order%2C%20%60findArrowEl%60%20selects%20that%20descendant%20instead%20of%20the%20parent%20overlay's%20arrow%2C%20causing%20popper%20to%20position%20the%20nested%20arrow%20with%20the%20parent's%20geometry%20while%20leaving%20the%20parent's%20arrow%20unpositioned.%0A%0A%23%23%23%20Issue%202%0Apackages%2Freact%2Fsrc%2Fcomponents%2Fpopover%2Ftests%2Farrow.test.tsx%3A26%0AThe%20test%20waits%20exactly%2050%20ms%20rather%20than%20polling%20for%20the%20asynchronously%20written%20offsets%2C%20so%20a%20delayed%20positioning%20update%20on%20a%20loaded%20CI%20worker%20can%20make%20correct%20behavior%20fail%20intermittently.%0A%0A%23%23%23%20Issue%203%0Apackages%2Freact%2Fsrc%2Fcomponents%2Fpopover%2Ftests%2Farrow.test.tsx%3A3%0AThe%20new%20test%20uses%20the%20relative%20%60..%2Findex.ts%60%20import%20and%20adds%20a%20multi-line%20implementation%20comment%2C%20contrary%20to%20the%20repository's%20framework-package%20import%20and%20minimal-commenting%20conventions%3B%20this%20makes%20refactors%20less%20reliable%20and%20adds%20redundant%20commentary.%0A%0ANote%3A%20If%20this%20suggestion%20doesn't%20match%20your%20team's%20coding%20style%2C%20reply%20to%20this%20and%20let%20me%20know.%20I'll%20remember%20it%20for%20next%20time!%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=chakra-ui%2Fark&pr=4029&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6" align="right"></picture></a>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Nested arrows hijack positioning** <a href="https://github.com/chakra-ui/ark/pull/4029#discussion_r3960883121">▶</a>
2. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Fixed delay makes test flaky** <a href="https://github.com/chakra-ui/ark/pull/4029#discussion_r3960883130">▶</a>
3. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Test diverges from repository conventions** <a href="https://github.com/chakra-ui/ark/pull/4029#discussion_r3960883135">▶</a>

<details><summary><h3>Summary</h3></summary>

- Adds a generic descendant scan when no explicit arrow-element callback is available.
- Rebuilds positioning middleware when the resolved arrow element changes.
- Adds a test asserting that popper writes offsets to the rendered popover arrow.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  U[Position update] --> C{getArrowElement callback returns an element?}
  C -->|Yes| A[Use callback arrow]
  C -->|No| S[Scan floating descendants]
  S --> F[Select first data-*-arrow element]
  A --> M[Build arrow and offset middleware]
  F --> M
```
</details>

<!-- /greptile_comment -->