### PR TITLE
fix: migrate presence and svelte menu parts off data-scope/data-part

### DIFF
--- a/.changeset/presence-menu-data-attrs.md
+++ b/.changeset/presence-menu-data-attrs.md
@@ -1,0 +1,8 @@
+---
+'@ark-ui/react': patch
+'@ark-ui/solid': patch
+'@ark-ui/svelte': patch
+'@ark-ui/vue': patch
+---
+
+Migrate the `Presence` and Svelte `Menu` parts off the legacy `data-scope`/`data-part` attributes. `Presence` now renders the unified `data-presence-root` attribute, and the Svelte `Menu.Separator`/`Menu.Trigger` parts drop the redundant hardcoded attributes in favour of the ones Zag emits (`data-menu-separator`, `data-menu-trigger`).

--- a/packages/react/src/components/presence/presence.test.tsx
+++ b/packages/react/src/components/presence/presence.test.tsx
@@ -46,6 +46,18 @@ const HideModeUnderTest = (props: PresenceProps) => {
 }
 
 describe('Presence', () => {
+  it('renders the unified data-presence-root attribute and no legacy scope/part attributes', async () => {
+    render(<ComponentUnderTest />)
+    await user.click(screen.getByRole('button'))
+    const box = await waitFor(() => {
+      expect(screen.getByTestId('box')).toBeVisible()
+      return screen.getByTestId('box')
+    })
+    expect(box).toHaveAttribute('data-presence-root')
+    expect(box).not.toHaveAttribute('data-scope')
+    expect(box).not.toHaveAttribute('data-part')
+  })
+
   it('should have no a11y violations', async () => {
     const { container } = render(<ComponentUnderTest />)
     const results = await axe(container)

--- a/packages/react/src/components/presence/presence.tsx
+++ b/packages/react/src/components/presence/presence.tsx
@@ -15,13 +15,7 @@ export const Presence = forwardRef<HTMLDivElement, PresenceProps>((props, ref) =
 
   return (
     <PresenceGate presence={presence}>
-      <ark.div
-        {...localProps}
-        {...presence.getPresenceProps()}
-        data-scope="presence"
-        data-part="root"
-        ref={composedRefs}
-      />
+      <ark.div {...localProps} {...presence.getPresenceProps()} data-presence-root="" ref={composedRefs} />
     </PresenceGate>
   )
 })

--- a/packages/solid/src/components/presence/presence.test.tsx
+++ b/packages/solid/src/components/presence/presence.test.tsx
@@ -18,6 +18,18 @@ const ComponentUnderTest = (props: PresenceProps) => {
 }
 
 describe('Presence', () => {
+  it('renders the unified data-presence-root attribute and no legacy scope/part attributes', async () => {
+    render(() => <ComponentUnderTest />)
+    await user.click(screen.getByRole('button'))
+    const box = await waitFor(() => {
+      expect(screen.getByTestId('box')).toBeVisible()
+      return screen.getByTestId('box')
+    })
+    expect(box).toHaveAttribute('data-presence-root')
+    expect(box).not.toHaveAttribute('data-scope')
+    expect(box).not.toHaveAttribute('data-part')
+  })
+
   it('should control presence when not lazy mounting and not unmounting on exit', async () => {
     render(() => <ComponentUnderTest />)
     expect(screen.queryByTestId('box')).not.toBeVisible()

--- a/packages/solid/src/components/presence/presence.tsx
+++ b/packages/solid/src/components/presence/presence.tsx
@@ -15,7 +15,7 @@ export const Presence = (props: PresenceProps) => {
 
   return (
     <Show when={!api().unmounted}>
-      <ark.div {...mergedProps} ref={composeRefs(api().ref, props.ref)} data-scope="presence" data-part="root" />
+      <ark.div {...mergedProps} ref={composeRefs(api().ref, props.ref)} data-presence-root="" />
     </Show>
   )
 }

--- a/packages/svelte/src/lib/components/menu/menu-separator.svelte
+++ b/packages/svelte/src/lib/components/menu/menu-separator.svelte
@@ -16,4 +16,4 @@
   const mergedProps = $derived(mergeProps(menu().getSeparatorProps(), props))
 </script>
 
-<Ark as="div" bind:ref data-scope="menu" data-part="separator" {...mergedProps} />
+<Ark as="div" bind:ref {...mergedProps} />

--- a/packages/svelte/src/lib/components/menu/menu-trigger.svelte
+++ b/packages/svelte/src/lib/components/menu/menu-trigger.svelte
@@ -27,8 +27,6 @@
 <Ark
   as="button"
   bind:ref
-  data-scope="menu"
-  data-part="trigger"
   {...mergedProps}
   state={menu().getTriggerState(triggerProps)}
 />

--- a/packages/svelte/src/lib/components/menu/menu.test.svelte
+++ b/packages/svelte/src/lib/components/menu/menu.test.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import { Menu, type MenuRootProps } from '@ark-ui/svelte/menu'
+  import { Portal } from '@ark-ui/svelte/portal'
+
+  let props: MenuRootProps = $props()
+</script>
+
+<Menu.Root {...props}>
+  <Menu.Trigger>Open</Menu.Trigger>
+  <Portal>
+    <Menu.Positioner>
+      <Menu.Content>
+        <Menu.Item value="new">New</Menu.Item>
+        <Menu.Separator />
+        <Menu.Item value="exit">Exit</Menu.Item>
+      </Menu.Content>
+    </Menu.Positioner>
+  </Portal>
+</Menu.Root>

--- a/packages/svelte/src/lib/components/menu/menu.test.ts
+++ b/packages/svelte/src/lib/components/menu/menu.test.ts
@@ -1,0 +1,25 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte'
+import { describe, expect, it } from 'vitest'
+import ComponentUnderTest from './menu.test.svelte'
+
+describe('Menu part attributes', () => {
+  it('renders the trigger with the data-menu-trigger attribute and no legacy scope/part attributes', () => {
+    render(ComponentUnderTest)
+    const trigger = screen.getByText('Open')
+    expect(trigger).toHaveAttribute('data-menu-trigger')
+    expect(trigger).not.toHaveAttribute('data-scope')
+    expect(trigger).not.toHaveAttribute('data-part')
+  })
+
+  it('renders the separator with the data-menu-separator attribute and no legacy scope/part attributes', async () => {
+    render(ComponentUnderTest)
+    fireEvent.click(screen.getByText('Open'))
+    const separator = await waitFor(() => {
+      const el = document.querySelector('[data-menu-separator]')
+      expect(el).not.toBeNull()
+      return el as HTMLElement
+    })
+    expect(separator).not.toHaveAttribute('data-scope')
+    expect(separator).not.toHaveAttribute('data-part')
+  })
+})

--- a/packages/svelte/src/lib/components/presence/presence.svelte
+++ b/packages/svelte/src/lib/components/presence/presence.svelte
@@ -24,5 +24,5 @@
 </script>
 
 {#if !presence().unmounted}
-  <Ark as="div" bind:ref data-scope="presence" data-part="root" {@attach setNode} {...mergedProps} />
+  <Ark as="div" bind:ref data-presence-root="" {@attach setNode} {...mergedProps} />
 {/if}

--- a/packages/svelte/src/lib/components/presence/presence.test.ts
+++ b/packages/svelte/src/lib/components/presence/presence.test.ts
@@ -4,6 +4,19 @@ import { describe, expect, it } from 'vitest'
 import ComponentUnderTest from './examples/basic.svelte'
 
 describe('Presence', () => {
+  it('renders the unified data-presence-root attribute and no legacy scope/part attributes', async () => {
+    render(ComponentUnderTest)
+    await user.click(screen.getByRole('button'))
+    const box = await waitFor(() => {
+      const el = screen.getByText('Content')
+      expect(el).toBeVisible()
+      return el
+    })
+    expect(box).toHaveAttribute('data-presence-root')
+    expect(box).not.toHaveAttribute('data-scope')
+    expect(box).not.toHaveAttribute('data-part')
+  })
+
   it('should control presence when not lazy mounting and not unmounting on exit', async () => {
     render(ComponentUnderTest)
 

--- a/packages/vue/src/components/presence/presence.vue
+++ b/packages/vue/src/components/presence/presence.vue
@@ -38,13 +38,7 @@ useForwardExpose()
 </script>
 
 <template>
-  <ark.div
-    v-if="!presence.unmounted"
-    v-bind="presence.presenceProps"
-    :as-child="asChild"
-    data-scope="presence"
-    data-part="root"
-  >
+  <ark.div v-if="!presence.unmounted" v-bind="presence.presenceProps" :as-child="asChild" data-presence-root="">
     <template v-if="$slots.render" #render="scope">
       <slot name="render" v-bind="scope" />
     </template>

--- a/packages/vue/src/components/presence/tests/presence.test.ts
+++ b/packages/vue/src/components/presence/tests/presence.test.ts
@@ -3,6 +3,16 @@ import { render, screen, waitFor } from '@testing-library/vue'
 import ComponentUnderTest from './presence.test.vue'
 
 describe('Presence', () => {
+  it('renders the unified data-presence-root attribute and no legacy scope/part attributes', async () => {
+    render(ComponentUnderTest)
+    await user.click(screen.getByRole('button'))
+    await waitFor(() => expect(screen.getByTestId('box')).toBeVisible())
+    const root = screen.getByTestId('box').closest('[data-presence-root]')
+    expect(root).not.toBeNull()
+    expect(root).not.toHaveAttribute('data-scope')
+    expect(root).not.toHaveAttribute('data-part')
+  })
+
   it('should control presence when not lazy mounting and not unmounting on exit', async () => {
     render(ComponentUnderTest)
     expect(screen.queryByTestId('box')).not.toBeVisible()


### PR DESCRIPTION
## 📝 Description

Continues the v6 data-attribute migration for the two parts that still hardcoded the legacy `data-scope`/`data-part` scheme.

## ⛳️ Current behavior

`Presence` renders `data-scope="presence" data-part="root"`, and the Svelte `Menu.Separator`/`Menu.Trigger` parts hardcode `data-scope="menu"` + `data-part` on top of the attributes Zag already emits.

## 🚀 New behavior

- `Presence` (React, Solid, Svelte, Vue) renders the unified `data-presence-root` attribute. It has no Zag anatomy, so the attribute is Ark-authored.
- Svelte `Menu.Separator`/`Menu.Trigger` drop the hardcoded attributes — `getSeparatorProps()`/`getTriggerProps()` already spread `data-menu-separator`/`data-menu-trigger` from Zag v2, so the old ones were pure duplication, matching how React renders these parts.

## 🧩 Frameworks

- [x] React
- [x] Solid
- [x] Svelte
- [x] Vue
- [ ] Not framework-specific

## 💣 Is this a breaking change (Yes/No):

Yes. The emitted DOM attributes change: anyone selecting on `[data-scope=presence]` / `[data-part=root]` (or the Svelte menu scope/part selectors) should target `data-presence-root` / `data-menu-separator` / `data-menu-trigger` instead. Covered by a `patch` changeset.

## ✅ Checklist

- [x] Added a changeset for user-facing changes
- [x] Added or updated tests
- [ ] Added an example for any new prop or part
- [ ] Updated the docs

## 📝 Additional information

Regression tests assert the new attributes are present and the legacy `data-scope`/`data-part` are gone, across the four `Presence` suites and a new Svelte `Menu` suite.
