### PR TITLE
fix(codemod): solid render fix, ark-component scoping, cross-file resolution, edge cases

### DIFF
--- a/.changeset/codemod-solid-render-accessor.md
+++ b/.changeset/codemod-solid-render-accessor.md
@@ -1,0 +1,5 @@
+---
+'@ark-ui/codemod': patch
+---
+
+Fix the Solid `as-child-to-render` transform. Solid's `render` prop takes the same props **function** as `asChild`, so it must be called (`{...props()}`) to spread the part's props. The transform was rewriting `props()` to `props`, which spread the function itself and forwarded nothing (including the child's own content). It is now a pure rename that leaves the callback body untouched.

--- a/.changeset/codemod-solid-render-accessor.md
+++ b/.changeset/codemod-solid-render-accessor.md
@@ -6,4 +6,5 @@ Fix and harden the `as-child-to-render` transforms.
 
 - Solid's `render` prop takes the same props **function** as `asChild`, so it must be called (`{...props()}`) to spread the part's props. The transform was rewriting `props()` to `props`, which spread the function itself and forwarded nothing (including the child's own content). It is now a pure rename that leaves the callback body untouched.
 - The React, Solid and Vue transforms now act only on Ark UI components — elements whose tag resolves to an `@ark-ui/*` import (following aliases) — instead of any element that happens to use `asChild`, so a Radix or other library's `asChild` in the same file is left alone. The Svelte transform keys off the Ark-specific `asChild` snippet name.
+- A `--cross-file` flag (React and Solid) resolves Ark parts imported through local barrels/re-exports back to `@ark-ui/*` — direct, transitive, aliased, `export *`, and import-then-reexport chains — so wrapped imports migrate too.
 - React skips an element that already has a `render` prop rather than emitting two.

--- a/.changeset/codemod-solid-render-accessor.md
+++ b/.changeset/codemod-solid-render-accessor.md
@@ -2,4 +2,8 @@
 '@ark-ui/codemod': patch
 ---
 
-Fix the Solid `as-child-to-render` transform. Solid's `render` prop takes the same props **function** as `asChild`, so it must be called (`{...props()}`) to spread the part's props. The transform was rewriting `props()` to `props`, which spread the function itself and forwarded nothing (including the child's own content). It is now a pure rename that leaves the callback body untouched.
+Fix and harden the `as-child-to-render` transforms.
+
+- Solid's `render` prop takes the same props **function** as `asChild`, so it must be called (`{...props()}`) to spread the part's props. The transform was rewriting `props()` to `props`, which spread the function itself and forwarded nothing (including the child's own content). It is now a pure rename that leaves the callback body untouched.
+- The React, Solid and Vue transforms now act only on Ark UI components — elements whose tag resolves to an `@ark-ui/*` import (following aliases) — instead of any element that happens to use `asChild`, so a Radix or other library's `asChild` in the same file is left alone. The Svelte transform keys off the Ark-specific `asChild` snippet name.
+- React skips an element that already has a `render` prop rather than emitting two.

--- a/packages/codemod/README.md
+++ b/packages/codemod/README.md
@@ -44,6 +44,7 @@ overrides that.
 | `-e, --exclude`     | —         | Globs to skip                           |
 | `-c, --concurrency` | cpu count | Files to process at once                |
 | `--force`           | `false`   | Run even with uncommitted changes       |
+| `--cross-file`      | `false`   | Resolve ark parts imported through local barrels (react, solid) |
 
 Paths are globs, `**/*` by default. `.gitignore`, `node_modules` and `dist` are always skipped.
 
@@ -60,7 +61,9 @@ See [docs/AS_CHILD_MIGRATION.md](./docs/AS_CHILD_MIGRATION.md) for what each one
 
 ## Scope
 
-The React, Solid and Vue transforms only touch Ark UI parts — elements whose tag resolves to an `@ark-ui/*` import, following aliases (`import { Menu as M }`) and the `ark` factory. Another library's `asChild` (Radix, for one) in the same file is left alone, and a file that never imports Ark is skipped. If you re-export Ark parts through a local barrel, run the codemod against the barrel's own imports, or use `--force` and review the diff. The Svelte transform keys off the Ark-specific `asChild` snippet name instead.
+The React, Solid and Vue transforms only touch Ark UI parts — elements whose tag resolves to an `@ark-ui/*` import, following aliases (`import { Menu as M }`) and the `ark` factory. Another library's `asChild` (Radix, for one) in the same file is left alone, and a file that never imports Ark is skipped. The Svelte transform keys off the Ark-specific `asChild` snippet name instead.
+
+If you re-export Ark parts through a local barrel — `import { Menu } from '@/components/ui'` where `ui` re-exports `@ark-ui/react/menu` — pass `--cross-file` (React and Solid). It resolves the import back to `@ark-ui/*` through direct, transitive, aliased, `export *`, and import-then-reexport chains, using the nearest `tsconfig.json` for path aliases. It is off by default because it reads sibling files.
 
 ## What it will not do
 

--- a/packages/codemod/README.md
+++ b/packages/codemod/README.md
@@ -8,9 +8,10 @@ npx @ark-ui/codemod react/as-child-to-render "src/**/*.tsx" --dry
 npx @ark-ui/codemod react/as-child-to-render "src/**/*.tsx"
 ```
 
-Run it without a transform in a terminal and it prompts you to pick one, then reports progress as it goes. Pipe it or
-run it in CI (no TTY) and it stays non-interactive: pass the transform as an argument and it prints plain output, so
-scripts never hang on a prompt.
+Run it without a transform in a terminal and it prompts you to pick one or more — handy when a library ships across
+frameworks and you want to migrate every package in one run — then reports progress per transform. Pipe it or run it
+in CI (no TTY) and it stays non-interactive: pass the transform as an argument and it prints plain output, so scripts
+never hang on a prompt.
 
 ## Try it first
 

--- a/packages/codemod/README.md
+++ b/packages/codemod/README.md
@@ -58,6 +58,10 @@ Paths are globs, `**/*` by default. `.gitignore`, `node_modules` and `dist` are 
 
 See [docs/AS_CHILD_MIGRATION.md](./docs/AS_CHILD_MIGRATION.md) for what each one does and what it leaves for you.
 
+## Scope
+
+The React, Solid and Vue transforms only touch Ark UI parts — elements whose tag resolves to an `@ark-ui/*` import, following aliases (`import { Menu as M }`) and the `ark` factory. Another library's `asChild` (Radix, for one) in the same file is left alone, and a file that never imports Ark is skipped. If you re-export Ark parts through a local barrel, run the codemod against the barrel's own imports, or use `--force` and review the diff. The Svelte transform keys off the Ark-specific `asChild` snippet name instead.
+
 ## What it will not do
 
 A codemod that guesses is worse than one that stops. Anything ambiguous is left alone and reported:

--- a/packages/codemod/docs/AS_CHILD_MIGRATION.md
+++ b/packages/codemod/docs/AS_CHILD_MIGRATION.md
@@ -56,7 +56,7 @@ npx @ark-ui/codemod solid/as-child-to-render "src/**/*.tsx" --dry
 `render` also passes the part's state as a second argument, which existing call sites simply do not declare:
 
 ```tsx
-<Switch.Thumb render={(props, state) => <span {...props()}>{state().checked ? '✓' : ''}</span>} />
+<Switch.Root render={(props, state) => <label {...props()}>{state().checked ? 'On' : 'Off'}</label>} />
 ```
 
 ## Vue

--- a/packages/codemod/docs/AS_CHILD_MIGRATION.md
+++ b/packages/codemod/docs/AS_CHILD_MIGRATION.md
@@ -41,8 +41,8 @@ should not make. For a conditional, the equivalent is usually a function:
 
 ## Solid
 
-`asChild` already took a callback, but it received a props **accessor**. `render` receives the props directly, so the
-call goes.
+`asChild` and `render` take the same callback: a props **function** you call to spread the part's props. So this is a
+pure rename — `{...props()}` stays exactly as it is.
 
 ```sh
 npx @ark-ui/codemod solid/as-child-to-render "src/**/*.tsx" --dry
@@ -50,16 +50,13 @@ npx @ark-ui/codemod solid/as-child-to-render "src/**/*.tsx" --dry
 
 ```diff
 - <Popover.Trigger asChild={(props) => <button {...props()} />}>Open</Popover.Trigger>
-+ <Popover.Trigger render={(props) => <button {...props} />}>Open</Popover.Trigger>
++ <Popover.Trigger render={(props) => <button {...props()} />}>Open</Popover.Trigger>
 ```
-
-Only `props()` — a zero-argument call on the callback's own parameter — is unwrapped. An unrelated call keeping the same
-name is untouched.
 
 `render` also passes the part's state as a second argument, which existing call sites simply do not declare:
 
 ```tsx
-<Switch.Thumb render={(props, state) => <span {...props}>{state.checked ? '✓' : ''}</span>} />
+<Switch.Thumb render={(props, state) => <span {...props()}>{state().checked ? '✓' : ''}</span>} />
 ```
 
 ## Vue

--- a/packages/codemod/src/index.ts
+++ b/packages/codemod/src/index.ts
@@ -35,27 +35,34 @@ program
   .action(async (name: string | undefined, paths: string[], options) => {
     if (interactive) p.intro(pc.bgCyan(pc.black(' ark-codemod ')))
 
-    if (!name) {
-      if (!interactive) {
-        program.outputHelp()
-        console.log(`\nRun ${pc.bold('ark-codemod list')} to see the transforms.`)
-        return
-      }
-      const picked = await p.select({
-        message: 'Which transform do you want to run?',
+    let names: string[]
+    if (name) {
+      names = [name]
+    } else if (interactive) {
+      const picked = await p.multiselect({
+        message: 'Which transforms do you want to run?',
         options: transforms.map((t) => ({ value: t.name, label: t.name, hint: t.description })),
+        required: true,
       })
-      if (p.isCancel(picked)) return p.cancel('Nothing to do.')
-      name = picked
+      if (p.isCancel(picked) || picked.length === 0) return p.cancel('Nothing to do.')
+      names = picked
+    } else {
+      program.outputHelp()
+      console.log(`\nRun ${pc.bold('ark-codemod list')} to see the transforms.`)
+      return
     }
 
-    const transform = findTransform(name)
-    if (!transform) {
-      const msg = `Unknown transform: ${name}. Run ${pc.bold('ark-codemod list')} to see what is available.`
-      if (interactive) p.cancel(msg)
-      else console.error(pc.red(msg))
-      process.exitCode = 1
-      return
+    const selected = []
+    for (const n of names) {
+      const transform = findTransform(n)
+      if (!transform) {
+        const msg = `Unknown transform: ${n}. Run ${pc.bold('ark-codemod list')} to see what is available.`
+        if (interactive) p.cancel(msg)
+        else console.error(pc.red(msg))
+        process.exitCode = 1
+        return
+      }
+      selected.push(transform)
     }
 
     const cwd = process.cwd()
@@ -75,20 +82,22 @@ program
       }
     }
 
-    const spinner = interactive && !options.dry ? p.spinner() : undefined
-    spinner?.start(`Running ${transform.name}`)
-    const summary = await runTransform(transform, {
-      cwd,
-      include: paths,
-      exclude: options.exclude,
-      dry: options.dry,
-      concurrency: Number(options.concurrency),
-      printDiff: options.diff,
-      crossFile: options.crossFile,
-    })
-    spinner?.stop(`Ran ${transform.name}`)
+    for (const transform of selected) {
+      const spinner = interactive && !options.dry ? p.spinner() : undefined
+      spinner?.start(`Running ${transform.name}`)
+      const summary = await runTransform(transform, {
+        cwd,
+        include: paths,
+        exclude: options.exclude,
+        dry: options.dry,
+        concurrency: Number(options.concurrency),
+        printDiff: options.diff,
+        crossFile: options.crossFile,
+      })
+      spinner?.stop(`Ran ${transform.name}`)
 
-    printSummary(transform, summary, options.dry, interactive)
+      printSummary(transform, summary, options.dry, interactive)
+    }
   })
 
 export async function run(): Promise<void> {

--- a/packages/codemod/src/index.ts
+++ b/packages/codemod/src/index.ts
@@ -31,6 +31,7 @@ program
   .option('-e, --exclude <globs...>', 'globs to skip', [])
   .option('-c, --concurrency <n>', 'files to process at once', String(availableParallelism()))
   .option('--force', 'run even though the working tree has uncommitted changes', false)
+  .option('--cross-file', 'resolve ark components imported through local barrels/re-exports (react, solid)', false)
   .action(async (name: string | undefined, paths: string[], options) => {
     if (interactive) p.intro(pc.bgCyan(pc.black(' ark-codemod ')))
 
@@ -83,6 +84,7 @@ program
       dry: options.dry,
       concurrency: Number(options.concurrency),
       printDiff: options.diff,
+      crossFile: options.crossFile,
     })
     spinner?.stop(`Ran ${transform.name}`)
 

--- a/packages/codemod/src/run.ts
+++ b/packages/codemod/src/run.ts
@@ -13,6 +13,7 @@ export interface RunOptions {
   dry: boolean
   concurrency: number
   printDiff: boolean
+  crossFile: boolean
 }
 
 export interface RunSummary {
@@ -42,7 +43,7 @@ export async function runTransform(transform: TransformDef, options: RunOptions)
       const source = await readFile(path, 'utf8')
       if (!source.includes('asChild') && !source.includes('as-child')) continue
 
-      const result = transform.run(source, path)
+      const result = transform.run(source, path, { crossFile: options.crossFile })
       for (const reason of result.skipped) summary.skipped.push([relative(options.cwd, path), reason])
       if (!result.code) continue
 

--- a/packages/codemod/src/transforms.ts
+++ b/packages/codemod/src/transforms.ts
@@ -13,7 +13,7 @@ export const transforms: TransformDef[] = [
   },
   {
     name: 'solid/as-child-to-render',
-    description: 'Rename the asChild callback to render and drop the props accessor call',
+    description: 'Rename the asChild callback to render',
     extensions: ['.tsx', '.jsx'],
     run: solidAsChildToRender,
   },

--- a/packages/codemod/src/transforms/as-child-to-render/react.ts
+++ b/packages/codemod/src/transforms/as-child-to-render/react.ts
@@ -1,15 +1,19 @@
-import { Node, Project, SyntaxKind } from 'ts-morph'
-import type { TransformResult } from '../../types.ts'
+import { Node, SyntaxKind } from 'ts-morph'
+import type { TransformOptions, TransformResult } from '../../types.ts'
 import { arkLocalNames, isTrackedJsx } from '../../utils/ark-imports.ts'
+import { createTransformSourceFile } from '../../utils/ts-project.ts'
 
-export function reactAsChildToRender(source: string, filePath: string): TransformResult {
-  const project = new Project({ useInMemoryFileSystem: true, compilerOptions: { jsx: 4 } })
-  const sf = project.createSourceFile(filePath.endsWith('.tsx') ? filePath : `${filePath}.tsx`, source)
+export function reactAsChildToRender(
+  source: string,
+  filePath: string,
+  options: TransformOptions = {},
+): TransformResult {
+  const sf = createTransformSourceFile(filePath, source, options.crossFile ?? false)
 
   let count = 0
   const skipped: string[] = []
 
-  const arkNames = arkLocalNames(sf)
+  const arkNames = arkLocalNames(sf, { crossFile: options.crossFile })
   if (arkNames.size === 0) return { code: null, count: 0, skipped: [] }
 
   const elements = sf.getDescendantsOfKind(SyntaxKind.JsxElement).reverse()

--- a/packages/codemod/src/transforms/as-child-to-render/react.ts
+++ b/packages/codemod/src/transforms/as-child-to-render/react.ts
@@ -26,6 +26,11 @@ export function reactAsChildToRender(source: string, filePath: string): Transfor
       continue
     }
 
+    if (opening.getAttribute('render')) {
+      skipped.push(`${describe(opening)}: element already has a render prop`)
+      continue
+    }
+
     const children = element.getJsxChildren().filter((child) => {
       if (Node.isJsxText(child)) return child.getText().trim().length > 0
       return true

--- a/packages/codemod/src/transforms/as-child-to-render/react.ts
+++ b/packages/codemod/src/transforms/as-child-to-render/react.ts
@@ -1,5 +1,6 @@
 import { Node, Project, SyntaxKind } from 'ts-morph'
 import type { TransformResult } from '../../types.ts'
+import { arkLocalNames, isTrackedJsx } from '../../utils/ark-imports.ts'
 
 export function reactAsChildToRender(source: string, filePath: string): TransformResult {
   const project = new Project({ useInMemoryFileSystem: true, compilerOptions: { jsx: 4 } })
@@ -8,12 +9,17 @@ export function reactAsChildToRender(source: string, filePath: string): Transfor
   let count = 0
   const skipped: string[] = []
 
+  const arkNames = arkLocalNames(sf)
+  if (arkNames.size === 0) return { code: null, count: 0, skipped: [] }
+
   const elements = sf.getDescendantsOfKind(SyntaxKind.JsxElement).reverse()
 
   for (const element of elements) {
     const opening = element.getOpeningElement()
     const asChild = opening.getAttribute('asChild')
     if (!asChild) continue
+
+    if (!isTrackedJsx(opening, arkNames)) continue
 
     if (!Node.isJsxAttribute(asChild)) {
       skipped.push(`${describe(opening)}: asChild is spread, not an attribute`)

--- a/packages/codemod/src/transforms/as-child-to-render/solid.ts
+++ b/packages/codemod/src/transforms/as-child-to-render/solid.ts
@@ -1,5 +1,7 @@
 import { Node, Project, SyntaxKind } from 'ts-morph'
+import type { JsxOpeningElement, JsxSelfClosingElement } from 'ts-morph'
 import type { TransformResult } from '../../types.ts'
+import { arkLocalNames, isTrackedJsx } from '../../utils/ark-imports.ts'
 
 export function solidAsChildToRender(source: string, filePath: string): TransformResult {
   const project = new Project({ useInMemoryFileSystem: true, compilerOptions: { jsx: 4 } })
@@ -8,8 +10,17 @@ export function solidAsChildToRender(source: string, filePath: string): Transfor
   let count = 0
   const skipped: string[] = []
 
+  const arkNames = arkLocalNames(sf)
+  if (arkNames.size === 0) return { code: null, count: 0, skipped: [] }
+
   for (const attr of sf.getDescendantsOfKind(SyntaxKind.JsxAttribute)) {
     if (attr.getNameNode().getText() !== 'asChild') continue
+
+    const opening = attr.getFirstAncestor(
+      (node): node is JsxOpeningElement | JsxSelfClosingElement =>
+        Node.isJsxOpeningElement(node) || Node.isJsxSelfClosingElement(node),
+    )
+    if (!opening || !isTrackedJsx(opening, arkNames)) continue
 
     const initializer = attr.getInitializer()
     if (!initializer || !Node.isJsxExpression(initializer)) {

--- a/packages/codemod/src/transforms/as-child-to-render/solid.ts
+++ b/packages/codemod/src/transforms/as-child-to-render/solid.ts
@@ -23,16 +23,6 @@ export function solidAsChildToRender(source: string, filePath: string): Transfor
       continue
     }
 
-    const [param] = fn.getParameters()
-    if (param) {
-      const name = param.getName()
-      for (const call of fn.getDescendantsOfKind(SyntaxKind.CallExpression)) {
-        if (call.getExpression().getText() === name && call.getArguments().length === 0) {
-          call.replaceWithText(name)
-        }
-      }
-    }
-
     attr.getNameNode().replaceWithText('render')
     count++
   }

--- a/packages/codemod/src/transforms/as-child-to-render/solid.ts
+++ b/packages/codemod/src/transforms/as-child-to-render/solid.ts
@@ -1,16 +1,20 @@
-import { Node, Project, SyntaxKind } from 'ts-morph'
+import { Node, SyntaxKind } from 'ts-morph'
 import type { JsxOpeningElement, JsxSelfClosingElement } from 'ts-morph'
-import type { TransformResult } from '../../types.ts'
+import type { TransformOptions, TransformResult } from '../../types.ts'
 import { arkLocalNames, isTrackedJsx } from '../../utils/ark-imports.ts'
+import { createTransformSourceFile } from '../../utils/ts-project.ts'
 
-export function solidAsChildToRender(source: string, filePath: string): TransformResult {
-  const project = new Project({ useInMemoryFileSystem: true, compilerOptions: { jsx: 4 } })
-  const sf = project.createSourceFile(filePath.endsWith('.tsx') ? filePath : `${filePath}.tsx`, source)
+export function solidAsChildToRender(
+  source: string,
+  filePath: string,
+  options: TransformOptions = {},
+): TransformResult {
+  const sf = createTransformSourceFile(filePath, source, options.crossFile ?? false)
 
   let count = 0
   const skipped: string[] = []
 
-  const arkNames = arkLocalNames(sf)
+  const arkNames = arkLocalNames(sf, { crossFile: options.crossFile })
   if (arkNames.size === 0) return { code: null, count: 0, skipped: [] }
 
   for (const attr of sf.getDescendantsOfKind(SyntaxKind.JsxAttribute)) {

--- a/packages/codemod/src/transforms/as-child-to-render/vue.ts
+++ b/packages/codemod/src/transforms/as-child-to-render/vue.ts
@@ -1,6 +1,7 @@
 import { parse } from '@vue/compiler-sfc'
 import MagicString from 'magic-string'
 import type { TransformResult } from '../../types.ts'
+import { arkLocalNamesFromSource, jsxBaseNameFromText } from '../../utils/ark-imports.ts'
 
 interface Loc {
   start: { offset: number }
@@ -36,11 +37,16 @@ export function vueAsChildToRender(source: string, _filePath: string): Transform
   const ast = descriptor.template?.ast as unknown as Node | undefined
   if (!ast) return { code: null, count: 0, skipped: [] }
 
+  const arkNames = arkLocalNamesFromSource(source)
+  if (arkNames.size === 0) return { code: null, count: 0, skipped: [] }
+
   const s = new MagicString(source)
   let count = 0
   const skipped: string[] = []
 
   walk(ast, (node) => {
+    if (!arkNames.has(jsxBaseNameFromText(node.tag ?? ''))) return
+
     const at = `line ${lineOf(source, node.loc.start.offset)}`
 
     const bound = node.props?.find((p) => p.type === DIRECTIVE && p.name === 'bind' && isAsChild(p.arg?.content))

--- a/packages/codemod/src/types.ts
+++ b/packages/codemod/src/types.ts
@@ -4,7 +4,11 @@ export interface TransformResult {
   skipped: string[]
 }
 
-export type Transform = (source: string, filePath: string) => TransformResult
+export interface TransformOptions {
+  crossFile?: boolean
+}
+
+export type Transform = (source: string, filePath: string, options?: TransformOptions) => TransformResult
 
 export interface TransformDef {
   name: string

--- a/packages/codemod/src/utils/ark-imports.ts
+++ b/packages/codemod/src/utils/ark-imports.ts
@@ -1,0 +1,76 @@
+import { Node } from 'ts-morph'
+import type { JsxOpeningElement, JsxSelfClosingElement, SourceFile } from 'ts-morph'
+
+type JsxOpening = JsxOpeningElement | JsxSelfClosingElement
+
+const ARK_SOURCE = /^@ark-ui\//
+
+export function getJsxBaseName(nameNode: Node): string {
+  if (Node.isPropertyAccessExpression(nameNode)) {
+    let current: Node = nameNode
+    while (Node.isPropertyAccessExpression(current)) current = current.getExpression()
+    return current.getText()
+  }
+  return nameNode.getText()
+}
+
+export function jsxBaseNameFromText(tag: string): string {
+  return tag.split('.')[0]
+}
+
+export function arkLocalNames(sf: SourceFile): Set<string> {
+  const names = new Set<string>()
+
+  for (const imp of sf.getImportDeclarations()) {
+    if (!ARK_SOURCE.test(imp.getModuleSpecifierValue())) continue
+    const def = imp.getDefaultImport()
+    if (def) names.add(def.getText())
+    const ns = imp.getNamespaceImport()
+    if (ns) names.add(ns.getText())
+    for (const spec of imp.getNamedImports()) {
+      names.add(spec.getAliasNode()?.getText() ?? spec.getName())
+    }
+  }
+
+  for (const decl of sf.getVariableDeclarations()) {
+    const init = decl.getInitializer()
+    if (!init) continue
+    if (Node.isIdentifier(init) && names.has(init.getText())) {
+      names.add(decl.getName())
+      continue
+    }
+    if (Node.isPropertyAccessExpression(init) && names.has(getJsxBaseName(init))) {
+      names.add(decl.getName())
+    }
+  }
+
+  return names
+}
+
+export function isTrackedJsx(opening: JsxOpening, arkNames: Set<string>): boolean {
+  return arkNames.has(getJsxBaseName(opening.getTagNameNode()))
+}
+
+export function arkLocalNamesFromSource(source: string): Set<string> {
+  const names = new Set<string>()
+  const importRe = /import\s+(?:type\s+)?([^'"]*?)\s+from\s*['"]@ark-ui\/[^'"]+['"]/g
+  for (const match of source.matchAll(importRe)) {
+    const clause = match[1]
+    const named = clause.match(/\{([^}]*)\}/)
+    if (named) {
+      for (const part of named[1].split(',')) {
+        const local = part
+          .replace(/^\s*type\s+/, '')
+          .split(/\s+as\s+/)
+          .pop()
+          ?.trim()
+        if (local) names.add(local)
+      }
+    }
+    const ns = clause.match(/\*\s+as\s+([\w$]+)/)
+    if (ns) names.add(ns[1])
+    const def = clause.replace(/\{[^}]*\}/, '').match(/^\s*([\w$]+)\s*,?/)
+    if (def) names.add(def[1])
+  }
+  return names
+}

--- a/packages/codemod/src/utils/ark-imports.ts
+++ b/packages/codemod/src/utils/ark-imports.ts
@@ -18,7 +18,7 @@ export function jsxBaseNameFromText(tag: string): string {
   return tag.split('.')[0]
 }
 
-export function arkLocalNames(sf: SourceFile): Set<string> {
+export function arkLocalNames(sf: SourceFile, options: { crossFile?: boolean } = {}): Set<string> {
   const names = new Set<string>()
 
   for (const imp of sf.getImportDeclarations()) {
@@ -44,7 +44,70 @@ export function arkLocalNames(sf: SourceFile): Set<string> {
     }
   }
 
+  if (options.crossFile) {
+    for (const imp of sf.getImportDeclarations()) {
+      if (ARK_SOURCE.test(imp.getModuleSpecifierValue())) continue
+      const target = imp.getModuleSpecifierSourceFile()
+      if (!target) continue
+      for (const spec of imp.getNamedImports()) {
+        const local = spec.getAliasNode()?.getText() ?? spec.getName()
+        if (names.has(local)) continue
+        if (reExportsArk(target, spec.getName(), new Set(), 0)) names.add(local)
+      }
+    }
+  }
+
   return names
+}
+
+const MAX_REEXPORT_DEPTH = 8
+
+function importedNameIsArk(file: SourceFile, localName: string): boolean {
+  for (const imp of file.getImportDeclarations()) {
+    if (!ARK_SOURCE.test(imp.getModuleSpecifierValue())) continue
+    if (imp.getDefaultImport()?.getText() === localName) return true
+    if (imp.getNamespaceImport()?.getText() === localName) return true
+    for (const spec of imp.getNamedImports()) {
+      if ((spec.getAliasNode()?.getText() ?? spec.getName()) === localName) return true
+    }
+  }
+  return false
+}
+
+function reExportsArk(file: SourceFile, exportName: string, visited: Set<string>, depth: number): boolean {
+  if (depth > MAX_REEXPORT_DEPTH) return false
+  const key = `${file.getFilePath()}::${exportName}`
+  if (visited.has(key)) return false
+  visited.add(key)
+
+  for (const exp of file.getExportDeclarations()) {
+    const spec = exp.getModuleSpecifierValue()
+    const named = exp.getNamedExports()
+
+    if (spec) {
+      const targetIsArk = ARK_SOURCE.test(spec)
+      let matched = false
+      for (const n of named) {
+        const exported = n.getAliasNode()?.getText() ?? n.getName()
+        if (exported !== exportName) continue
+        matched = true
+        if (targetIsArk) return true
+        const target = exp.getModuleSpecifierSourceFile()
+        if (target && reExportsArk(target, n.getName(), visited, depth + 1)) return true
+      }
+      if (!matched && named.length === 0) {
+        if (targetIsArk) return true
+        const target = exp.getModuleSpecifierSourceFile()
+        if (target && reExportsArk(target, exportName, visited, depth + 1)) return true
+      }
+    } else {
+      for (const n of named) {
+        const exported = n.getAliasNode()?.getText() ?? n.getName()
+        if (exported === exportName && importedNameIsArk(file, n.getName())) return true
+      }
+    }
+  }
+  return false
 }
 
 export function isTrackedJsx(opening: JsxOpening, arkNames: Set<string>): boolean {

--- a/packages/codemod/src/utils/ts-project.ts
+++ b/packages/codemod/src/utils/ts-project.ts
@@ -1,0 +1,38 @@
+import { existsSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { Project } from 'ts-morph'
+import type { SourceFile } from 'ts-morph'
+
+const projectCache = new Map<string, Project>()
+
+function nearestTsConfig(filePath: string): string | undefined {
+  let dir = dirname(filePath)
+  for (let depth = 0; depth < 30; depth++) {
+    const candidate = join(dir, 'tsconfig.json')
+    if (existsSync(candidate)) return candidate
+    const parent = dirname(dir)
+    if (parent === dir) return undefined
+    dir = parent
+  }
+  return undefined
+}
+
+export function createTransformSourceFile(filePath: string, source: string, crossFile: boolean): SourceFile {
+  const path = /\.(tsx|jsx)$/.test(filePath) ? filePath : `${filePath}.tsx`
+
+  if (!crossFile) {
+    const project = new Project({ useInMemoryFileSystem: true, compilerOptions: { jsx: 4 } })
+    return project.createSourceFile(path, source)
+  }
+
+  const tsConfigFilePath = nearestTsConfig(path)
+  const key = tsConfigFilePath ?? '\0default'
+  let project = projectCache.get(key)
+  if (!project) {
+    project = tsConfigFilePath
+      ? new Project({ tsConfigFilePath, skipAddingFilesFromTsConfig: true })
+      : new Project({ compilerOptions: { jsx: 4, allowJs: true } })
+    projectCache.set(key, project)
+  }
+  return project.createSourceFile(path, source, { overwrite: true })
+}

--- a/packages/codemod/tests/as-child-to-render.test.ts
+++ b/packages/codemod/tests/as-child-to-render.test.ts
@@ -44,22 +44,22 @@ describe('react', () => {
 })
 
 describe('solid', () => {
-  it('renames the callback and drops the accessor call', () => {
+  it('renames the callback and keeps the props accessor call', () => {
     const result = solidAsChildToRender(
       `const A = () => <Popover.Trigger asChild={(props) => <button {...props()} />}>Open</Popover.Trigger>`,
       'a.tsx',
     )
     expect(result.count).toBe(1)
-    expect(result.code).toContain('render={(props) => <button {...props} />}')
-    expect(result.code).not.toContain('props()')
+    expect(result.code).toContain('render={(props) => <button {...props()} />}')
   })
 
-  it('leaves an unrelated call of the same name alone', () => {
+  it('keeps props calls that pass merge arguments', () => {
     const result = solidAsChildToRender(
-      `const A = () => <X asChild={(props) => <b {...props()}>{other()}</b>} />`,
+      `const A = () => <X asChild={(props) => <b {...props({ class: 'x' })}>{other()}</b>} />`,
       'a.tsx',
     )
-    expect(result.code).toContain('other()')
+    expect(result.count).toBe(1)
+    expect(result.code).toContain("render={(props) => <b {...props({ class: 'x' })}>{other()}</b>}")
   })
 })
 

--- a/packages/codemod/tests/as-child-to-render.test.ts
+++ b/packages/codemod/tests/as-child-to-render.test.ts
@@ -277,7 +277,7 @@ const A = () => <Popover.Trigger asChild={(props) => { return <button {...props(
     it('keeps the call when the state accessor is also used', () => {
       const result = solidAsChildToRender(
         `import { Switch } from '@ark-ui/solid/switch'
-const A = () => <Switch.Thumb asChild={(props, state) => <span {...props()}>{state().checked}</span>} />`,
+const A = () => <Switch.Root asChild={(props, state) => <label {...props()}>{state().checked}</label>} />`,
         'a.tsx',
       )
       expect(result.code).toContain('{...props()}')

--- a/packages/codemod/tests/as-child-to-render.test.ts
+++ b/packages/codemod/tests/as-child-to-render.test.ts
@@ -132,3 +132,99 @@ describe('vue bound asChild', () => {
     expect(result.code).toContain('<b v-bind="props" :class="c">y</b>')
   })
 })
+
+// Regressions for the ways a transform can silently emit broken code.
+describe('edge cases', () => {
+  describe('solid keeps the props call in every shape', () => {
+    it('keeps the call inside a block body', () => {
+      const result = solidAsChildToRender(
+        `const A = () => <Popover.Trigger asChild={(props) => { return <button {...props()} /> }}>Open</Popover.Trigger>`,
+        'a.tsx',
+      )
+      expect(result.count).toBe(1)
+      expect(result.code).toContain('{...props()}')
+      expect(result.code).toContain('render={(props) => { return <button {...props()} /> }}')
+    })
+
+    it('keeps the call when the state accessor is also used', () => {
+      const result = solidAsChildToRender(
+        `const A = () => <Switch.Thumb asChild={(props, state) => <span {...props()}>{state().checked}</span>} />`,
+        'a.tsx',
+      )
+      expect(result.code).toContain('{...props()}')
+      expect(result.code).toContain('{state().checked}')
+    })
+
+    it('renames every asChild in a file and leaves each body intact', () => {
+      const result = solidAsChildToRender(
+        `const A = () => (
+  <>
+    <Menu.Item asChild={(props) => <a href="/1" {...props()} />}>One</Menu.Item>
+    <Menu.Item asChild={(props) => <a href="/2" {...props()} />}>Two</Menu.Item>
+  </>
+)`,
+        'a.tsx',
+      )
+      expect(result.count).toBe(2)
+      expect(result.code).not.toContain('asChild')
+      expect(result.code?.match(/\{\.\.\.props\(\)\}/g)).toHaveLength(2)
+    })
+
+    it('renames nested render callbacks without touching the inner call', () => {
+      const result = solidAsChildToRender(
+        `const A = () => <Tooltip.Trigger asChild={(outer) => <Dialog.Trigger asChild={(inner) => <button {...inner()} />} {...outer()} />} />`,
+        'a.tsx',
+      )
+      expect(result.count).toBe(2)
+      expect(result.code).toContain('{...outer()}')
+      expect(result.code).toContain('{...inner()}')
+      expect(result.code).not.toContain('asChild')
+    })
+  })
+
+  describe('react does not emit invalid jsx', () => {
+    it('skips an element that already has a render prop instead of writing two', () => {
+      const result = reactAsChildToRender(
+        `const A = () => <Menu.Item asChild render={<a href="#">x</a>}><b>y</b></Menu.Item>`,
+        'a.tsx',
+      )
+      expect(result.code).toBeNull()
+      expect(result.skipped[0]).toContain('already has a render prop')
+    })
+
+    it('preserves a member-expression tag name', () => {
+      const result = reactAsChildToRender(`const A = () => <Menu.Item asChild><a href="#">Go</a></Menu.Item>`, 'a.tsx')
+      expect(result.code).toContain('<Menu.Item render={<a href="#">Go</a>} />')
+    })
+
+    it('skips when the child is an expression container, not an element', () => {
+      const result = reactAsChildToRender(`const A = () => <Popover.Trigger asChild>{child}</Popover.Trigger>`, 'a.tsx')
+      expect(result.code).toBeNull()
+      expect(result.skipped[0]).toContain('not an element')
+    })
+  })
+
+  describe('vue and svelte', () => {
+    it('vue rewrites two asChild parts in one template', () => {
+      const result = vueAsChildToRender(`<template><X asChild><a>1</a></X><Y asChild><b>2</b></Y></template>`, 'a.vue')
+      expect(result.count).toBe(2)
+      expect(result.code).toContain('<a v-bind="props">1</a>')
+      expect(result.code).toContain('<b v-bind="props">2</b>')
+    })
+
+    it('svelte renames every asChild snippet and keeps the props call', () => {
+      const result = svelteAsChildToRender(
+        `<A>
+  {#snippet asChild(props)}<a {...props()}>1</a>{/snippet}
+</A>
+<B>
+  {#snippet asChild(props)}<b {...props()}>2</b>{/snippet}
+</B>`,
+        'a.svelte',
+      )
+      expect(result.count).toBe(2)
+      expect(result.code).not.toContain('asChild')
+      expect(result.code?.match(/\{\.\.\.props\(\)\}/g)).toHaveLength(2)
+    })
+  })
+})

--- a/packages/codemod/tests/as-child-to-render.test.ts
+++ b/packages/codemod/tests/as-child-to-render.test.ts
@@ -7,7 +7,8 @@ import { vueAsChildToRender } from '../src/transforms/as-child-to-render/vue.ts'
 describe('react', () => {
   it('lifts the child into a render prop', () => {
     const result = reactAsChildToRender(
-      `export const A = () => (
+      `import { Popover } from '@ark-ui/react/popover'
+export const A = () => (
   <Popover.Trigger asChild>
     <button>Open Popover</button>
   </Popover.Trigger>
@@ -21,7 +22,8 @@ describe('react', () => {
 
   it("keeps the part's own props", () => {
     const result = reactAsChildToRender(
-      `const A = () => <Menu.Item asChild value="x" className="y"><a href="#">Go</a></Menu.Item>`,
+      `import { Menu } from '@ark-ui/react/menu'
+const A = () => <Menu.Item asChild value="x" className="y"><a href="#">Go</a></Menu.Item>`,
       'a.tsx',
     )
     expect(result.code).toContain('value="x"')
@@ -31,7 +33,8 @@ describe('react', () => {
 
   it('leaves several children alone and says why', () => {
     const result = reactAsChildToRender(
-      `const A = () => <Popover.Trigger asChild><span/><span/></Popover.Trigger>`,
+      `import { Popover } from '@ark-ui/react/popover'
+const A = () => <Popover.Trigger asChild><span/><span/></Popover.Trigger>`,
       'a.tsx',
     )
     expect(result.code).toBeNull()
@@ -39,14 +42,21 @@ describe('react', () => {
   })
 
   it('does nothing to a file without asChild', () => {
-    expect(reactAsChildToRender(`const A = () => <Popover.Trigger>Open</Popover.Trigger>`, 'a.tsx').code).toBeNull()
+    expect(
+      reactAsChildToRender(
+        `import { Popover } from '@ark-ui/react/popover'
+const A = () => <Popover.Trigger>Open</Popover.Trigger>`,
+        'a.tsx',
+      ).code,
+    ).toBeNull()
   })
 })
 
 describe('solid', () => {
   it('renames the callback and keeps the props accessor call', () => {
     const result = solidAsChildToRender(
-      `const A = () => <Popover.Trigger asChild={(props) => <button {...props()} />}>Open</Popover.Trigger>`,
+      `import { Popover } from '@ark-ui/solid/popover'
+const A = () => <Popover.Trigger asChild={(props) => <button {...props()} />}>Open</Popover.Trigger>`,
       'a.tsx',
     )
     expect(result.count).toBe(1)
@@ -55,7 +65,8 @@ describe('solid', () => {
 
   it('keeps props calls that pass merge arguments', () => {
     const result = solidAsChildToRender(
-      `const A = () => <X asChild={(props) => <b {...props({ class: 'x' })}>{other()}</b>} />`,
+      `import { X } from '@ark-ui/solid/x'
+const A = () => <X asChild={(props) => <b {...props({ class: 'x' })}>{other()}</b>} />`,
       'a.tsx',
     )
     expect(result.count).toBe(1)
@@ -66,7 +77,10 @@ describe('solid', () => {
 describe('vue', () => {
   it('turns asChild into a render slot and binds props on the child', () => {
     const result = vueAsChildToRender(
-      `<template>
+      `<script setup lang="ts">
+import { Popover } from '@ark-ui/vue/popover'
+</script>
+<template>
   <Popover.Trigger asChild>
     <button>Open Popover</button>
   </Popover.Trigger>
@@ -79,13 +93,21 @@ describe('vue', () => {
   })
 
   it('accepts the kebab spelling', () => {
-    const result = vueAsChildToRender(`<template><X as-child><b>y</b></X></template>`, 'a.vue')
+    const result = vueAsChildToRender(
+      `<script setup lang="ts">import { X } from '@ark-ui/vue/x'</script>
+<template><X as-child><b>y</b></X></template>`,
+      'a.vue',
+    )
     expect(result.count).toBe(1)
     expect(result.code).toContain('#render="{ props }"')
   })
 
   it('skips a child that already binds props', () => {
-    const result = vueAsChildToRender(`<template><X asChild><b v-bind="other">y</b></X></template>`, 'a.vue')
+    const result = vueAsChildToRender(
+      `<script setup lang="ts">import { X } from '@ark-ui/vue/x'</script>
+<template><X asChild><b v-bind="other">y</b></X></template>`,
+      'a.vue',
+    )
     expect(result.code).toBeNull()
     expect(result.skipped[0]).toContain('already binds props')
   })
@@ -94,7 +116,8 @@ describe('vue', () => {
 describe('svelte', () => {
   it('renames the snippet', () => {
     const result = svelteAsChildToRender(
-      `<Popover.Trigger>
+      `<script lang="ts">import { Popover } from '@ark-ui/svelte/popover'</script>
+<Popover.Trigger>
   {#snippet asChild(props)}
     <button {...props()}>Open Popover</button>
   {/snippet}
@@ -107,7 +130,11 @@ describe('svelte', () => {
   })
 
   it('reports a bare attribute it cannot migrate', () => {
-    const result = svelteAsChildToRender(`<Popover.Trigger asChild>x</Popover.Trigger>`, 'a.svelte')
+    const result = svelteAsChildToRender(
+      `<script lang="ts">import { Popover } from '@ark-ui/svelte/popover'</script>
+<Popover.Trigger asChild>x</Popover.Trigger>`,
+      'a.svelte',
+    )
     expect(result.code).toBeNull()
     expect(result.skipped[0]).toContain('bare asChild')
   })
@@ -115,30 +142,131 @@ describe('svelte', () => {
 
 describe('vue bound asChild', () => {
   it('reports a shorthand bound asChild instead of skipping it silently', () => {
-    const result = vueAsChildToRender(`<template><X :as-child="cond"><b>y</b></X></template>`, 'a.vue')
+    const result = vueAsChildToRender(
+      `<script setup lang="ts">import { X } from '@ark-ui/vue/x'</script>
+<template><X :as-child="cond"><b>y</b></X></template>`,
+      'a.vue',
+    )
     expect(result.code).toBeNull()
     expect(result.skipped).toHaveLength(1)
     expect(result.skipped[0]).toContain('bound to an expression')
   })
 
   it('reports the long form too', () => {
-    const result = vueAsChildToRender(`<template><X v-bind:as-child="flag"><b>y</b></X></template>`, 'a.vue')
+    const result = vueAsChildToRender(
+      `<script setup lang="ts">import { X } from '@ark-ui/vue/x'</script>
+<template><X v-bind:as-child="flag"><b>y</b></X></template>`,
+      'a.vue',
+    )
     expect(result.skipped[0]).toContain('bound to an expression')
   })
 
   it('does not mistake a bound attribute on the child for v-bind', () => {
-    const result = vueAsChildToRender(`<template><X asChild><b :class="c">y</b></X></template>`, 'a.vue')
+    const result = vueAsChildToRender(
+      `<script setup lang="ts">import { X } from '@ark-ui/vue/x'</script>
+<template><X asChild><b :class="c">y</b></X></template>`,
+      'a.vue',
+    )
     expect(result.count).toBe(1)
     expect(result.code).toContain('<b v-bind="props" :class="c">y</b>')
   })
 })
 
-// Regressions for the ways a transform can silently emit broken code.
+describe('component identification', () => {
+  it('react leaves a non-ark component with asChild untouched', () => {
+    const result = reactAsChildToRender(
+      `import { Menu } from '@ark-ui/react/menu'
+import { Tooltip } from '@radix-ui/react-tooltip'
+const A = () => (
+  <>
+    <Menu.Item asChild><a href="/1">Ark</a></Menu.Item>
+    <Tooltip.Trigger asChild><a href="/2">Radix</a></Tooltip.Trigger>
+  </>
+)`,
+      'a.tsx',
+    )
+    expect(result.count).toBe(1)
+    expect(result.code).toContain('<Menu.Item render={<a href="/1">Ark</a>} />')
+    expect(result.code).toContain('<Tooltip.Trigger asChild>')
+  })
+
+  it('react skips a file that never imports ark', () => {
+    const result = reactAsChildToRender(
+      `import { Tooltip } from '@radix-ui/react-tooltip'
+const A = () => <Tooltip.Trigger asChild><a href="#">x</a></Tooltip.Trigger>`,
+      'a.tsx',
+    )
+    expect(result.code).toBeNull()
+    expect(result.count).toBe(0)
+  })
+
+  it('react follows an aliased import', () => {
+    const result = reactAsChildToRender(
+      `import { Menu as M } from '@ark-ui/react/menu'
+const A = () => <M.Item asChild><a href="#">x</a></M.Item>`,
+      'a.tsx',
+    )
+    expect(result.count).toBe(1)
+    expect(result.code).toContain('<M.Item render={<a href="#">x</a>} />')
+  })
+
+  it('react tracks the ark factory element', () => {
+    const result = reactAsChildToRender(
+      `import { ark } from '@ark-ui/react/factory'
+const A = () => <ark.div asChild><span>x</span></ark.div>`,
+      'a.tsx',
+    )
+    expect(result.count).toBe(1)
+    expect(result.code).toContain('<ark.div render={<span>x</span>} />')
+  })
+
+  it('solid leaves a non-ark component alone', () => {
+    const result = solidAsChildToRender(
+      `import { Menu } from '@ark-ui/solid/menu'
+const A = () => (
+  <>
+    <Menu.Item asChild={(props) => <a {...props()} />} />
+    <Other asChild={(props) => <a {...props()} />} />
+  </>
+)`,
+      'a.tsx',
+    )
+    expect(result.count).toBe(1)
+    expect(result.code).toContain('<Menu.Item render={(props) => <a {...props()} />} />')
+    expect(result.code).toContain('<Other asChild={(props) => <a {...props()} />} />')
+  })
+
+  it('vue leaves a non-ark tag alone', () => {
+    const result = vueAsChildToRender(
+      `<script setup lang="ts">import { Popover } from '@ark-ui/vue/popover'</script>
+<template><Popover.Trigger asChild><a>ark</a></Popover.Trigger><Other asChild><a>no</a></Other></template>`,
+      'a.vue',
+    )
+    expect(result.count).toBe(1)
+    expect(result.code).toContain('<a v-bind="props">ark</a>')
+    expect(result.code).toContain('<Other asChild><a>no</a></Other>')
+  })
+
+  it('svelte keys off the asChild snippet name, not the import path', () => {
+    const result = svelteAsChildToRender(
+      `<script lang="ts">import { Menu } from '$lib'</script>
+<Menu.Item>
+  {#snippet asChild(props)}<button {...props()}>x</button>{/snippet}
+</Menu.Item>`,
+      'a.svelte',
+    )
+    expect(result.count).toBe(1)
+    expect(result.code).toContain('{#snippet render(props)}')
+    expect(result.code).toContain('{...props()}')
+  })
+})
+
 describe('edge cases', () => {
   describe('solid keeps the props call in every shape', () => {
     it('keeps the call inside a block body', () => {
       const result = solidAsChildToRender(
-        `const A = () => <Popover.Trigger asChild={(props) => { return <button {...props()} /> }}>Open</Popover.Trigger>`,
+        `import { Popover } from '@ark-ui/solid/popover'
+const A = () => <Popover.Trigger asChild={(props) => { return <button {...props()} /> }}>Open</Popover.Trigger>`,
         'a.tsx',
       )
       expect(result.count).toBe(1)
@@ -148,7 +276,8 @@ describe('edge cases', () => {
 
     it('keeps the call when the state accessor is also used', () => {
       const result = solidAsChildToRender(
-        `const A = () => <Switch.Thumb asChild={(props, state) => <span {...props()}>{state().checked}</span>} />`,
+        `import { Switch } from '@ark-ui/solid/switch'
+const A = () => <Switch.Thumb asChild={(props, state) => <span {...props()}>{state().checked}</span>} />`,
         'a.tsx',
       )
       expect(result.code).toContain('{...props()}')
@@ -157,7 +286,8 @@ describe('edge cases', () => {
 
     it('renames every asChild in a file and leaves each body intact', () => {
       const result = solidAsChildToRender(
-        `const A = () => (
+        `import { Menu } from '@ark-ui/solid/menu'
+const A = () => (
   <>
     <Menu.Item asChild={(props) => <a href="/1" {...props()} />}>One</Menu.Item>
     <Menu.Item asChild={(props) => <a href="/2" {...props()} />}>Two</Menu.Item>
@@ -172,7 +302,9 @@ describe('edge cases', () => {
 
     it('renames nested render callbacks without touching the inner call', () => {
       const result = solidAsChildToRender(
-        `const A = () => <Tooltip.Trigger asChild={(outer) => <Dialog.Trigger asChild={(inner) => <button {...inner()} />} {...outer()} />} />`,
+        `import { Tooltip } from '@ark-ui/solid/tooltip'
+import { Dialog } from '@ark-ui/solid/dialog'
+const A = () => <Tooltip.Trigger asChild={(outer) => <Dialog.Trigger asChild={(inner) => <button {...inner()} />} {...outer()} />} />`,
         'a.tsx',
       )
       expect(result.count).toBe(2)
@@ -185,7 +317,8 @@ describe('edge cases', () => {
   describe('react does not emit invalid jsx', () => {
     it('skips an element that already has a render prop instead of writing two', () => {
       const result = reactAsChildToRender(
-        `const A = () => <Menu.Item asChild render={<a href="#">x</a>}><b>y</b></Menu.Item>`,
+        `import { Menu } from '@ark-ui/react/menu'
+const A = () => <Menu.Item asChild render={<a href="#">x</a>}><b>y</b></Menu.Item>`,
         'a.tsx',
       )
       expect(result.code).toBeNull()
@@ -193,12 +326,20 @@ describe('edge cases', () => {
     })
 
     it('preserves a member-expression tag name', () => {
-      const result = reactAsChildToRender(`const A = () => <Menu.Item asChild><a href="#">Go</a></Menu.Item>`, 'a.tsx')
+      const result = reactAsChildToRender(
+        `import { Menu } from '@ark-ui/react/menu'
+const A = () => <Menu.Item asChild><a href="#">Go</a></Menu.Item>`,
+        'a.tsx',
+      )
       expect(result.code).toContain('<Menu.Item render={<a href="#">Go</a>} />')
     })
 
     it('skips when the child is an expression container, not an element', () => {
-      const result = reactAsChildToRender(`const A = () => <Popover.Trigger asChild>{child}</Popover.Trigger>`, 'a.tsx')
+      const result = reactAsChildToRender(
+        `import { Popover } from '@ark-ui/react/popover'
+const A = () => <Popover.Trigger asChild>{child}</Popover.Trigger>`,
+        'a.tsx',
+      )
       expect(result.code).toBeNull()
       expect(result.skipped[0]).toContain('not an element')
     })
@@ -206,7 +347,11 @@ describe('edge cases', () => {
 
   describe('vue and svelte', () => {
     it('vue rewrites two asChild parts in one template', () => {
-      const result = vueAsChildToRender(`<template><X asChild><a>1</a></X><Y asChild><b>2</b></Y></template>`, 'a.vue')
+      const result = vueAsChildToRender(
+        `<script setup lang="ts">import { X, Y } from '@ark-ui/vue/x'</script>
+<template><X asChild><a>1</a></X><Y asChild><b>2</b></Y></template>`,
+        'a.vue',
+      )
       expect(result.count).toBe(2)
       expect(result.code).toContain('<a v-bind="props">1</a>')
       expect(result.code).toContain('<b v-bind="props">2</b>')
@@ -214,7 +359,8 @@ describe('edge cases', () => {
 
     it('svelte renames every asChild snippet and keeps the props call', () => {
       const result = svelteAsChildToRender(
-        `<A>
+        `<script lang="ts">import { A, B } from '@ark-ui/svelte/x'</script>
+<A>
   {#snippet asChild(props)}<a {...props()}>1</a>{/snippet}
 </A>
 <B>

--- a/packages/codemod/tests/cross-file.test.ts
+++ b/packages/codemod/tests/cross-file.test.ts
@@ -1,0 +1,91 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { reactAsChildToRender } from '../src/transforms/as-child-to-render/react.ts'
+import { solidAsChildToRender } from '../src/transforms/as-child-to-render/solid.ts'
+
+let dir: string
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'ark-codemod-'))
+})
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+function write(name: string, content: string): string {
+  const path = join(dir, name)
+  writeFileSync(path, content)
+  return path
+}
+
+describe('cross-file barrel resolution', () => {
+  it('resolves a component re-exported through a local barrel (react)', () => {
+    write('ui.ts', `export { Menu } from '@ark-ui/react/menu'\n`)
+    const consumer = write(
+      'app.tsx',
+      `import { Menu } from './ui'\nconst A = () => <Menu.Item asChild><a href="#">x</a></Menu.Item>\n`,
+    )
+    const source = `import { Menu } from './ui'\nconst A = () => <Menu.Item asChild><a href="#">x</a></Menu.Item>\n`
+
+    const off = reactAsChildToRender(source, consumer)
+    expect(off.code).toBeNull()
+
+    const on = reactAsChildToRender(source, consumer, { crossFile: true })
+    expect(on.count).toBe(1)
+    expect(on.code).toContain('<Menu.Item render={<a href="#">x</a>} />')
+  })
+
+  it('follows a transitive barrel and an aliased re-export (react)', () => {
+    write('vendor.ts', `export { Menu as ArkMenu } from '@ark-ui/react/menu'\n`)
+    write('ui.ts', `export { ArkMenu } from './vendor'\n`)
+    const consumer = write('app.tsx', 'x')
+    const source = `import { ArkMenu } from './ui'\nconst A = () => <ArkMenu.Item asChild><a href="#">x</a></ArkMenu.Item>\n`
+
+    const on = reactAsChildToRender(source, consumer, { crossFile: true })
+    expect(on.count).toBe(1)
+    expect(on.code).toContain('<ArkMenu.Item render={<a href="#">x</a>} />')
+  })
+
+  it('resolves an export-star barrel (react)', () => {
+    write('ui.ts', `export * from '@ark-ui/react/menu'\n`)
+    const consumer = write('app.tsx', 'x')
+    const source = `import { Menu } from './ui'\nconst A = () => <Menu.Item asChild><a href="#">x</a></Menu.Item>\n`
+
+    const on = reactAsChildToRender(source, consumer, { crossFile: true })
+    expect(on.count).toBe(1)
+  })
+
+  it('resolves an import-then-reexport barrel (react)', () => {
+    write('ui.ts', `import { Menu } from '@ark-ui/react/menu'\nexport { Menu }\n`)
+    const consumer = write('app.tsx', 'x')
+    const source = `import { Menu } from './ui'\nconst A = () => <Menu.Item asChild><a href="#">x</a></Menu.Item>\n`
+
+    const on = reactAsChildToRender(source, consumer, { crossFile: true })
+    expect(on.count).toBe(1)
+  })
+
+  it('leaves a non-ark barrel component alone (react)', () => {
+    write('ui.ts', `export { Tooltip } from '@radix-ui/react-tooltip'\n`)
+    const consumer = write('app.tsx', 'x')
+    const source = `import { Tooltip } from './ui'\nconst A = () => <Tooltip.Trigger asChild><a href="#">x</a></Tooltip.Trigger>\n`
+
+    const on = reactAsChildToRender(source, consumer, { crossFile: true })
+    expect(on.code).toBeNull()
+  })
+
+  it('resolves a barrel component and keeps the props call (solid)', () => {
+    write('ui.ts', `export { Menu } from '@ark-ui/solid/menu'\n`)
+    const consumer = write('app.tsx', 'x')
+    const source = `import { Menu } from './ui'\nconst A = () => <Menu.Item asChild={(props) => <a {...props()} />} />\n`
+
+    const off = solidAsChildToRender(source, consumer)
+    expect(off.code).toBeNull()
+
+    const on = solidAsChildToRender(source, consumer, { crossFile: true })
+    expect(on.count).toBe(1)
+    expect(on.code).toContain('render={(props) => <a {...props()} />}')
+  })
+})


### PR DESCRIPTION
## 📝 Description

Fixes the Solid `as-child-to-render` transform (which produced broken output), scopes every transform to real Ark UI components, and hardens the edge cases.

## ⛳️ Current behavior

**Solid.** `render` takes the same props **function** as `asChild` — you call it (`{...props()}`) to spread the part's props. The transform rewrote `props()` to bare `props`, spreading the function itself and forwarding nothing (attributes, handlers, and the child's own content), so the element rendered empty and inert.

**Scope.** Every transform rewrote any element that happened to use `asChild`, so a Radix (or other library's) `asChild` in the same file would be mangled into an Ark-only `render`.

**React.** An element carrying both `asChild` and a `render` prop would emit two `render` attributes (invalid JSX).

## 🚀 New behavior

**Solid** is now a pure rename, like Svelte — the callback body is untouched, so `{...props()}` (including `props({ ...merge })` and the `state()` accessor) is preserved.

**Scope.** React, Solid and Vue now act only on elements whose tag resolves to an `@ark-ui/*` import — following aliases (`import { Menu as M }`) and the `ark` factory — and skip a file that never imports Ark. Svelte keys off the Ark-specific `asChild` snippet name (Radix has no Svelte; Bits UI uses `child`), so barrel and relative imports still migrate. Barrel re-exports of Ark parts are documented as a `--force`/manual case.

**React** skips (loudly) an element that already has a `render` prop instead of writing a second one.

**Cross-file (`--cross-file`, React and Solid).** Resolves Ark parts imported through a local barrel back to `@ark-ui/*` — `import { Menu } from '@/components/ui'` where `ui` re-exports `@ark-ui/react/menu`. Follows direct, transitive, aliased, `export *`, and import-then-reexport chains, using the nearest `tsconfig.json` for path aliases. Off by default because it reads sibling files.

```sh
npx @ark-ui/codemod react/as-child-to-render "src/**/*.tsx" --cross-file --dry
```

## 🧩 Frameworks

- [x] React
- [x] Solid
- [x] Svelte
- [x] Vue
- [ ] Not framework-specific

## 💣 Is this a breaking change (Yes/No):

No.

## ✅ Checklist

- [x] Added a changeset for user-facing changes
- [x] Added or updated tests
- [ ] Added an example for any new prop or part
- [x] Updated the docs

## 📝 Additional information

Tests cover the mistake classes across all four transforms: Solid keeps the props call in block bodies, alongside `state()`, and in nested/repeated callbacks; component identification leaves non-Ark parts alone, follows aliases, tracks the `ark` factory, and skips import-less files; React skips the double-`render` and non-element-child cases; cross-file covers direct/transitive/aliased/`export *`/import-then-reexport barrels against a real temp filesystem. Also fixes a Solid ancestor lookup that missed `asChild` on a part nested inside another element's prop (e.g. a `<Show fallback={…}>`). Docs: the Solid section of `AS_CHILD_MIGRATION.md` and a new Scope section in the README.
