### PR TITLE
fix(solid): resolve the renamed interaction provider barrel

### DIFF
--- a/.changeset/solid-interaction-barrel-import.md
+++ b/.changeset/solid-interaction-barrel-import.md
@@ -1,0 +1,7 @@
+---
+'@ark-ui/solid': patch
+---
+
+Fix the Solid build failing to resolve the `interaction` provider barrel. The providers index still imported
+`./interaction/index.ts` after the file was renamed to `index.tsx`, so `bun run build` aborted with an unresolved
+import.

--- a/packages/solid/src/providers/index.tsx
+++ b/packages/solid/src/providers/index.tsx
@@ -1,4 +1,4 @@
 export * from './environment/index.tsx'
 export * from './hotkeys/index.tsx'
-export * from './interaction/index.ts'
+export * from './interaction/index.tsx'
 export * from './locale/index.tsx'


### PR DESCRIPTION
## 📝 Description

The Solid build fails on `main` with:

```
src/providers/index.tsx:3:14: ERROR: Could not resolve "./interaction/index.ts"
```

Follow-up to #4033.

## ⛳️ Current behavior

#4033 renamed the Solid `interaction` provider barrel from `index.ts` to `index.tsx` (so Solid's `src/**/*/index.tsx` build entry glob would pick it up). That PR also updated the one importer, `src/providers/index.tsx`, but the squash merge landed the rename **without** that follow-up commit — so the barrel still imports the now-missing `./interaction/index.ts` and `bun run build` aborts.

## 🚀 New behavior

Point the import at the renamed file (`./interaction/index.tsx`), matching its `environment` / `hotkeys` / `locale` siblings. The build resolves the barrel again and emits `dist/providers/interaction/{index.js,index.jsx,index.d.ts}`.

## 🧩 Frameworks

- [ ] React
- [x] Solid
- [ ] Svelte
- [ ] Vue
- [ ] Not framework-specific

## 💣 Is this a breaking change (Yes/No):

No.

## ✅ Checklist

- [x] Added a changeset for user-facing changes
- [ ] Added or updated tests
- [ ] Added an example for any new prop or part
- [ ] Updated the docs

## 📝 Additional information

Verified locally: the `Could not resolve` error is gone and `dist/providers/interaction/index.js` + `index.jsx` emit. (A separate, pre-existing `@zag-js/floating-panel` type error shows up only in a stale local install; CI compiled that module fine on #4033.)

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62968982"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge and correctly restores resolution of the Solid interaction provider barrel.

<details><summary><h3>Summary</h3></summary>

- Updates the interaction re-export to resolve the existing `.tsx` entry point.
- Adds an `@ark-ui/solid` patch changeset documenting the build fix.
</details>

<sub>Reviews (1) · Last reviewed commit: ["fix(solid): resolve the renamed interact..."](https://github.com/chakra-ui/ark/commit/f979c9e2276a3d5f8b332fb68e44ea1019e7c246)</sub>

<!-- /greptile_comment -->