### PR TITLE
perf(solid, vue): reuse the select item state instead of recomputing it

### DIFF
--- a/packages/solid/src/components/select/select-item.tsx
+++ b/packages/solid/src/components/select/select-item.tsx
@@ -21,7 +21,7 @@ export const SelectItem = (props: SelectItemProps) => {
   return (
     <SelectItemPropsProvider value={itemProps}>
       <SelectItemProvider value={itemState}>
-        <ark.div {...mergedProps} state={select().getItemState(itemProps)} />
+        <ark.div {...mergedProps} state={itemState()} />
       </SelectItemProvider>
     </SelectItemPropsProvider>
   )

--- a/packages/vue/src/components/select/select-item.vue
+++ b/packages/vue/src/components/select/select-item.vue
@@ -27,14 +27,16 @@ const props = defineProps<SelectItemProps>()
 defineSlots<PolymorphicSlots<SelectItemState>>()
 const select = useSelectContext()
 
+const itemState = computed(() => select.value.getItemState(props))
+
 SelectItemPropsProvider(props)
-SelectItemProvider(computed(() => select.value.getItemState(props)))
+SelectItemProvider(itemState)
 
 useForwardExpose()
 </script>
 
 <template>
-  <ark.div v-bind="select.getItemProps(props)" :state="select.getItemState(props)" :as-child="asChild">
+  <ark.div v-bind="select.getItemProps(props)" :state="itemState" :as-child="asChild">
     <template v-if="$slots.render" #render="scope">
       <slot name="render" v-bind="scope" />
     </template>


### PR DESCRIPTION
`select-item` computed `getItemState` twice per render — once for the context provider, once for the forwarded `state` prop — so each render did the work twice and handed a fresh object identity downstream.

Reuse the memo (solid) / computed (vue) already derived, matching react, which deduped this in its own perf pass.

- **solid**: `state={itemState()}` instead of `state={select().getItemState(itemProps)}`
- **vue**: shared `computed` used by both the provider and `:state`

Typecheck passes for both packages.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62560127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge, with both framework changes preserving state shape and reactivity while eliminating duplicate computation.

<details><summary><h3>Summary</h3></summary>

- Solid now forwards the value from the existing `createMemo`.
- Vue shares one `computed` between the item provider and rendered element.
</details>

<sub>Reviews (1) · Last reviewed commit: ["perf(solid, vue): reuse the select item ..."](https://github.com/chakra-ui/ark/commit/34d07882810e493c9262f734ac5279bec6f576ce)</sub>

<!-- /greptile_comment -->