### PR TITLE
feat(codemod): resolve ark components through factory wrappers

### DIFF
--- a/.changeset/codemod-wrapper-resolution.md
+++ b/.changeset/codemod-wrapper-resolution.md
@@ -1,0 +1,5 @@
+---
+'@ark-ui/codemod': patch
+---
+
+Resolve Ark parts reached through factory wrappers, not just re-exports. A local `styled(ark.button)` component, a `forwardRef`/function wrapper that renders one, and chains of these across files (following path aliases via the nearest `tsconfig.json`) now count as Ark components, so `<Button asChild>` migrates when `Button` bottoms out at an `@ark-ui/*` part. In-file wrappers are recognised without `--cross-file`; wrapper chains that cross files need it.

--- a/packages/codemod/README.md
+++ b/packages/codemod/README.md
@@ -64,7 +64,9 @@ See [docs/AS_CHILD_MIGRATION.md](./docs/AS_CHILD_MIGRATION.md) for what each one
 
 The React, Solid and Vue transforms only touch Ark UI parts — elements whose tag resolves to an `@ark-ui/*` import, following aliases (`import { Menu as M }`) and the `ark` factory. Another library's `asChild` (Radix, for one) in the same file is left alone, and a file that never imports Ark is skipped. The Svelte transform keys off the Ark-specific `asChild` snippet name instead.
 
-If you re-export Ark parts through a local barrel — `import { Menu } from '@/components/ui'` where `ui` re-exports `@ark-ui/react/menu` — pass `--cross-file` (React and Solid). It resolves the import back to `@ark-ui/*` through direct, transitive, aliased, `export *`, and import-then-reexport chains, using the nearest `tsconfig.json` for path aliases. It is off by default because it reads sibling files.
+A local wrapper counts as an Ark part when it bottoms out at one — `const Button = styled(ark.button, …)`, or a `forwardRef` that renders it. In-file wrappers are recognised on their own.
+
+If a wrapper or re-export crosses files — `import { Button } from '@/components/ui'` where `ui` wraps or re-exports `@ark-ui/react/*` — pass `--cross-file` (React and Solid). It follows `styled()`/`forwardRef` wrappers and direct, transitive, aliased, `export *`, and import-then-reexport chains back to `@ark-ui/*`, using the nearest `tsconfig.json` for path aliases. It is off by default because it reads sibling files.
 
 ## What it will not do
 

--- a/packages/codemod/src/utils/ark-imports.ts
+++ b/packages/codemod/src/utils/ark-imports.ts
@@ -1,9 +1,10 @@
-import { Node } from 'ts-morph'
+import { Node, SyntaxKind } from 'ts-morph'
 import type { JsxOpeningElement, JsxSelfClosingElement, SourceFile } from 'ts-morph'
 
 type JsxOpening = JsxOpeningElement | JsxSelfClosingElement
 
 const ARK_SOURCE = /^@ark-ui\//
+const MAX_DEPTH = 12
 
 export function getJsxBaseName(nameNode: Node): string {
   if (Node.isPropertyAccessExpression(nameNode)) {
@@ -18,100 +19,149 @@ export function jsxBaseNameFromText(tag: string): string {
   return tag.split('.')[0]
 }
 
+export function isTrackedJsx(opening: JsxOpening, arkNames: Set<string>): boolean {
+  return arkNames.has(getJsxBaseName(opening.getTagNameNode()))
+}
+
 export function arkLocalNames(sf: SourceFile, options: { crossFile?: boolean } = {}): Set<string> {
+  const crossFile = options.crossFile ?? false
   const names = new Set<string>()
 
+  const candidates = new Set<string>()
   for (const imp of sf.getImportDeclarations()) {
-    if (!ARK_SOURCE.test(imp.getModuleSpecifierValue())) continue
     const def = imp.getDefaultImport()
-    if (def) names.add(def.getText())
+    if (def) candidates.add(def.getText())
     const ns = imp.getNamespaceImport()
-    if (ns) names.add(ns.getText())
-    for (const spec of imp.getNamedImports()) {
-      names.add(spec.getAliasNode()?.getText() ?? spec.getName())
-    }
+    if (ns) candidates.add(ns.getText())
+    for (const spec of imp.getNamedImports()) candidates.add(spec.getAliasNode()?.getText() ?? spec.getName())
+  }
+  for (const decl of sf.getVariableDeclarations()) candidates.add(decl.getName())
+  for (const fn of sf.getFunctions()) {
+    const name = fn.getName()
+    if (name) candidates.add(name)
   }
 
-  for (const decl of sf.getVariableDeclarations()) {
-    const init = decl.getInitializer()
-    if (!init) continue
-    if (Node.isIdentifier(init) && names.has(init.getText())) {
-      names.add(decl.getName())
-      continue
-    }
-    if (Node.isPropertyAccessExpression(init) && names.has(getJsxBaseName(init))) {
-      names.add(decl.getName())
-    }
-  }
-
-  if (options.crossFile) {
-    for (const imp of sf.getImportDeclarations()) {
-      if (ARK_SOURCE.test(imp.getModuleSpecifierValue())) continue
-      const target = imp.getModuleSpecifierSourceFile()
-      if (!target) continue
-      for (const spec of imp.getNamedImports()) {
-        const local = spec.getAliasNode()?.getText() ?? spec.getName()
-        if (names.has(local)) continue
-        if (reExportsArk(target, spec.getName(), new Set(), 0)) names.add(local)
-      }
-    }
+  for (const name of candidates) {
+    if (nameResolvesToArk(sf, name, crossFile, new Set(), 0)) names.add(name)
   }
 
   return names
 }
 
-const MAX_REEXPORT_DEPTH = 8
-
-function importedNameIsArk(file: SourceFile, localName: string): boolean {
-  for (const imp of file.getImportDeclarations()) {
-    if (!ARK_SOURCE.test(imp.getModuleSpecifierValue())) continue
-    if (imp.getDefaultImport()?.getText() === localName) return true
-    if (imp.getNamespaceImport()?.getText() === localName) return true
-    for (const spec of imp.getNamedImports()) {
-      if ((spec.getAliasNode()?.getText() ?? spec.getName()) === localName) return true
-    }
-  }
-  return false
-}
-
-function reExportsArk(file: SourceFile, exportName: string, visited: Set<string>, depth: number): boolean {
-  if (depth > MAX_REEXPORT_DEPTH) return false
-  const key = `${file.getFilePath()}::${exportName}`
+function nameResolvesToArk(
+  file: SourceFile,
+  name: string,
+  crossFile: boolean,
+  visited: Set<string>,
+  depth: number,
+): boolean {
+  if (depth > MAX_DEPTH) return false
+  const key = `${file.getFilePath()}::${name}`
   if (visited.has(key)) return false
   visited.add(key)
 
-  for (const exp of file.getExportDeclarations()) {
-    const spec = exp.getModuleSpecifierValue()
-    const named = exp.getNamedExports()
+  for (const imp of file.getImportDeclarations()) {
+    const source = imp.getModuleSpecifierValue()
+    const isArk = ARK_SOURCE.test(source)
 
-    if (spec) {
-      const targetIsArk = ARK_SOURCE.test(spec)
+    if (imp.getDefaultImport()?.getText() === name || imp.getNamespaceImport()?.getText() === name) {
+      if (isArk) return true
+    }
+    for (const spec of imp.getNamedImports()) {
+      const local = spec.getAliasNode()?.getText() ?? spec.getName()
+      if (local !== name) continue
+      if (isArk) return true
+      if (!crossFile) continue
+      const target = imp.getModuleSpecifierSourceFile()
+      if (target && nameResolvesToArk(target, spec.getName(), crossFile, visited, depth + 1)) return true
+    }
+  }
+
+  const decl = file.getVariableDeclaration(name)
+  if (decl && initializerIsArk(file, decl.getInitializer(), crossFile, visited, depth)) return true
+
+  const fn = file.getFunction(name)
+  if (fn && returnedJsxBaseNames(fn).some((base) => nameResolvesToArk(file, base, crossFile, visited, depth + 1)))
+    return true
+
+  for (const exp of file.getExportDeclarations()) {
+    const source = exp.getModuleSpecifierValue()
+    const named = exp.getNamedExports()
+    if (source) {
+      const isArk = ARK_SOURCE.test(source)
       let matched = false
-      for (const n of named) {
-        const exported = n.getAliasNode()?.getText() ?? n.getName()
-        if (exported !== exportName) continue
+      for (const spec of named) {
+        if ((spec.getAliasNode()?.getText() ?? spec.getName()) !== name) continue
         matched = true
-        if (targetIsArk) return true
+        if (isArk) return true
+        if (!crossFile) continue
         const target = exp.getModuleSpecifierSourceFile()
-        if (target && reExportsArk(target, n.getName(), visited, depth + 1)) return true
+        if (target && nameResolvesToArk(target, spec.getName(), crossFile, visited, depth + 1)) return true
       }
       if (!matched && named.length === 0) {
-        if (targetIsArk) return true
-        const target = exp.getModuleSpecifierSourceFile()
-        if (target && reExportsArk(target, exportName, visited, depth + 1)) return true
+        if (isArk) return true
+        if (crossFile) {
+          const target = exp.getModuleSpecifierSourceFile()
+          if (target && nameResolvesToArk(target, name, crossFile, visited, depth + 1)) return true
+        }
       }
     } else {
-      for (const n of named) {
-        const exported = n.getAliasNode()?.getText() ?? n.getName()
-        if (exported === exportName && importedNameIsArk(file, n.getName())) return true
+      for (const spec of named) {
+        if ((spec.getAliasNode()?.getText() ?? spec.getName()) !== name) continue
+        if (nameResolvesToArk(file, spec.getName(), crossFile, visited, depth + 1)) return true
       }
     }
+  }
+
+  return false
+}
+
+function initializerIsArk(
+  file: SourceFile,
+  node: Node | undefined,
+  crossFile: boolean,
+  visited: Set<string>,
+  depth: number,
+): boolean {
+  if (!node || depth > MAX_DEPTH) return false
+  if (Node.isParenthesizedExpression(node)) {
+    return initializerIsArk(file, node.getExpression(), crossFile, visited, depth)
+  }
+  if (Node.isIdentifier(node)) {
+    return nameResolvesToArk(file, node.getText(), crossFile, visited, depth + 1)
+  }
+  if (Node.isPropertyAccessExpression(node)) {
+    return nameResolvesToArk(file, getJsxBaseName(node), crossFile, visited, depth + 1)
+  }
+  if (Node.isCallExpression(node)) {
+    return node.getArguments().some((arg) => initializerIsArk(file, arg, crossFile, visited, depth + 1))
+  }
+  if (Node.isArrowFunction(node) || Node.isFunctionExpression(node)) {
+    return returnedJsxBaseNames(node).some((base) => nameResolvesToArk(file, base, crossFile, visited, depth + 1))
   }
   return false
 }
 
-export function isTrackedJsx(opening: JsxOpening, arkNames: Set<string>): boolean {
-  return arkNames.has(getJsxBaseName(opening.getTagNameNode()))
+function returnedJsxBaseNames(fn: Node): string[] {
+  const bases: string[] = []
+  const push = (expr: Node | undefined) => {
+    if (!expr) return
+    let node: Node = expr
+    while (Node.isParenthesizedExpression(node)) node = node.getExpression()
+    if (Node.isJsxElement(node)) bases.push(getJsxBaseName(node.getOpeningElement().getTagNameNode()))
+    else if (Node.isJsxSelfClosingElement(node)) bases.push(getJsxBaseName(node.getTagNameNode()))
+  }
+
+  const body =
+    Node.isArrowFunction(fn) || Node.isFunctionExpression(fn) || Node.isFunctionDeclaration(fn)
+      ? fn.getBody()
+      : undefined
+  if (body && !Node.isBlock(body)) {
+    push(body)
+  } else {
+    for (const ret of fn.getDescendantsOfKind(SyntaxKind.ReturnStatement)) push(ret.getExpression())
+  }
+  return bases
 }
 
 export function arkLocalNamesFromSource(source: string): Set<string> {

--- a/packages/codemod/tests/as-child-to-render.test.ts
+++ b/packages/codemod/tests/as-child-to-render.test.ts
@@ -220,6 +220,18 @@ const A = () => <ark.div asChild><span>x</span></ark.div>`,
     expect(result.code).toContain('<ark.div render={<span>x</span>} />')
   })
 
+  it('react tracks an in-file styled(ark.x) wrapper', () => {
+    const result = reactAsChildToRender(
+      `import { ark } from '@ark-ui/react/factory'
+import { styled } from 'styled-system/jsx'
+const Btn = styled(ark.button, {})
+const A = () => <Btn asChild><a href="#">x</a></Btn>`,
+      'a.tsx',
+    )
+    expect(result.count).toBe(1)
+    expect(result.code).toContain('<Btn render={<a href="#">x</a>} />')
+  })
+
   it('solid leaves a non-ark component alone', () => {
     const result = solidAsChildToRender(
       `import { Menu } from '@ark-ui/solid/menu'

--- a/packages/codemod/tests/cross-file.test.ts
+++ b/packages/codemod/tests/cross-file.test.ts
@@ -76,6 +76,48 @@ describe('cross-file barrel resolution', () => {
     expect(on.code).toBeNull()
   })
 
+  it('resolves a styled(ark.x) wrapper across files (react)', () => {
+    write(
+      'prim.tsx',
+      `import { ark } from '@ark-ui/react/factory'\nimport { styled } from 'styled-system/jsx'\nexport const Btn = styled(ark.button, {})\n`,
+    )
+    const consumer = write('app.tsx', 'x')
+    const source = `import { Btn } from './prim'\nconst A = () => <Btn asChild><a href="#">x</a></Btn>\n`
+
+    const off = reactAsChildToRender(source, consumer)
+    expect(off.code).toBeNull()
+
+    const on = reactAsChildToRender(source, consumer, { crossFile: true })
+    expect(on.count).toBe(1)
+    expect(on.code).toContain('<Btn render={<a href="#">x</a>} />')
+  })
+
+  it('resolves a forwardRef wrapper chain across files (react)', () => {
+    write(
+      'prim.tsx',
+      `import { ark } from '@ark-ui/react/factory'\nimport { styled } from 'styled-system/jsx'\nexport const Button = styled(ark.button, {})\n`,
+    )
+    write(
+      'button.tsx',
+      `import { forwardRef } from 'react'\nimport { Button as Styled } from './prim'\nexport const Button = forwardRef((props, ref) => <Styled {...props} ref={ref} />)\n`,
+    )
+    const consumer = write('app.tsx', 'x')
+    const source = `import { Button } from './button'\nconst A = () => <Button asChild><a href="#">x</a></Button>\n`
+
+    const on = reactAsChildToRender(source, consumer, { crossFile: true })
+    expect(on.count).toBe(1)
+    expect(on.code).toContain('<Button render={<a href="#">x</a>} />')
+  })
+
+  it('leaves a wrapper that does not bottom out at ark alone (react)', () => {
+    write('prim.tsx', `import { styled } from 'styled-system/jsx'\nexport const Box = styled('div', {})\n`)
+    const consumer = write('app.tsx', 'x')
+    const source = `import { Box } from './prim'\nconst A = () => <Box asChild><a href="#">x</a></Box>\n`
+
+    const on = reactAsChildToRender(source, consumer, { crossFile: true })
+    expect(on.code).toBeNull()
+  })
+
   it('resolves a barrel component and keeps the props call (solid)', () => {
     write('ui.ts', `export { Menu } from '@ark-ui/solid/menu'\n`)
     const consumer = write('app.tsx', 'x')


### PR DESCRIPTION
## 📝 Description

Teaches the `as-child-to-render` scope resolver to recognise Ark parts reached through a **factory wrapper**, not just a re-export. This is what a design system on top of Ark actually looks like: `<Button asChild>` where `Button` is a styled wrapper of `ark.button`.

## ⛳️ Current behavior

The codemod treats an element as Ark only when its tag resolves directly to an `@ark-ui/*` import (or, with `--cross-file`, a re-export chain). A component like `const Button = styled(ark.button, …)` — or a `forwardRef` around one — is invisible, so `<Button asChild>` is left behind.

## 🚀 New behavior

A local name counts as an Ark part when it bottoms out at one:

- `const Btn = styled(ark.button, …)` — a `styled()`/factory call whose argument resolves to Ark
- `const Button = forwardRef((props, ref) => <Styled {...props} ref={ref} />)` — a `forwardRef`/function wrapper that renders an Ark-derived component
- chains of the above

In-file wrappers are recognised on their own. Wrapper (and re-export) chains that cross files are followed under `--cross-file`, using the nearest `tsconfig.json` for path aliases. A wrapper that does **not** bottom out at Ark (`styled('div', …)`) is still left alone.

```diff
- <Button asChild><NextLink href="/docs">Get Started</NextLink></Button>
+ <Button render={<NextLink href="/docs">Get Started</NextLink>} />
```

On this repo's own website, `--cross-file` coverage goes from 13 to 108 sites (44 files); the two it still leaves are genuine "child is not an element" skips.

## 🧩 Frameworks

- [x] React
- [x] Solid
- [ ] Svelte
- [ ] Vue
- [ ] Not framework-specific

Wrapper resolution rides on the ts-morph scope resolver, so it covers the React and Solid transforms. Vue/Svelte identify Ark by SFC imports and the `asChild` snippet name respectively.

## 💣 Is this a breaking change (Yes/No):

No.

## ✅ Checklist

- [x] Added a changeset for user-facing changes
- [x] Added or updated tests
- [ ] Added an example for any new prop or part
- [x] Updated the docs

## 📝 Additional information

New tests cover an in-file `styled(ark.x)` wrapper (no flag), a cross-file `styled` wrapper, a cross-file `forwardRef` chain, and a non-Ark wrapper left alone. The resolver is a single recursive `nameResolvesToArk` with a depth cap and a visited set, unifying imports, in-file declarations, factory wrappers, and re-export chains.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63183699"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 1/5</h2>

This PR is not yet safe to merge because ordinary wrapper shapes can be missed while unrelated components can be incorrectly rewritten.

<h2><a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apackages%2Fcodemod%2Fsrc%2Futils%2Fark-imports.ts%3A162%0AFor%20block-bodied%20components%2C%20%60getDescendantsOfKind%28ReturnStatement%29%60%20also%20collects%20returns%20inside%20nested%20callbacks%20and%20local%20functions.%20If%20a%20non-Ark%20component%20contains%20a%20nested%20callback%20that%20returns%20%60%3Cark.div%20%2F%3E%60%2C%20the%20outer%20component%20is%20classified%20as%20Ark%20and%20its%20%60%3CComponent%20asChild%3E%60%20usages%20are%20incorrectly%20rewritten%20to%20the%20incompatible%20%60render%60%20API.%0A%0A%23%23%23%20Issue%202%0Apackages%2Fcodemod%2Fsrc%2Futils%2Fark-imports.ts%3A136-138%0AEvery%20call%20expression%20is%20considered%20Ark-derived%20when%20any%20argument%20resolves%20to%20Ark%2C%20regardless%20of%20the%20callee%20or%20argument%20position.%20For%20example%2C%20a%20helper%20that%20receives%20%60ark.button%60%20but%20returns%20a%20different%20component%20will%20cause%20that%20component's%20valid%20%60asChild%60%20usage%20to%20be%20rewritten%20even%20though%20it%20is%20not%20an%20Ark%20wrapper.%0A%0A%23%23%23%20Issue%203%0Apackages%2Fcodemod%2Fsrc%2Futils%2Fark-imports.ts%3A67-69%0ALocal%20default%20and%20namespace%20imports%20are%20recognized%20only%20when%20their%20module%20specifier%20is%20directly%20under%20%60%40ark-ui%60%3B%20the%20cross-file%20resolver%20never%20follows%20their%20source%20file.%20As%20a%20result%2C%20a%20wrapper%20such%20as%20%60export%20default%20styled%28ark.button%2C%20...%29%60%20imported%20as%20%60Button%60%20remains%20unmigrated%20even%20with%20%60--cross-file%60%2C%20despite%20the%20documented%20support%20for%20wrapper%20chains%20across%20files.%0A%0A%23%23%23%20Issue%204%0Apackages%2Fcodemod%2Fsrc%2Futils%2Fark-imports.ts%3A149-153%0A%60returnedJsxBaseNames%60%20recognizes%20only%20return%20expressions%20that%20are%20directly%20JSX%20elements.%20A%20wrapper%20such%20as%20%60forwardRef%28%28props%2C%20ref%29%20%3D%3E%20ready%20%3F%20%3CStyled%20ref%3D%7Bref%7D%20%7B...props%7D%20%2F%3E%20%3A%20null%29%60%20therefore%20does%20not%20resolve%20to%20Ark%2C%20so%20its%20%60asChild%60%20usage%20is%20silently%20left%20behind.%20Conditional%2C%20logical%2C%20and%20fragment-wrapped%20JSX%20returns%20need%20to%20be%20traversed%20without%20entering%20nested%20function%20scopes.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=chakra-ui%2Fark&pr=4038&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6" align="right"></picture></a>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Nested returns misclassify components** <a href="https://github.com/chakra-ui/ark/pull/4038#discussion_r3992006737">▶</a>
2. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Call arguments cause false positives** <a href="https://github.com/chakra-ui/ark/pull/4038#discussion_r3992006747">▶</a>
3. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Default wrappers remain unresolved** <a href="https://github.com/chakra-ui/ark/pull/4038#discussion_r3992006756">▶</a>
4. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Conditional wrapper returns are missed** <a href="https://github.com/chakra-ui/ark/pull/4038#discussion_r3992006770">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
packages/codemod/src/utils/ark-imports.ts:162
For block-bodied components, `getDescendantsOfKind(ReturnStatement)` also collects returns inside nested callbacks and local functions. If a non-Ark component contains a nested callback that returns `<ark.div />`, the outer component is classified as Ark and its `<Component asChild>` usages are incorrectly rewritten to the incompatible `render` API.

### Issue 2
packages/codemod/src/utils/ark-imports.ts:136-138
Every call expression is considered Ark-derived when any argument resolves to Ark, regardless of the callee or argument position. For example, a helper that receives `ark.button` but returns a different component will cause that component's valid `asChild` usage to be rewritten even though it is not an Ark wrapper.

### Issue 3
packages/codemod/src/utils/ark-imports.ts:67-69
Local default and namespace imports are recognized only when their module specifier is directly under `@ark-ui`; the cross-file resolver never follows their source file. As a result, a wrapper such as `export default styled(ark.button, ...)` imported as `Button` remains unmigrated even with `--cross-file`, despite the documented support for wrapper chains across files.

### Issue 4
packages/codemod/src/utils/ark-imports.ts:149-153
`returnedJsxBaseNames` recognizes only return expressions that are directly JSX elements. A wrapper such as `forwardRef((props, ref) => ready ? <Styled ref={ref} {...props} /> : null)` therefore does not resolve to Ark, so its `asChild` usage is silently left behind. Conditional, logical, and fragment-wrapped JSX returns need to be traversed without entering nested function scopes.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<details><summary><h3>Summary</h3></summary>

- Unifies direct imports, declarations, wrapper calls, JSX-returning functions, and re-export resolution under a recursive resolver.
- Adds local `styled(ark.x)`, cross-file styled/forwardRef, and non-Ark wrapper coverage.
- Documents the new behavior and publishes it as a codemod patch.
</details>

<details open><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Collect imported and declared names] --> B[nameResolvesToArk]
  B --> C{Resolution form}
  C -->|Ark import| D[Track JSX base name]
  C -->|Named cross-file import or export| E[Resolve target source file]
  C -->|Variable initializer| F[Inspect identifier, property access, call, or function]
  C -->|Function declaration| G[Inspect returned JSX base names]
  E --> B
  F --> B
  G --> B
  D --> H[React or Solid asChild transform]
```
</details>

<sub>Reviews (1) · Last reviewed commit: ["feat(codemod): resolve ark components th..."](https://github.com/chakra-ui/ark/commit/13a20f694877ec9e4c8ea5bace3f03cb9df14dcb)</sub>

<!-- /greptile_comment -->