### PR TITLE
refactor(examples): migrate asChild usage to the render prop

### DIFF
--- a/packages/react/src/components/combobox/examples/links.tsx
+++ b/packages/react/src/components/combobox/examples/links.tsx
@@ -37,14 +37,19 @@ export const Links = () => {
           <Combobox.Content className={styles.Content}>
             <Combobox.List className={styles.List}>
               {collection.items.map((item) => (
-                <Combobox.Item className={styles.Item} key={item.value} item={item} asChild>
-                  <a href={item.href}>
-                    <Combobox.ItemText className={styles.ItemText}>{item.label}</Combobox.ItemText>
-                    <Combobox.ItemIndicator className={styles.ItemIndicator}>
-                      <CheckIcon />
-                    </Combobox.ItemIndicator>
-                  </a>
-                </Combobox.Item>
+                <Combobox.Item
+                  className={styles.Item}
+                  key={item.value}
+                  item={item}
+                  render={
+                    <a href={item.href}>
+                      <Combobox.ItemText className={styles.ItemText}>{item.label}</Combobox.ItemText>
+                      <Combobox.ItemIndicator className={styles.ItemIndicator}>
+                        <CheckIcon />
+                      </Combobox.ItemIndicator>
+                    </a>
+                  }
+                />
               ))}
             </Combobox.List>
           </Combobox.Content>

--- a/packages/react/src/components/editable/examples/textarea.tsx
+++ b/packages/react/src/components/editable/examples/textarea.tsx
@@ -10,9 +10,7 @@ export const Textarea = () => (
   >
     <Editable.Label className={styles.Label}>Description</Editable.Label>
     <Editable.Area className={styles.Area}>
-      <Editable.Input className={styles.Textarea} asChild>
-        <textarea />
-      </Editable.Input>
+      <Editable.Input className={styles.Textarea} render={<textarea />} />
       <Editable.Preview className={styles.Textarea} />
     </Editable.Area>
     <div className={styles.HelperText}>Press Cmd + Enter to save</div>

--- a/packages/react/src/components/hover-card/examples/basic.tsx
+++ b/packages/react/src/components/hover-card/examples/basic.tsx
@@ -5,11 +5,7 @@ import styles from 'styles/hover-card.module.css'
 export const Basic = () => (
   <HoverCard.Root>
     <p>
-      Liked by{' '}
-      <HoverCard.Trigger className={styles.Trigger} asChild>
-        <a href="#profile">@sarah_chen</a>
-      </HoverCard.Trigger>{' '}
-      and 3 others
+      Liked by <HoverCard.Trigger className={styles.Trigger} render={<a href="#profile">@sarah_chen</a>} /> and 3 others
     </p>
     <Portal>
       <HoverCard.Positioner>

--- a/packages/react/src/components/hover-card/examples/context.tsx
+++ b/packages/react/src/components/hover-card/examples/context.tsx
@@ -9,9 +9,10 @@ export const Context = () => (
       {(context) => (
         <p>
           Liked by{' '}
-          <HoverCard.Trigger className={styles.Trigger} asChild>
-            <a href="#profile">@sarah_chen {context.open ? <ChevronUpIcon /> : <ChevronDownIcon />}</a>
-          </HoverCard.Trigger>{' '}
+          <HoverCard.Trigger
+            className={styles.Trigger}
+            render={<a href="#profile">@sarah_chen {context.open ? <ChevronUpIcon /> : <ChevronDownIcon />}</a>}
+          />{' '}
           and 3 others
         </p>
       )}

--- a/packages/react/src/components/hover-card/examples/controlled.tsx
+++ b/packages/react/src/components/hover-card/examples/controlled.tsx
@@ -14,11 +14,8 @@ export const Controlled = () => {
       </button>
       <HoverCard.Root open={open} onOpenChange={(e) => setOpen(e.open)}>
         <p>
-          Liked by{' '}
-          <HoverCard.Trigger className={styles.Trigger} asChild>
-            <a href="#profile">@sarah_chen</a>
-          </HoverCard.Trigger>{' '}
-          and 3 others
+          Liked by <HoverCard.Trigger className={styles.Trigger} render={<a href="#profile">@sarah_chen</a>} /> and 3
+          others
         </p>
         <Portal>
           <HoverCard.Positioner>

--- a/packages/react/src/components/hover-card/examples/delay.tsx
+++ b/packages/react/src/components/hover-card/examples/delay.tsx
@@ -5,11 +5,7 @@ import styles from 'styles/hover-card.module.css'
 export const Delay = () => (
   <HoverCard.Root openDelay={200} closeDelay={500}>
     <p>
-      Liked by{' '}
-      <HoverCard.Trigger className={styles.Trigger} asChild>
-        <a href="#profile">@sarah_chen</a>
-      </HoverCard.Trigger>{' '}
-      and 3 others
+      Liked by <HoverCard.Trigger className={styles.Trigger} render={<a href="#profile">@sarah_chen</a>} /> and 3 others
     </p>
     <Portal>
       <HoverCard.Positioner>

--- a/packages/react/src/components/hover-card/examples/multiple-triggers.tsx
+++ b/packages/react/src/components/hover-card/examples/multiple-triggers.tsx
@@ -46,23 +46,32 @@ export const MultipleTriggers = () => {
     >
       <p className={styles.Paragraph}>
         Reviewed by{' '}
-        <HoverCard.Trigger value="sarah" asChild>
-          <a href="#" className={styles.Trigger}>
-            @sarah_chen
-          </a>
-        </HoverCard.Trigger>
+        <HoverCard.Trigger
+          value="sarah"
+          render={
+            <a href="#" className={styles.Trigger}>
+              @sarah_chen
+            </a>
+          }
+        />
         ,{' '}
-        <HoverCard.Trigger value="alex" asChild>
-          <a href="#" className={styles.Trigger}>
-            @alex_r
-          </a>
-        </HoverCard.Trigger>
+        <HoverCard.Trigger
+          value="alex"
+          render={
+            <a href="#" className={styles.Trigger}>
+              @alex_r
+            </a>
+          }
+        />
         , and{' '}
-        <HoverCard.Trigger value="jordan" asChild>
-          <a href="#" className={styles.Trigger}>
-            @jordan_lee
-          </a>
-        </HoverCard.Trigger>
+        <HoverCard.Trigger
+          value="jordan"
+          render={
+            <a href="#" className={styles.Trigger}>
+              @jordan_lee
+            </a>
+          }
+        />
       </p>
       <Portal>
         <HoverCard.Positioner>

--- a/packages/react/src/components/hover-card/examples/positioning.tsx
+++ b/packages/react/src/components/hover-card/examples/positioning.tsx
@@ -5,11 +5,7 @@ import styles from 'styles/hover-card.module.css'
 export const Positioning = () => (
   <HoverCard.Root positioning={{ placement: 'right', gutter: 12 }}>
     <p>
-      Liked by{' '}
-      <HoverCard.Trigger className={styles.Trigger} asChild>
-        <a href="#profile">@sarah_chen</a>
-      </HoverCard.Trigger>{' '}
-      and 3 others
+      Liked by <HoverCard.Trigger className={styles.Trigger} render={<a href="#profile">@sarah_chen</a>} /> and 3 others
     </p>
     <Portal>
       <HoverCard.Positioner>

--- a/packages/react/src/components/hover-card/examples/root-provider.tsx
+++ b/packages/react/src/components/hover-card/examples/root-provider.tsx
@@ -10,11 +10,8 @@ export const RootProvider = () => {
       <output>Open: {String(hoverCard.open)}</output>
       <HoverCard.RootProvider value={hoverCard}>
         <p>
-          Liked by{' '}
-          <HoverCard.Trigger className={styles.Trigger} asChild>
-            <a href="#profile">@sarah_chen</a>
-          </HoverCard.Trigger>{' '}
-          and 3 others
+          Liked by <HoverCard.Trigger className={styles.Trigger} render={<a href="#profile">@sarah_chen</a>} /> and 3
+          others
         </p>
         <Portal>
           <HoverCard.Positioner>

--- a/packages/react/src/components/menu/examples/links.tsx
+++ b/packages/react/src/components/menu/examples/links.tsx
@@ -12,16 +12,18 @@ export const Links = () => (
     </Menu.Trigger>
     <Menu.Positioner>
       <Menu.Content className={styles.Content}>
-        <Menu.Item className={styles.Item} value="docs" asChild>
-          <a href="https://ark-ui.com">Documentation</a>
-        </Menu.Item>
-        <Menu.Item className={styles.Item} value="github" asChild>
-          <a href="https://github.com/chakra-ui/ark">GitHub</a>
-        </Menu.Item>
+        <Menu.Item className={styles.Item} value="docs" render={<a href="https://ark-ui.com">Documentation</a>} />
+        <Menu.Item
+          className={styles.Item}
+          value="github"
+          render={<a href="https://github.com/chakra-ui/ark">GitHub</a>}
+        />
         <Menu.Separator className={styles.Separator} />
-        <Menu.Item className={styles.Item} value="changelog" asChild>
-          <a href="https://github.com/chakra-ui/ark/releases">Changelog</a>
-        </Menu.Item>
+        <Menu.Item
+          className={styles.Item}
+          value="changelog"
+          render={<a href="https://github.com/chakra-ui/ark/releases">Changelog</a>}
+        />
       </Menu.Content>
     </Menu.Positioner>
   </Menu.Root>

--- a/packages/react/src/components/popover/examples/factory.tsx
+++ b/packages/react/src/components/popover/examples/factory.tsx
@@ -1,7 +1,3 @@
 import { ark } from '@ark-ui/react/factory'
 
-export const Factory = () => (
-  <ark.span asChild>
-    <a href="#">Ark UI</a>
-  </ark.span>
-)
+export const Factory = () => <ark.span render={<a href="#">Ark UI</a>} />

--- a/packages/react/src/components/tabs/examples/links.tsx
+++ b/packages/react/src/components/tabs/examples/links.tsx
@@ -4,15 +4,9 @@ import styles from 'styles/tabs.module.css'
 export const Links = () => (
   <Tabs.Root className={styles.Root} defaultValue="account">
     <Tabs.List className={styles.List}>
-      <Tabs.Trigger className={styles.Trigger} value="account" asChild>
-        <a href="#account">Account</a>
-      </Tabs.Trigger>
-      <Tabs.Trigger className={styles.Trigger} value="password" asChild>
-        <a href="#password">Password</a>
-      </Tabs.Trigger>
-      <Tabs.Trigger className={styles.Trigger} value="billing" asChild>
-        <a href="#billing">Billing</a>
-      </Tabs.Trigger>
+      <Tabs.Trigger className={styles.Trigger} value="account" render={<a href="#account">Account</a>} />
+      <Tabs.Trigger className={styles.Trigger} value="password" render={<a href="#password">Password</a>} />
+      <Tabs.Trigger className={styles.Trigger} value="billing" render={<a href="#billing">Billing</a>} />
     </Tabs.List>
     <Tabs.Content className={styles.Content} value="account">
       Make changes to your account here.

--- a/packages/react/src/components/tags-input/examples/with-combobox.tsx
+++ b/packages/react/src/components/tags-input/examples/with-combobox.tsx
@@ -53,9 +53,7 @@ export const WithCombobox = () => {
               <TagsInput.ItemInput className={styles.ItemInput} />
             </TagsInput.Item>
           ))}
-          <Combobox.Input asChild>
-            <TagsInput.Input placeholder="Add Framework" className={styles.Input} />
-          </Combobox.Input>
+          <Combobox.Input render={<TagsInput.Input placeholder="Add Framework" className={styles.Input} />} />
           <TagsInput.ClearTrigger className={styles.ClearTrigger}>
             <XIcon />
           </TagsInput.ClearTrigger>

--- a/packages/react/src/components/toggle-group/examples/with-tooltip.tsx
+++ b/packages/react/src/components/toggle-group/examples/with-tooltip.tsx
@@ -20,9 +20,13 @@ export const WithTooltip = () => {
     <Tooltip.RootProvider value={tooltip}>
       <ToggleGroup.Root defaultValue={['bold']} ids={{ item: getTriggerId }} className={styles.Root}>
         {items.map((item) => (
-          <ToggleGroup.Item key={item.value} value={item.value} aria-label={item.label} className={styles.Item} asChild>
-            <Tooltip.Trigger value={item.value}>{item.icon}</Tooltip.Trigger>
-          </ToggleGroup.Item>
+          <ToggleGroup.Item
+            key={item.value}
+            value={item.value}
+            aria-label={item.label}
+            className={styles.Item}
+            render={<Tooltip.Trigger value={item.value}>{item.icon}</Tooltip.Trigger>}
+          />
         ))}
       </ToggleGroup.Root>
       <Portal>

--- a/packages/react/src/components/tree-view/examples/context-menu.tsx
+++ b/packages/react/src/components/tree-view/examples/context-menu.tsx
@@ -60,19 +60,22 @@ const TreeNode = (props: TreeView.NodeProviderProps<Node> & { triggerId: string 
             <TreeView.NodeGroup className={styles.NodeGroup}>
               <TreeView.Node className={styles.Node}>
                 <TreeNodeContextMenu triggerId={triggerId}>
-                  <TreeView.Cell className={styles.Cell} asChild>
-                    <Menu.ContextTrigger>
-                      <TreeView.NodeExpandTrigger className={styles.NodeExpandTrigger}>
-                        <TreeView.NodeIndicator type="expanded" className={styles.NodeIndicator}>
-                          <ChevronRightIcon />
-                        </TreeView.NodeIndicator>
-                      </TreeView.NodeExpandTrigger>
-                      <TreeView.NodeText className={styles.NodeText}>
-                        {nodeState.expanded ? <FolderOpenIcon /> : <FolderIcon />}
-                        {node.name}
-                      </TreeView.NodeText>
-                    </Menu.ContextTrigger>
-                  </TreeView.Cell>
+                  <TreeView.Cell
+                    className={styles.Cell}
+                    render={
+                      <Menu.ContextTrigger>
+                        <TreeView.NodeExpandTrigger className={styles.NodeExpandTrigger}>
+                          <TreeView.NodeIndicator type="expanded" className={styles.NodeIndicator}>
+                            <ChevronRightIcon />
+                          </TreeView.NodeIndicator>
+                        </TreeView.NodeExpandTrigger>
+                        <TreeView.NodeText className={styles.NodeText}>
+                          {nodeState.expanded ? <FolderOpenIcon /> : <FolderIcon />}
+                          {node.name}
+                        </TreeView.NodeText>
+                      </Menu.ContextTrigger>
+                    }
+                  />
                 </TreeNodeContextMenu>
               </TreeView.Node>
               <TreeView.NodeGroupContent className={styles.NodeGroupContent}>
@@ -85,12 +88,15 @@ const TreeNode = (props: TreeView.NodeProviderProps<Node> & { triggerId: string 
           ) : (
             <TreeView.Node className={styles.Node}>
               <TreeNodeContextMenu triggerId={triggerId}>
-                <TreeView.Cell className={styles.Cell} asChild>
-                  <Menu.ContextTrigger>
-                    <FileIcon />
-                    <TreeView.NodeText className={styles.NodeText}>{node.name}</TreeView.NodeText>
-                  </Menu.ContextTrigger>
-                </TreeView.Cell>
+                <TreeView.Cell
+                  className={styles.Cell}
+                  render={
+                    <Menu.ContextTrigger>
+                      <FileIcon />
+                      <TreeView.NodeText className={styles.NodeText}>{node.name}</TreeView.NodeText>
+                    </Menu.ContextTrigger>
+                  }
+                />
               </TreeNodeContextMenu>
             </TreeView.Node>
           )

--- a/packages/react/src/components/tree-view/examples/links.tsx
+++ b/packages/react/src/components/tree-view/examples/links.tsx
@@ -40,15 +40,18 @@ const TreeNode = (props: TreeView.NodeProviderProps<Node>) => {
         </TreeView.NodeGroup>
       ) : (
         <TreeView.Node className={styles.Node}>
-          <TreeView.Cell className={styles.Cell} asChild>
-            <a href={node.href}>
-              <TreeView.NodeText className={styles.NodeText}>
-                <FileIcon />
-                {node.name}
-              </TreeView.NodeText>
-              {node.href?.startsWith('http') && <ExternalLinkIcon size={12} />}
-            </a>
-          </TreeView.Cell>
+          <TreeView.Cell
+            className={styles.Cell}
+            render={
+              <a href={node.href}>
+                <TreeView.NodeText className={styles.NodeText}>
+                  <FileIcon />
+                  {node.name}
+                </TreeView.NodeText>
+                {node.href?.startsWith('http') && <ExternalLinkIcon size={12} />}
+              </a>
+            }
+          />
         </TreeView.Node>
       )}
     </TreeView.NodeProvider>

--- a/packages/solid/src/components/combobox/examples/links.tsx
+++ b/packages/solid/src/components/combobox/examples/links.tsx
@@ -51,7 +51,7 @@ export const Links = () => {
                   <Combobox.Item
                     class={styles.Item}
                     item={item}
-                    asChild={(props) => <a href={item.href} {...props()} />}
+                    render={(props) => <a href={item.href} {...props()} />}
                   >
                     <Combobox.ItemText class={styles.ItemText}>{item.label}</Combobox.ItemText>
                     <Combobox.ItemIndicator class={styles.ItemIndicator}>

--- a/packages/solid/src/components/editable/examples/textarea.tsx
+++ b/packages/solid/src/components/editable/examples/textarea.tsx
@@ -10,7 +10,7 @@ export const Textarea = () => (
   >
     <Editable.Label class={styles.Label}>Description</Editable.Label>
     <Editable.Area class={styles.Area}>
-      <Editable.Input class={styles.Textarea} asChild={(props) => <textarea {...props()} />} />
+      <Editable.Input class={styles.Textarea} render={(props) => <textarea {...props()} />} />
       <Editable.Preview class={styles.Textarea} />
     </Editable.Area>
     <div class={styles.HelperText}>Press Cmd + Enter to save</div>

--- a/packages/solid/src/components/hover-card/examples/basic.tsx
+++ b/packages/solid/src/components/hover-card/examples/basic.tsx
@@ -8,7 +8,7 @@ export const Basic = () => (
       Liked by{' '}
       <HoverCard.Trigger
         class={styles.Trigger}
-        asChild={(props) => (
+        render={(props) => (
           <a href="#profile" {...props()}>
             @sarah_chen
           </a>

--- a/packages/solid/src/components/hover-card/examples/context.tsx
+++ b/packages/solid/src/components/hover-card/examples/context.tsx
@@ -11,7 +11,7 @@ export const Context = () => (
           Liked by{' '}
           <HoverCard.Trigger
             class={styles.Trigger}
-            asChild={(props) => (
+            render={(props) => (
               <a href="#profile" {...props()}>
                 @sarah_chen {context().open ? <ChevronUpIcon /> : <ChevronDownIcon />}
               </a>

--- a/packages/solid/src/components/hover-card/examples/controlled.tsx
+++ b/packages/solid/src/components/hover-card/examples/controlled.tsx
@@ -17,7 +17,7 @@ export const Controlled = () => {
           Liked by{' '}
           <HoverCard.Trigger
             class={styles.Trigger}
-            asChild={(props) => (
+            render={(props) => (
               <a href="#profile" {...props()}>
                 @sarah_chen
               </a>

--- a/packages/solid/src/components/hover-card/examples/delay.tsx
+++ b/packages/solid/src/components/hover-card/examples/delay.tsx
@@ -8,7 +8,7 @@ export const Delay = () => (
       Liked by{' '}
       <HoverCard.Trigger
         class={styles.Trigger}
-        asChild={(props) => (
+        render={(props) => (
           <a href="#profile" {...props()}>
             @sarah_chen
           </a>

--- a/packages/solid/src/components/hover-card/examples/multiple-triggers.tsx
+++ b/packages/solid/src/components/hover-card/examples/multiple-triggers.tsx
@@ -48,7 +48,7 @@ export const MultipleTriggers = () => {
         Reviewed by{' '}
         <HoverCard.Trigger
           value="sarah"
-          asChild={(props) => (
+          render={(props) => (
             <a href="#" class={styles.Trigger} {...props()}>
               @sarah_chen
             </a>
@@ -57,7 +57,7 @@ export const MultipleTriggers = () => {
         ,{' '}
         <HoverCard.Trigger
           value="alex"
-          asChild={(props) => (
+          render={(props) => (
             <a href="#" class={styles.Trigger} {...props()}>
               @alex_r
             </a>
@@ -66,7 +66,7 @@ export const MultipleTriggers = () => {
         , and{' '}
         <HoverCard.Trigger
           value="jordan"
-          asChild={(props) => (
+          render={(props) => (
             <a href="#" class={styles.Trigger} {...props()}>
               @jordan_lee
             </a>

--- a/packages/solid/src/components/hover-card/examples/positioning.tsx
+++ b/packages/solid/src/components/hover-card/examples/positioning.tsx
@@ -8,7 +8,7 @@ export const Positioning = () => (
       Liked by{' '}
       <HoverCard.Trigger
         class={styles.Trigger}
-        asChild={(props) => (
+        render={(props) => (
           <a href="#profile" {...props()}>
             @sarah_chen
           </a>

--- a/packages/solid/src/components/hover-card/examples/root-provider.tsx
+++ b/packages/solid/src/components/hover-card/examples/root-provider.tsx
@@ -13,7 +13,7 @@ export const RootProvider = () => {
           Liked by{' '}
           <HoverCard.Trigger
             class={styles.Trigger}
-            asChild={(props) => (
+            render={(props) => (
               <a href="#profile" {...props()}>
                 @sarah_chen
               </a>

--- a/packages/solid/src/components/menu/examples/links.tsx
+++ b/packages/solid/src/components/menu/examples/links.tsx
@@ -12,13 +12,13 @@ export const Links = () => (
     </Menu.Trigger>
     <Menu.Positioner>
       <Menu.Content class={styles.Content}>
-        <Menu.Item class={styles.Item} value="docs" asChild={(props) => <a href="https://ark-ui.com" {...props()} />}>
+        <Menu.Item class={styles.Item} value="docs" render={(props) => <a href="https://ark-ui.com" {...props()} />}>
           Documentation
         </Menu.Item>
         <Menu.Item
           class={styles.Item}
           value="github"
-          asChild={(props) => <a href="https://github.com/chakra-ui/ark" {...props()} />}
+          render={(props) => <a href="https://github.com/chakra-ui/ark" {...props()} />}
         >
           GitHub
         </Menu.Item>
@@ -26,7 +26,7 @@ export const Links = () => (
         <Menu.Item
           class={styles.Item}
           value="changelog"
-          asChild={(props) => <a href="https://github.com/chakra-ui/ark/releases" {...props()} />}
+          render={(props) => <a href="https://github.com/chakra-ui/ark/releases" {...props()} />}
         >
           Changelog
         </Menu.Item>

--- a/packages/solid/src/components/popover/examples/as-child.tsx
+++ b/packages/solid/src/components/popover/examples/as-child.tsx
@@ -2,7 +2,7 @@ import { Popover } from '@ark-ui/solid/popover'
 
 export const AsChild = () => (
   <Popover.Root>
-    <Popover.Trigger asChild={(props) => <button {...props()} />}>Open Popover</Popover.Trigger>
+    <Popover.Trigger render={(props) => <button {...props()} />}>Open Popover</Popover.Trigger>
     <Popover.Positioner>
       <Popover.Content>Content</Popover.Content>
     </Popover.Positioner>

--- a/packages/solid/src/components/popover/examples/factory.tsx
+++ b/packages/solid/src/components/popover/examples/factory.tsx
@@ -2,7 +2,7 @@ import { ark } from '@ark-ui/solid/factory'
 
 export const Factory = () => (
   <ark.span
-    asChild={(props) => (
+    render={(props) => (
       <a href="#" {...props()}>
         Ark UI
       </a>

--- a/packages/solid/src/components/tabs/examples/links.tsx
+++ b/packages/solid/src/components/tabs/examples/links.tsx
@@ -7,7 +7,7 @@ export const Links = () => (
       <Tabs.Trigger
         class={styles.Trigger}
         value="account"
-        asChild={(props) => (
+        render={(props) => (
           <a href="#account" {...props()}>
             Account
           </a>
@@ -16,7 +16,7 @@ export const Links = () => (
       <Tabs.Trigger
         class={styles.Trigger}
         value="password"
-        asChild={(props) => (
+        render={(props) => (
           <a href="#password" {...props()}>
             Password
           </a>
@@ -25,7 +25,7 @@ export const Links = () => (
       <Tabs.Trigger
         class={styles.Trigger}
         value="billing"
-        asChild={(props) => (
+        render={(props) => (
           <a href="#billing" {...props()}>
             Billing
           </a>

--- a/packages/solid/src/components/tags-input/examples/with-combobox.tsx
+++ b/packages/solid/src/components/tags-input/examples/with-combobox.tsx
@@ -56,7 +56,7 @@ export const WithCombobox = () => {
             )}
           </For>
           <Combobox.Input
-            asChild={(props) => <TagsInput.Input placeholder="Add Framework" class={styles.Input} {...props()} />}
+            render={(props) => <TagsInput.Input placeholder="Add Framework" class={styles.Input} {...props()} />}
           />
           <TagsInput.ClearTrigger class={styles.ClearTrigger}>
             <XIcon />

--- a/packages/solid/src/components/toggle-group/examples/with-tooltip.tsx
+++ b/packages/solid/src/components/toggle-group/examples/with-tooltip.tsx
@@ -26,7 +26,7 @@ export const WithTooltip = () => {
               value={item.value}
               aria-label={item.label}
               class={styles.Item}
-              asChild={(itemProps) => (
+              render={(itemProps) => (
                 <Tooltip.Trigger value={item.value} {...itemProps()}>
                   <item.icon />
                 </Tooltip.Trigger>

--- a/packages/solid/src/components/tree-view/examples/context-menu.tsx
+++ b/packages/solid/src/components/tree-view/examples/context-menu.tsx
@@ -58,7 +58,7 @@ const TreeNode = (props: TreeView.NodeProviderProps<Node> & { triggerId: string 
                 <TreeNodeContextMenu triggerId={props.triggerId}>
                   <TreeView.Cell
                     class={styles.Cell}
-                    asChild={(cellProps) => (
+                    render={(cellProps) => (
                       <Menu.ContextTrigger {...cellProps()}>
                         <FileIcon />
                         <TreeView.NodeText class={styles.NodeText}>{props.node.name}</TreeView.NodeText>
@@ -74,7 +74,7 @@ const TreeNode = (props: TreeView.NodeProviderProps<Node> & { triggerId: string 
                 <TreeNodeContextMenu triggerId={props.triggerId}>
                   <TreeView.Cell
                     class={styles.Cell}
-                    asChild={(cellProps) => (
+                    render={(cellProps) => (
                       <Menu.ContextTrigger {...cellProps()}>
                         <TreeView.NodeExpandTrigger class={styles.NodeExpandTrigger}>
                           <TreeView.NodeIndicator type="expanded" class={styles.NodeIndicator}>

--- a/packages/solid/src/components/tree-view/examples/links.tsx
+++ b/packages/solid/src/components/tree-view/examples/links.tsx
@@ -23,7 +23,7 @@ const TreeNode = (props: TreeView.NodeProviderProps<Node>) => {
           <TreeView.Node class={styles.Node}>
             <TreeView.Cell
               class={styles.Cell}
-              asChild={(cellProps) => (
+              render={(cellProps) => (
                 <a href={props.node.href} {...cellProps()}>
                   <TreeView.NodeText class={styles.NodeText}>
                     <FileIcon />

--- a/packages/solid/src/components/tree-view/examples/tree-node-with-links.tsx
+++ b/packages/solid/src/components/tree-view/examples/tree-node-with-links.tsx
@@ -20,7 +20,7 @@ export const TreeNodeWithLinks: Component<Props> = (props) => (
       when={props.node.children}
       fallback={
         <TreeView.Node>
-          <TreeView.Cell asChild={(cellProps) => <a href={props.node.href} {...cellProps()} />}>
+          <TreeView.Cell render={(cellProps) => <a href={props.node.href} {...cellProps()} />}>
             <TreeView.NodeText>
               <File />
               {props.node.name}

--- a/packages/svelte/src/lib/components/combobox/examples/links.svelte
+++ b/packages/svelte/src/lib/components/combobox/examples/links.svelte
@@ -43,7 +43,7 @@
         <Combobox.List class={styles.List}>
           {#each collection().items as item (item.value)}
             <Combobox.Item class={styles.Item} {item}>
-              {#snippet asChild(props)}
+              {#snippet render(props)}
                 <a {...props()} href={item.href}>
                   <Combobox.ItemText class={styles.ItemText}>{item.label}</Combobox.ItemText>
                   <Combobox.ItemIndicator class={styles.ItemIndicator}>✓</Combobox.ItemIndicator>

--- a/packages/svelte/src/lib/components/editable/examples/textarea.svelte
+++ b/packages/svelte/src/lib/components/editable/examples/textarea.svelte
@@ -12,7 +12,7 @@
   <Editable.Label class={styles.Label}>Description</Editable.Label>
   <Editable.Area class={styles.Area}>
     <Editable.Input class={styles.Textarea}>
-      {#snippet asChild(props)}
+      {#snippet render(props)}
         <textarea {...props()}></textarea>
       {/snippet}
     </Editable.Input>

--- a/packages/svelte/src/lib/components/factory/examples/basic.svelte
+++ b/packages/svelte/src/lib/components/factory/examples/basic.svelte
@@ -18,7 +18,7 @@
   style="background: red"
   onclick={onClickParent}
 >
-  {#snippet asChild(props)}
+  {#snippet render(props)}
     <Ark
       as="span"
       {...props({ id: 'child', class: 'child', style: 'color: blue', onclick: onClickChild })}

--- a/packages/svelte/src/lib/components/hover-card/examples/basic.svelte
+++ b/packages/svelte/src/lib/components/hover-card/examples/basic.svelte
@@ -8,7 +8,7 @@
   <p>
     Liked by
     <HoverCard.Trigger class={styles.Trigger}>
-      {#snippet asChild(props)}
+      {#snippet render(props)}
         <a href="#profile" {...props()}>@sarah_chen</a>
       {/snippet}
     </HoverCard.Trigger>

--- a/packages/svelte/src/lib/components/hover-card/examples/context.svelte
+++ b/packages/svelte/src/lib/components/hover-card/examples/context.svelte
@@ -12,7 +12,7 @@
       <p>
         Liked by
         <HoverCard.Trigger class={styles.Trigger}>
-          {#snippet asChild(props)}
+          {#snippet render(props)}
             <a href="#profile" {...props()}>
               @sarah_chen
               {#if context().open}

--- a/packages/svelte/src/lib/components/hover-card/examples/controlled.svelte
+++ b/packages/svelte/src/lib/components/hover-card/examples/controlled.svelte
@@ -13,7 +13,7 @@
     <p>
       Liked by
       <HoverCard.Trigger class={styles.Trigger}>
-        {#snippet asChild(props)}
+        {#snippet render(props)}
           <a href="#profile" {...props()}>@sarah_chen</a>
         {/snippet}
       </HoverCard.Trigger>

--- a/packages/svelte/src/lib/components/hover-card/examples/delay.svelte
+++ b/packages/svelte/src/lib/components/hover-card/examples/delay.svelte
@@ -8,7 +8,7 @@
   <p>
     Liked by
     <HoverCard.Trigger class={styles.Trigger}>
-      {#snippet asChild(props)}
+      {#snippet render(props)}
         <a href="#profile" {...props()}>@sarah_chen</a>
       {/snippet}
     </HoverCard.Trigger>

--- a/packages/svelte/src/lib/components/hover-card/examples/multiple-triggers.svelte
+++ b/packages/svelte/src/lib/components/hover-card/examples/multiple-triggers.svelte
@@ -46,19 +46,19 @@
   <p class={styles.Paragraph}>
     Reviewed by{' '}
     <HoverCard.Trigger value="sarah" class={styles.Trigger}>
-      {#snippet asChild(props)}
+      {#snippet render(props)}
         <a href="#" {...props()}>@sarah_chen</a>
       {/snippet}
     </HoverCard.Trigger>
     ,{' '}
     <HoverCard.Trigger value="alex" class={styles.Trigger}>
-      {#snippet asChild(props)}
+      {#snippet render(props)}
         <a href="#" {...props()}>@alex_r</a>
       {/snippet}
     </HoverCard.Trigger>
     , and{' '}
     <HoverCard.Trigger value="jordan" class={styles.Trigger}>
-      {#snippet asChild(props)}
+      {#snippet render(props)}
         <a href="#" {...props()}>@jordan_lee</a>
       {/snippet}
     </HoverCard.Trigger>

--- a/packages/svelte/src/lib/components/hover-card/examples/positioning.svelte
+++ b/packages/svelte/src/lib/components/hover-card/examples/positioning.svelte
@@ -8,7 +8,7 @@
   <p>
     Liked by
     <HoverCard.Trigger class={styles.Trigger}>
-      {#snippet asChild(props)}
+      {#snippet render(props)}
         <a href="#profile" {...props()}>@sarah_chen</a>
       {/snippet}
     </HoverCard.Trigger>

--- a/packages/svelte/src/lib/components/hover-card/examples/root-provider.svelte
+++ b/packages/svelte/src/lib/components/hover-card/examples/root-provider.svelte
@@ -13,7 +13,7 @@
     <p>
       Liked by
       <HoverCard.Trigger class={styles.Trigger}>
-        {#snippet asChild(props)}
+        {#snippet render(props)}
           <a href="#profile" {...props()}>@sarah_chen</a>
         {/snippet}
       </HoverCard.Trigger>

--- a/packages/svelte/src/lib/components/menu/examples/links.svelte
+++ b/packages/svelte/src/lib/components/menu/examples/links.svelte
@@ -14,18 +14,18 @@
   <Menu.Positioner>
     <Menu.Content class={styles.Content}>
       <Menu.Item class={styles.Item} value="docs">
-        {#snippet asChild(itemProps)}
+        {#snippet render(itemProps)}
           <a href="https://ark-ui.com" {...itemProps()}>Documentation</a>
         {/snippet}
       </Menu.Item>
       <Menu.Item class={styles.Item} value="github">
-        {#snippet asChild(itemProps)}
+        {#snippet render(itemProps)}
           <a href="https://github.com/chakra-ui/ark" {...itemProps()}>GitHub</a>
         {/snippet}
       </Menu.Item>
       <Menu.Separator class={styles.Separator} />
       <Menu.Item class={styles.Item} value="changelog">
-        {#snippet asChild(itemProps)}
+        {#snippet render(itemProps)}
           <a href="https://github.com/chakra-ui/ark/releases" {...itemProps()}>Changelog</a>
         {/snippet}
       </Menu.Item>

--- a/packages/svelte/src/lib/components/popover/examples/factory.svelte
+++ b/packages/svelte/src/lib/components/popover/examples/factory.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <Ark as="span">
-  {#snippet asChild(props)}
+  {#snippet render(props)}
     <a href="#" {...props()}>Ark UI</a>
   {/snippet}
 </Ark>

--- a/packages/svelte/src/lib/components/tabs/examples/links.svelte
+++ b/packages/svelte/src/lib/components/tabs/examples/links.svelte
@@ -6,17 +6,17 @@
 <Tabs.Root class={styles.Root} defaultValue="account">
   <Tabs.List class={styles.List}>
     <Tabs.Trigger class={styles.Trigger} value="account">
-      {#snippet asChild(props)}
+      {#snippet render(props)}
         <a href="#account" {...props()}>Account</a>
       {/snippet}
     </Tabs.Trigger>
     <Tabs.Trigger class={styles.Trigger} value="password">
-      {#snippet asChild(props)}
+      {#snippet render(props)}
         <a href="#password" {...props()}>Password</a>
       {/snippet}
     </Tabs.Trigger>
     <Tabs.Trigger class={styles.Trigger} value="billing">
-      {#snippet asChild(props)}
+      {#snippet render(props)}
         <a href="#billing" {...props()}>Billing</a>
       {/snippet}
     </Tabs.Trigger>

--- a/packages/svelte/src/lib/components/tags-input/examples/with-combobox.svelte
+++ b/packages/svelte/src/lib/components/tags-input/examples/with-combobox.svelte
@@ -59,7 +59,7 @@
         </TagsInput.Item>
       {/each}
       <Combobox.Input>
-        {#snippet asChild(inputProps)}
+        {#snippet render(inputProps)}
           <TagsInput.Input placeholder="Add Framework" class={styles.Input} {...inputProps()} />
         {/snippet}
       </Combobox.Input>

--- a/packages/svelte/src/lib/components/toggle-group/examples/with-tooltip.svelte
+++ b/packages/svelte/src/lib/components/toggle-group/examples/with-tooltip.svelte
@@ -24,7 +24,7 @@
   <ToggleGroup.Root defaultValue={['bold']} ids={{ item: getTriggerId }} class={styles.Root}>
     {#each items as item (item.value)}
       <ToggleGroup.Item value={item.value} aria-label={item.label} class={styles.Item}>
-        {#snippet asChild(itemProps)}
+        {#snippet render(itemProps)}
           <Tooltip.Trigger value={item.value} {...itemProps()}>
             <item.icon />
           </Tooltip.Trigger>

--- a/packages/svelte/src/lib/components/tree-view/examples/context-menu.svelte
+++ b/packages/svelte/src/lib/components/tree-view/examples/context-menu.svelte
@@ -72,7 +72,7 @@
             <TreeView.Node class={styles.Node}>
               <Menu.Root ids={{ contextTrigger: triggerId }}>
                 <TreeView.Cell class={styles.Cell}>
-                  {#snippet asChild(cellProps)}
+                  {#snippet render(cellProps)}
                     <Menu.ContextTrigger {...cellProps()}>
                       <TreeView.NodeExpandTrigger class={styles.NodeExpandTrigger}>
                         <TreeView.NodeIndicator type="expanded" class={styles.NodeIndicator}>
@@ -104,7 +104,7 @@
           <TreeView.Node class={styles.Node}>
             <Menu.Root ids={{ contextTrigger: triggerId }}>
               <TreeView.Cell class={styles.Cell}>
-                {#snippet asChild(cellProps)}
+                {#snippet render(cellProps)}
                   <Menu.ContextTrigger {...cellProps()}>
                     <FileIcon />
                     <TreeView.NodeText class={styles.NodeText}>{node.name}</TreeView.NodeText>

--- a/packages/svelte/src/lib/components/tree-view/examples/links-tree-node.svelte
+++ b/packages/svelte/src/lib/components/tree-view/examples/links-tree-node.svelte
@@ -51,7 +51,7 @@
       {:else}
         <TreeView.Node class={styles.Node}>
           <TreeView.Cell class={styles.Cell}>
-            {#snippet asChild(itemProps)}
+            {#snippet render(itemProps)}
               <a href={node.href} {...itemProps()}>
                 <TreeView.NodeText class={styles.NodeText}>
                   <FileIcon />


### PR DESCRIPTION
## 📝 Description

Migrates the example suite from the deprecated `asChild` prop to the v6 `render` prop using `@ark-ui/codemod` (#4024).

## ⛳️ Current behavior

Examples demonstrate composition with `asChild` and a child element.

## 🚀 New behavior

Examples use `render` instead:

| Framework | Shape |
| --- | --- |
| React | `render={<child />}` |
| Solid | `render={(props) => <b {...props} />}` (accessor dropped) |
| Svelte | `{#snippet render(props)}` |
| Vue | `#render="{ props }"` + `v-bind="props"` on the child |

The dedicated `popover/examples/as-child.*` demos are intentionally left on `asChild` — they document the prop, which still works in v6.

## 🧩 Frameworks

- [x] React
- [x] Solid
- [x] Svelte
- [x] Vue
- [ ] Not framework-specific

## 💣 Is this a breaking change (Yes/No):

No. Examples only, no published API change. The `asChild` prop itself remains supported (deprecated) in v6.

## ✅ Checklist

- [ ] Added a changeset for user-facing changes
- [ ] Added or updated tests
- [ ] Added an example for any new prop or part
- [ ] Updated the docs

## 📝 Additional information

Docs/examples only, so no changeset. Produced by running the `as-child-to-render` transforms from `@ark-ui/codemod`; the four `popover` `as-child` demos were restored by hand.
